### PR TITLE
Fix rbac so that gpu node mocker can run

### DIFF
--- a/charts/gpu-node-mocker/templates/clusterrole-auto-generated.yaml
+++ b/charts/gpu-node-mocker/templates/clusterrole-auto-generated.yaml
@@ -11,6 +11,8 @@ rules:
   verbs:
   - create
   - get
+  - list
+  - watch
 - apiGroups:
   - ""
   resources:
@@ -28,6 +30,7 @@ rules:
   - nodes/status
   verbs:
   - get
+  - patch
   - update
 - apiGroups:
   - ""

--- a/pkg/gpu-node-mocker/controllers/node_claim_controller.go
+++ b/pkg/gpu-node-mocker/controllers/node_claim_controller.go
@@ -74,7 +74,7 @@ func (r *NodeClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups=karpenter.sh,resources=nodeclaims,verbs=get;list;watch;update
 // +kubebuilder:rbac:groups=karpenter.sh,resources=nodeclaims/status,verbs=patch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch;create;update;delete
-// +kubebuilder:rbac:groups="",resources=nodes/status,verbs=get;update
+// +kubebuilder:rbac:groups="",resources=nodes/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;patch;delete
 
 func (r *NodeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
@@ -99,7 +99,7 @@ func (r *ShadowPodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods/status,verbs=get;patch
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;create
+// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create
 
 func (r *ShadowPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx).WithValues("pod", req.NamespacedName)


### PR DESCRIPTION
**Reason for Change**:
Bug fix for the below errors when running `gpu-node-mocker`

```
ERROR failed to patch node status to Ready {"controller": "nodeclaim", "controllerGroup": "karpenter.sh", "controllerKind": "NodeClaim", "NodeClaim": {"name":"wsa6754fba3"}, "namespace": "", "name": "wsa6754fba3", "reconcileID": "c7933699-4780-4bad-b13a-dc6154142b49", "nodeclaim": {"name":"wsa6754fba3"}, "error": "patch node status: nodes "fake-wsa6754fba3" is forbidden: User "system:serviceaccount:kaito-system:gpu-node-mocker" cannot patch resource "nodes/status" in API group "" at the cluster scope"}
```

```
ERROR controller-runtime.cache.UnhandledError Failed to watch {"reflector": "pkg/mod/k8s.io/[client-go@v0.35.3](vscode-file://vscode-app/c:/Users/wangjessi/AppData/Local/Programs/Microsoft%20VS%20Code/0870c2a0c7/resources/app/out/vs/code/electron-browser/workbench/workbench.html)/tools/cache/reflector.go:289", "type": "*v1.Namespace", "error": "failed to list *v1.Namespace: namespaces is forbidden: User "system:serviceaccount:kaito-system:gpu-node-mocker" cannot list resource "namespaces" in API group "" at the cluster scope"}
```

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
