### PR TITLE
fix: create shadow pods in model namespace instead of kaito-shadow

### DIFF
--- a/charts/gpu-node-mocker/templates/clusterrole-auto-generated.yaml
+++ b/charts/gpu-node-mocker/templates/clusterrole-auto-generated.yaml
@@ -8,7 +8,6 @@ rules:
   - ""
   resources:
   - configmaps
-  - namespaces
   verbs:
   - create
   - get

--- a/charts/gpu-node-mocker/templates/deployment.yaml
+++ b/charts/gpu-node-mocker/templates/deployment.yaml
@@ -25,7 +25,6 @@ spec:
           args:
             - --metrics-bind-address=:8080
             - --health-probe-bind-address=:8081
-            - --shadow-pod-namespace={{ .Values.shadowPod.namespace }}
             - --shadow-pod-image={{ .Values.shadowPod.image }}
             - --uds-tokenizer-image={{ .Values.shadowPod.udsTokenizerImage }}
             - --lease-duration-seconds={{ .Values.leaseDurationSeconds }}

--- a/charts/gpu-node-mocker/values.yaml
+++ b/charts/gpu-node-mocker/values.yaml
@@ -5,7 +5,6 @@ image:
   pullPolicy: IfNotPresent
 
 shadowPod:
-  namespace: kaito-shadow
   image: ghcr.io/llm-d/llm-d-inference-sim:v0.8.1
   udsTokenizerImage: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.6.0
 

--- a/cmd/gpu-node-mocker/main.go
+++ b/cmd/gpu-node-mocker/main.go
@@ -60,7 +60,6 @@ func main() {
 	var (
 		metricsAddr           string
 		probeAddr             string
-		shadowPodNamespace    string
 		shadowPodImage        string
 		udsTokenizerImage     string
 		leaseDurationSec      int
@@ -69,8 +68,6 @@ func main() {
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
-	flag.StringVar(&shadowPodNamespace, "shadow-pod-namespace", "kaito-shadow",
-		"Namespace where shadow pods are created.")
 	flag.StringVar(&shadowPodImage, "shadow-pod-image", controllers.DefaultInferenceSimImage,
 		"Container image for the inference simulator running in shadow pods.")
 	flag.StringVar(&udsTokenizerImage, "uds-tokenizer-image", controllers.DefaultUDSTokenizerImage,
@@ -96,7 +93,6 @@ func main() {
 	}
 
 	cfg := controllers.Config{
-		ShadowPodNamespace:    shadowPodNamespace,
 		ShadowPodImage:        shadowPodImage,
 		UDSTokenizerImage:     udsTokenizerImage,
 		LeaseDurationSec:      int32(leaseDurationSec),

--- a/pkg/gpu-node-mocker/controllers/config.go
+++ b/pkg/gpu-node-mocker/controllers/config.go
@@ -83,9 +83,6 @@ const (
 
 // Config holds operator-wide settings injected via CLI flags.
 type Config struct {
-	// ShadowPodNamespace is where Phase 2 creates shadow pods.
-	ShadowPodNamespace string
-
 	// ShadowPodImage is the inference simulator container image.
 	ShadowPodImage string
 

--- a/pkg/gpu-node-mocker/controllers/node_claim_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/node_claim_controller_test.go
@@ -49,7 +49,6 @@ func testScheme() *runtime.Scheme {
 
 func testConfig() Config {
 	return Config{
-		ShadowPodNamespace:    "kaito-shadow",
 		ShadowPodImage:        DefaultInferenceSimImage,
 		UDSTokenizerImage:     DefaultUDSTokenizerImage,
 		LeaseDurationSec:      40,

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
@@ -44,7 +44,7 @@ import (
 //   - Still in Pending phase (no kubelet will ever run it)
 //
 // For each such pod the reconciler:
-//  1. Creates a "shadow pod" in Config.ShadowPodNamespace on a real AKS node.
+//  1. Creates a "shadow pod" in the same namespace as the original pod on a real AKS node.
 //     The shadow pod runs the LLM Mocker container and gets a real CNI IP.
 //  2. Waits until the shadow pod is Running and has a podIP.
 //  3. Patches the original pending pod's STATUS (not spec) with:
@@ -99,7 +99,6 @@ func (r *ShadowPodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups="",resources=pods/status,verbs=get;patch
-// +kubebuilder:rbac:groups="",resources=namespaces,verbs=get;list;watch;create
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create
 
 func (r *ShadowPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -135,7 +134,7 @@ func (r *ShadowPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if original.Annotations == nil {
 			original.Annotations = map[string]string{}
 		}
-		original.Annotations[AnnotationShadowPodRef] = r.Config.ShadowPodNamespace + "/" + shadowName
+		original.Annotations[AnnotationShadowPodRef] = original.Namespace + "/" + shadowName
 		if pErr := r.Patch(ctx, original, patch); pErr != nil {
 			log.Error(pErr, "failed to annotate original pod with shadow ref")
 		}
@@ -168,13 +167,13 @@ func (r *ShadowPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 //   - Model name extracted from the original pod's args/command
 //   - KV cache enabled, no threshold set
 func (r *ShadowPodReconciler) ensureShadowPod(ctx context.Context, original *corev1.Pod, shadowName string) (*corev1.Pod, error) {
-	// Ensure the shadow pod namespace exists.
-	if err := r.ensureNamespace(ctx, r.Config.ShadowPodNamespace); err != nil {
-		return nil, fmt.Errorf("ensure shadow namespace: %w", err)
-	}
+	// Create the shadow pod in the same namespace as the original pod so that
+	// Kubernetes NetworkPolicies applied to the model namespace also govern
+	// the shadow pod's ingress/egress traffic.
+	shadowNS := original.Namespace
 
 	existing := &corev1.Pod{}
-	err := r.Get(ctx, types.NamespacedName{Namespace: r.Config.ShadowPodNamespace, Name: shadowName}, existing)
+	err := r.Get(ctx, types.NamespacedName{Namespace: shadowNS, Name: shadowName}, existing)
 	if err == nil {
 		return existing, nil
 	}
@@ -187,7 +186,7 @@ func (r *ShadowPodReconciler) ensureShadowPod(ctx context.Context, original *cor
 	servingPort := extractServingPort(original)
 
 	// Ensure the ConfigMap for the inference simulator exists.
-	if err := r.ensureSimConfigMap(ctx, shadowName, modelName, servedModelName, servingPort); err != nil {
+	if err := r.ensureSimConfigMap(ctx, shadowNS, shadowName, modelName, servedModelName, servingPort); err != nil {
 		return nil, fmt.Errorf("ensure sim configmap: %w", err)
 	}
 
@@ -204,7 +203,7 @@ func (r *ShadowPodReconciler) ensureShadowPod(ctx context.Context, original *cor
 	shadow := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      shadowName,
-			Namespace: r.Config.ShadowPodNamespace,
+			Namespace: shadowNS,
 			Labels:    labels,
 			Annotations: map[string]string{
 				"kaito.sh/original-pod": original.Namespace + "/" + original.Name,
@@ -441,33 +440,13 @@ func makePodCondition(t corev1.PodConditionType, s corev1.ConditionStatus, reaso
 	}
 }
 
-// ensureNamespace creates the namespace if it does not already exist.
-func (r *ShadowPodReconciler) ensureNamespace(ctx context.Context, name string) error {
-	ns := &corev1.Namespace{}
-	if err := r.Get(ctx, types.NamespacedName{Name: name}, ns); err == nil {
-		return nil
-	}
-	ns = &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name: name,
-			Labels: map[string]string{
-				LabelManagedBy: ControllerName,
-			},
-		},
-	}
-	if err := r.Create(ctx, ns); err != nil && !errors.IsAlreadyExists(err) {
-		return fmt.Errorf("create namespace %s: %w", name, err)
-	}
-	return nil
-}
-
 // ensureSimConfigMap creates the inference simulator ConfigMap if it does not exist.
 // The config enables KV cache but does not set any threshold so cache_threshold
 // is never triggered. The port is set to match the original pod's serving port.
-func (r *ShadowPodReconciler) ensureSimConfigMap(ctx context.Context, shadowName, modelName, servedModelName string, port int32) error {
+func (r *ShadowPodReconciler) ensureSimConfigMap(ctx context.Context, namespace, shadowName, modelName, servedModelName string, port int32) error {
 	cmName := shadowName + "-config"
 	existing := &corev1.ConfigMap{}
-	if err := r.Get(ctx, types.NamespacedName{Namespace: r.Config.ShadowPodNamespace, Name: cmName}, existing); err == nil {
+	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cmName}, existing); err == nil {
 		return nil
 	}
 
@@ -488,7 +467,7 @@ inter-token-latency: 30ms
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cmName,
-			Namespace: r.Config.ShadowPodNamespace,
+			Namespace: namespace,
 			Labels: map[string]string{
 				LabelManagedBy: ControllerName,
 			},

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
@@ -131,7 +131,7 @@ func TestEnsureShadowPod_Creates(t *testing.T) {
 	cfg := testConfig()
 
 	// Create the shadow namespace
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cfg.ShadowPodNamespace}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 	original := newPendingPodOnFakeNode("falcon-0", "default", "fake-ws1")
 
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns, original).Build()
@@ -144,8 +144,8 @@ func TestEnsureShadowPod_Creates(t *testing.T) {
 	if shadow.Name != "shadow-default-falcon-0" {
 		t.Errorf("name = %q", shadow.Name)
 	}
-	if shadow.Namespace != cfg.ShadowPodNamespace {
-		t.Errorf("namespace = %q", shadow.Namespace)
+	if shadow.Namespace != "default" {
+		t.Errorf("namespace = %q, want %q", shadow.Namespace, "default")
 	}
 	// Main container should be llm-d-inference-sim
 	if len(shadow.Spec.Containers) != 1 {
@@ -226,7 +226,7 @@ func TestEnsureShadowPod_Creates(t *testing.T) {
 
 	// Verify ConfigMap was created
 	cm := &corev1.ConfigMap{}
-	if err := cl.Get(ctx, types.NamespacedName{Name: "shadow-default-falcon-0-config", Namespace: cfg.ShadowPodNamespace}, cm); err != nil {
+	if err := cl.Get(ctx, types.NamespacedName{Name: "shadow-default-falcon-0-config", Namespace: "default"}, cm); err != nil {
 		t.Fatalf("configmap not created: %v", err)
 	}
 	configYAML := cm.Data["config.yaml"]
@@ -250,11 +250,11 @@ func TestEnsureShadowPod_ReturnsExisting(t *testing.T) {
 	scheme := testScheme()
 	cfg := testConfig()
 
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cfg.ShadowPodNamespace}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 	existing := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "shadow-default-falcon-0",
-			Namespace: cfg.ShadowPodNamespace,
+			Namespace: "default",
 			Labels:    map[string]string{"existing": "true"},
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "i"}}},
@@ -279,7 +279,7 @@ func TestPatchOriginalPodStatus(t *testing.T) {
 
 	original := newPendingPodOnFakeNode("falcon-0", "default", "fake-ws1")
 	shadow := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "shadow-default-falcon-0", Namespace: "kaito-shadow"},
+		ObjectMeta: metav1.ObjectMeta{Name: "shadow-default-falcon-0", Namespace: "default"},
 		Status: corev1.PodStatus{
 			Phase:  corev1.PodRunning,
 			PodIP:  "10.244.1.100",
@@ -419,7 +419,7 @@ func TestShadowPodReconcile_CreatesShadowAndRequeues(t *testing.T) {
 	scheme := testScheme()
 	cfg := testConfig()
 
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cfg.ShadowPodNamespace}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 	original := newPendingPodOnFakeNode("falcon-0", "default", "fake-ws1")
 
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns, original).WithStatusSubresource(original).Build()
@@ -436,14 +436,14 @@ func TestShadowPodReconcile_CreatesShadowAndRequeues(t *testing.T) {
 
 	// Verify shadow pod was created
 	shadow := &corev1.Pod{}
-	if err := cl.Get(ctx, types.NamespacedName{Name: "shadow-default-falcon-0", Namespace: cfg.ShadowPodNamespace}, shadow); err != nil {
+	if err := cl.Get(ctx, types.NamespacedName{Name: "shadow-default-falcon-0", Namespace: "default"}, shadow); err != nil {
 		t.Fatalf("shadow pod not created: %v", err)
 	}
 
 	// Verify annotation was set on original pod
 	updated := &corev1.Pod{}
 	_ = cl.Get(ctx, types.NamespacedName{Name: "falcon-0", Namespace: "default"}, updated)
-	if updated.Annotations[AnnotationShadowPodRef] != cfg.ShadowPodNamespace+"/shadow-default-falcon-0" {
+	if updated.Annotations[AnnotationShadowPodRef] != "default/shadow-default-falcon-0" {
 		t.Errorf("annotation = %q", updated.Annotations[AnnotationShadowPodRef])
 	}
 }
@@ -453,14 +453,14 @@ func TestShadowPodReconcile_PatchesWhenShadowRunning(t *testing.T) {
 	scheme := testScheme()
 	cfg := testConfig()
 
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cfg.ShadowPodNamespace}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 	original := newPendingPodOnFakeNode("falcon-0", "default", "fake-ws1")
 
 	// Pre-create a Running shadow pod
 	shadow := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "shadow-default-falcon-0",
-			Namespace: cfg.ShadowPodNamespace,
+			Namespace: "default",
 			Labels:    map[string]string{ShadowPodLabelKey: "default.falcon-0"},
 		},
 		Spec: corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "i"}}},
@@ -535,7 +535,7 @@ func TestPatchOriginalPodStatus_MultipleContainers(t *testing.T) {
 		Status: corev1.PodStatus{Phase: corev1.PodPending},
 	}
 	shadow := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{Name: "shadow-default-multi-0", Namespace: "kaito-shadow"},
+		ObjectMeta: metav1.ObjectMeta{Name: "shadow-default-multi-0", Namespace: "default"},
 		Status: corev1.PodStatus{
 			Phase:  corev1.PodRunning,
 			PodIP:  "10.244.1.200",
@@ -584,7 +584,7 @@ func TestEnsureShadowPod_MultiplePorts(t *testing.T) {
 	scheme := testScheme()
 	cfg := testConfig()
 
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cfg.ShadowPodNamespace}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 	original := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "multi-port-0",
@@ -621,7 +621,7 @@ func TestEnsureShadowPod_DefaultProbePort(t *testing.T) {
 	scheme := testScheme()
 	cfg := testConfig()
 
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cfg.ShadowPodNamespace}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 	original := &corev1.Pod{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "no-port-0",
@@ -812,18 +812,18 @@ func TestEnsureSimConfigMap(t *testing.T) {
 	ctx := context.Background()
 	scheme := testScheme()
 	cfg := testConfig()
-	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: cfg.ShadowPodNamespace}}
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
 	r := &ShadowPodReconciler{Client: cl, Config: cfg}
 
-	err := r.ensureSimConfigMap(ctx, "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000)
+	err := r.ensureSimConfigMap(ctx, "default", "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000)
 	if err != nil {
 		t.Fatalf("ensureSimConfigMap: %v", err)
 	}
 
 	cm := &corev1.ConfigMap{}
-	if err := cl.Get(ctx, types.NamespacedName{Name: "shadow-default-falcon-0-config", Namespace: cfg.ShadowPodNamespace}, cm); err != nil {
+	if err := cl.Get(ctx, types.NamespacedName{Name: "shadow-default-falcon-0-config", Namespace: "default"}, cm); err != nil {
 		t.Fatalf("configmap not found: %v", err)
 	}
 
@@ -845,70 +845,8 @@ func TestEnsureSimConfigMap(t *testing.T) {
 	}
 
 	// Idempotent: calling again should not error
-	if err := r.ensureSimConfigMap(ctx, "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000); err != nil {
+	if err := r.ensureSimConfigMap(ctx, "default", "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000); err != nil {
 		t.Fatalf("second call should be idempotent: %v", err)
 	}
 }
 
-func TestEnsureNamespace_CreatesWhenMissing(t *testing.T) {
-	ctx := context.Background()
-	scheme := testScheme()
-
-	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-	r := &ShadowPodReconciler{Client: cl, Config: testConfig()}
-
-	if err := r.ensureNamespace(ctx, "kaito-shadow"); err != nil {
-		t.Fatalf("ensureNamespace: %v", err)
-	}
-
-	// Namespace should now exist.
-	ns := &corev1.Namespace{}
-	if err := cl.Get(ctx, types.NamespacedName{Name: "kaito-shadow"}, ns); err != nil {
-		t.Fatalf("namespace should exist: %v", err)
-	}
-	if ns.Labels[LabelManagedBy] != ControllerName {
-		t.Errorf("label = %q, want %q", ns.Labels[LabelManagedBy], ControllerName)
-	}
-}
-
-func TestEnsureNamespace_SkipsWhenExists(t *testing.T) {
-	ctx := context.Background()
-	scheme := testScheme()
-
-	existing := &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:   "kaito-shadow",
-			Labels: map[string]string{"existing": "true"},
-		},
-	}
-
-	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(existing).Build()
-	r := &ShadowPodReconciler{Client: cl, Config: testConfig()}
-
-	if err := r.ensureNamespace(ctx, "kaito-shadow"); err != nil {
-		t.Fatalf("ensureNamespace: %v", err)
-	}
-
-	// Should not overwrite existing namespace.
-	ns := &corev1.Namespace{}
-	_ = cl.Get(ctx, types.NamespacedName{Name: "kaito-shadow"}, ns)
-	if ns.Labels["existing"] != "true" {
-		t.Error("should not recreate existing namespace")
-	}
-}
-
-func TestEnsureNamespace_Idempotent(t *testing.T) {
-	ctx := context.Background()
-	scheme := testScheme()
-
-	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-	r := &ShadowPodReconciler{Client: cl, Config: testConfig()}
-
-	// Call twice — second call should not error.
-	if err := r.ensureNamespace(ctx, "kaito-shadow"); err != nil {
-		t.Fatalf("first call: %v", err)
-	}
-	if err := r.ensureNamespace(ctx, "kaito-shadow"); err != nil {
-		t.Fatalf("second call should be idempotent: %v", err)
-	}
-}

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
@@ -849,4 +849,3 @@ func TestEnsureSimConfigMap(t *testing.T) {
 		t.Fatalf("second call should be idempotent: %v", err)
 	}
 }
-

--- a/test/e2e/gpu_mocker_test.go
+++ b/test/e2e/gpu_mocker_test.go
@@ -31,8 +31,7 @@ import (
 )
 
 const (
-	shadowNamespace = "kaito-shadow"
-	testNamespace   = "default"
+	testNamespace = "default"
 
 	falconModel    = "falcon-7b-instruct"
 	ministralModel = "ministral-3-3b-instruct"
@@ -261,7 +260,7 @@ var _ = Describe("GPU Mocker E2E", Ordered, func() {
 				// Use field selector to skip stale Failed/Completed pods from
 				// previous test runs that haven't been garbage-collected yet.
 				Eventually(func() error {
-					pods, err := clientset.CoreV1().Pods(shadowNamespace).List(context.Background(), metav1.ListOptions{
+					pods, err := clientset.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{
 						LabelSelector: "kaito.sh/managed-by=gpu-mocker",
 						FieldSelector: "status.phase=Running",
 					})
@@ -269,7 +268,7 @@ var _ = Describe("GPU Mocker E2E", Ordered, func() {
 						return fmt.Errorf("failed to list shadow pods: %w", err)
 					}
 					if len(pods.Items) == 0 {
-						return fmt.Errorf("no running shadow pods found in %s", shadowNamespace)
+						return fmt.Errorf("no running shadow pods found in %s", testNamespace)
 					}
 					for _, pod := range pods.Items {
 						if _, ok := pod.Labels["kaito.sh/shadow-pod-for"]; !ok {
@@ -278,14 +277,14 @@ var _ = Describe("GPU Mocker E2E", Ordered, func() {
 					}
 					return nil
 				}, 3*time.Minute, 10*time.Second).Should(Succeed(),
-					"running shadow pods should exist in %s", shadowNamespace)
+					"running shadow pods should exist in %s", testNamespace)
 			})
 
 			It("should have shadow pods with both llm-d-inference-sim and tokenizer containers", func() {
 				clientset, err := utils.GetK8sClientset()
 				Expect(err).NotTo(HaveOccurred())
 
-				pods, err := clientset.CoreV1().Pods(shadowNamespace).List(context.Background(), metav1.ListOptions{
+				pods, err := clientset.CoreV1().Pods(testNamespace).List(context.Background(), metav1.ListOptions{
 					LabelSelector: "kaito.sh/managed-by=gpu-mocker",
 					FieldSelector: "status.phase=Running",
 				})

--- a/test/e2e/production-stack-E2E-test-scenarios.md
+++ b/test/e2e/production-stack-E2E-test-scenarios.md
@@ -190,7 +190,7 @@ individually so failures can be localised.
 * Generate queue pressure — Send concurrent requests at a rate exceeding serving capacity so that `vllm:num_requests_waiting` rises above the KEDA threshold (10) on at least one pod. Verify by scraping shadow pod metrics. This is the trigger condition for scale-up.
 * KEDA triggers replica increase — Poll the InferenceSet and verify `.spec.replicas` increases (e.g. 2 → 3) within the KEDA polling interval. Proves the ScaledObject correctly read the vLLM metric and patched the InferenceSet.
 * New fake node provisioned — Verify a new fake node appears with the correct labels and `Ready=True` status. Proves gpu-node-mocker Phase 1 (NodeClaimReconciler) handled the new NodeClaim produced by Karpenter.
-* New shadow pod running — Verify a new shadow pod reaches `Running` in the `kaito-shadow` namespace with both `inference-sim` and `tokenizer` containers ready. Proves gpu-node-mocker Phase 2 (ShadowPodReconciler) completed the shadow-pod creation path.
+* New shadow pod running — Verify a new shadow pod reaches `Running` in the model's namespace with both `inference-sim` and `tokenizer` containers ready. Proves gpu-node-mocker Phase 2 (ShadowPodReconciler) completed the shadow-pod creation path.
 * Original pod patched to Running — Verify the newly scheduled original pod's status is patched to `Running` with the shadow pod's real CNI IP as `PodIP`. Proves the status-patch pipeline works for dynamically scaled pods, not just initially deployed ones.
 * InferencePool endpoint list updated — Verify `inference_pool_ready_pods{name}` increases to match the new replica count. If InferencePool doesn't learn about the new pod, EPP cannot route to it and the new replica is wasted.
 * New pod receives traffic — Continue sending requests. Scrape `vllm:request_success_total` from the new pod and verify it is > 0 within a reasonable window. The new replica must actually serve traffic, not just exist on paper. (General load-distribution fairness is covered by *Model-Based Routing → Load distribution*; not duplicated here.)
@@ -199,7 +199,7 @@ individually so failures can be localised.
 
 * Stop traffic and drain queue — Cease all inbound requests. Wait for `vllm:num_requests_waiting` to reach 0 on every pod and `vllm:num_requests_running` to reach 0. The queue must fully drain before KEDA begins scale-down.
 * KEDA triggers replica decrease — Poll the InferenceSet and verify `.spec.replicas` decreases (e.g. 3 → 2) after the KEDA cooldown period elapses. Proves the scale-down path is not silently stuck.
-* Excess shadow pod and fake node cleaned up — Verify the extra shadow pod is deleted from `kaito-shadow`, the corresponding fake node is removed, and the NodeClaim is released. Proves the cleanup pipeline (ShadowPodReconciler → NodeClaim release, including the lease-renewal goroutine stop) works.
+* Excess shadow pod and fake node cleaned up — Verify the extra shadow pod is deleted from the model's namespace, the corresponding fake node is removed, and the NodeClaim is released. Proves the cleanup pipeline (ShadowPodReconciler → NodeClaim release, including the lease-renewal goroutine stop) works.
 * InferencePool endpoint list shrinks — Verify `inference_pool_ready_pods{name}` decreases to match the new replica count. A stale endpoint would cause EPP to route to a non-existent pod and requests would fail.
 * Remaining pods continue to serve traffic — Resume sending requests. Verify all requests succeed (HTTP 200). Scrape `vllm:request_success_total` on the remaining pods to confirm they handle the load. `inference_extension_scheduler_attempts_total{status="failure"}` must not increment.
 * No request failures during transition — Send a low-rate stream of requests throughout the scale-down window. Verify `inference_objective_request_error_total` does not increment and no HTTP 5xx responses are observed. Proves the system handles pod removal gracefully without dropping in-flight requests.
@@ -238,7 +238,7 @@ deliberately damage cluster state.
   `Ready=True` without the `node.kubernetes.io/unreachable` taint. If the Phase-1 renewal goroutine
   stops, the node-lifecycle-controller marks the node `Unknown` within 40s and evicts all inference
   pods — the entire stack silently fails.
-* Shadow pod deletion self-heals — Delete a specific shadow pod from `kaito-shadow` while the original
+* Shadow pod deletion self-heals — Delete a specific shadow pod from the model's namespace while the original
   inference pod is running. Verify `ShadowPodReconciler` creates a replacement shadow pod (same
   `kaito.sh/shadow-pod-for` label, new CNI IP), the original pod's `status.podIP` is re-patched to the
   new IP, and the `kaito.sh/shadow-pod-ref` annotation is updated. Send a request afterwards and

--- a/test/e2e/utils/metrics.go
+++ b/test/e2e/utils/metrics.go
@@ -35,7 +35,8 @@ const (
 	EPPMetricsPort = 9090
 
 	// ShadowNamespace is the namespace where shadow pods are deployed.
-	ShadowNamespace = "kaito-shadow"
+	// Shadow pods are created in the same namespace as the original model pods.
+	ShadowNamespace = "default"
 )
 
 // ScrapePodMetrics fetches the /metrics endpoint from a pod using the


### PR DESCRIPTION
Shadow pods were created in a fixed `kaito-shadow` namespace, but Kubernetes NetworkPolicies applied to the model namespace only govern pods within that namespace. Traffic to the model pod IP hit the shadow pod in `kaito-shadow` which had no network policies, so nothing was blocked.

Create shadow pods in the same namespace as the original model pod so that NetworkPolicies apply correctly.

- Remove Config.ShadowPodNamespace, --shadow-pod-namespace flag, and helm chart value
- Remove ensureNamespace() (model namespace already exists)
- Update all unit tests, E2E tests, and docs

Fixes #32

**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

**Requirements**

- [x] added unit tests and e2e tests (if applicable)

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Fixes https://github.com/kaito-project/production-stack/issues/32

**Notes for Reviewers**:
