### PR TITLE
Add local e2e setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,6 +129,14 @@ e2e-push-image: ## Tag and push image to ACR. Sets SHADOW_CONTROLLER_IMAGE.
 	docker push "$${IMAGE}" >&2; \
 	echo "image=$${IMAGE}"
 
+.PHONY: e2e-push-image-local
+e2e-push-image-local: ## Tag and push locally-built image to ACR (no hash, uses IMG).
+	az acr login --name "$${ACR_NAME}" >&2; \
+	IMAGE="$${ACR_NAME}.azurecr.io/gpu-node-mocker:latest"; \
+	docker tag $(IMG) "$${IMAGE}" >&2; \
+	docker push "$${IMAGE}" >&2; \
+	echo "image=$${IMAGE}"
+
 .PHONY: e2e-install
 e2e-install: ## Install all E2E components onto the cluster.
 	hack/e2e/scripts/run-e2e-local.sh install
@@ -148,3 +156,17 @@ e2e-dump: ## Dump cluster state for debugging.
 .PHONY: e2e-teardown
 e2e-teardown: ## Tear down the E2E cluster.
 	hack/e2e/scripts/run-e2e-local.sh teardown
+
+.PHONY: e2e-up
+e2e-up: docker-build e2e-setup ## Setup local E2E env: build image, create cluster, push image, install and validate components.
+	@echo "=== Deriving ACR name ==="
+	$(eval ACR_NAME := $(shell az acr list --resource-group $${RESOURCE_GROUP:-kaito-e2e-local} --query '[0].name' -o tsv))
+	@echo "=== Pushing gpu-node-mocker image to ACR ($(ACR_NAME)) ==="
+	$(eval SHADOW_CONTROLLER_IMAGE := $(shell ACR_NAME=$(ACR_NAME) $(MAKE) --no-print-directory e2e-push-image-local | grep '^image=' | cut -d= -f2-))
+	@echo "Image: $(SHADOW_CONTROLLER_IMAGE)"
+	SHADOW_CONTROLLER_IMAGE="$(SHADOW_CONTROLLER_IMAGE)" $(MAKE) e2e-install
+	$(MAKE) e2e-validate
+	@echo ""
+	@echo "=== E2E environment is ready ==="
+	@echo "Run tests with: make test-e2e"
+	@echo "Tear down with: make e2e-teardown"

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -49,6 +49,99 @@ E2E_LABEL=PrefixCache make test-e2e
 go test -v -timeout 30m ./test/e2e/... --ginkgo.v
 ```
 
+### Setting up a local E2E environment from scratch
+
+This creates an AKS cluster, builds and pushes the gpu-node-mocker image, installs
+all components (KAITO, Istio, BBR, Gateway, InferenceSets), and validates them.
+
+**Prerequisites:**
+- Azure CLI (`az`) logged in with a subscription that has quota for `Standard_D8s_v3` nodes
+- Docker installed (for building the gpu-node-mocker image)
+- `kubectl`, `helm`, `istioctl` available in PATH (or the setup script will install them)
+
+**One-command setup:**
+
+```bash
+# Uses default names (kaito-e2e-local, eastus, 2 nodes)
+make e2e-up
+```
+
+**With custom configuration:**
+
+```bash
+export RESOURCE_GROUP=my-e2e-rg
+export CLUSTER_NAME=my-e2e-cluster
+export LOCATION=westus2
+export NODE_COUNT=3
+export NODE_VM_SIZE=Standard_D8s_v3
+make e2e-up
+```
+
+**After setup completes, run tests:**
+
+```bash
+make test-e2e
+
+# Or run specific labels
+make test-e2e E2E_LABEL=Smoke
+make test-e2e E2E_LABEL=Infra
+make test-e2e E2E_LABEL=Routing
+make test-e2e E2E_LABEL=PrefixCache
+```
+
+**Tear down when done:**
+
+```bash
+make e2e-teardown
+```
+
+**Step-by-step (if you need more control):**
+
+```bash
+# 1. Build the gpu-node-mocker image
+make docker-build
+
+# 2. Create AKS cluster and ACR
+make e2e-setup
+
+# 3. Push image to ACR
+make e2e-push-image
+
+# 4. Install all components (KAITO, Istio, BBR, Gateway, InferenceSets)
+SHADOW_CONTROLLER_IMAGE=<image-from-step-3> make e2e-install
+
+# 5. Validate everything is healthy
+make e2e-validate
+
+# 6. Run tests
+make test-e2e
+
+# 7. (Optional) Dump cluster state for debugging
+make e2e-dump
+
+# 8. Tear down
+make e2e-teardown
+```
+
+**Skip docker build (use default upstream image):**
+
+If you don't need to test local gpu-node-mocker changes:
+
+```bash
+make e2e-setup
+make e2e-install
+make e2e-validate
+make test-e2e
+```
+
+**Keep the cluster after tests (for debugging):**
+
+```bash
+SKIP_TEARDOWN=true make e2e
+# Cluster stays running. Tear down later:
+make e2e-teardown
+```
+
 ### Environment Variables
 
 | Variable | Description | Default |


### PR DESCRIPTION
**Reason for Change**:
Add local e2e setup so that we can setup the cluster and run tests locally,

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
https://github.com/kaito-project/production-stack/issues/10

**Notes for Reviewers**:
