### PR TITLE
fix: simplify e2e-up with username-based naming

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -87,6 +87,7 @@ jobs:
             echo "BBR_VERSION=${BBR_VERSION}"
             echo "KEDA_VERSION=${KEDA_VERSION}"
             echo "KEDA_KAITO_SCALER_VERSION=${KEDA_KAITO_SCALER_VERSION}"
+            echo "AKS_K8S_VERSION=${AKS_K8S_VERSION}"
           } >> "$GITHUB_ENV"
 
       - name: Print versions
@@ -98,6 +99,7 @@ jobs:
           echo "BBR_VERSION=${BBR_VERSION}"
           echo "KEDA_VERSION=${KEDA_VERSION}"
           echo "KEDA_KAITO_SCALER_VERSION=${KEDA_KAITO_SCALER_VERSION}"
+          echo "AKS_K8S_VERSION=${AKS_K8S_VERSION}"
 
       - name: Setup Go
         uses: actions/setup-go@v6

--- a/Makefile
+++ b/Makefile
@@ -79,6 +79,7 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 IMG_TAG ?= $(VERSION)
 IMG ?= $(REGISTRY)/$(IMG_NAME):$(IMG_TAG)
 
+CONTAINER_ENGINE ?= $(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
 ARCH ?= amd64
 
 .PHONY: build
@@ -89,8 +90,6 @@ build: ## Build the gpu-node-mocker binary.
 .PHONY: test
 test: ## Run unit tests.
 	go test -v -race -count=1 ./pkg/... ./cmd/...
-
-CONTAINER_TOOL ?= $(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null || echo docker)
 
 .PHONY: docker-build
 docker-build: ## Build docker image for the target ARCH.
@@ -161,13 +160,15 @@ e2e-teardown: ## Tear down the E2E cluster.
 	hack/e2e/scripts/run-e2e-local.sh teardown
 
 .PHONY: e2e-up
-e2e-up: docker-build e2e-setup ## One command to set up full local E2E env (build, cluster, push, install, validate).
-	@echo "=== Deriving ACR name ==="
-	$(eval ACR_NAME := $(shell az acr list --resource-group $${RESOURCE_GROUP:-kaito-e2e-local} --query '[0].name' -o tsv))
-	@echo "=== Pushing gpu-node-mocker image to ACR ($(ACR_NAME)) ==="
-	$(eval SHADOW_CONTROLLER_IMAGE := $(shell ACR_NAME=$(ACR_NAME) $(MAKE) --no-print-directory e2e-push-image-local | grep '^image=' | cut -d= -f2-))
-	@echo "Image: $(SHADOW_CONTROLLER_IMAGE)"
-	SHADOW_CONTROLLER_IMAGE="$(SHADOW_CONTROLLER_IMAGE)" $(MAKE) e2e-install
+e2e-up: e2e-setup ## One command to set up full local E2E env (build, cluster, push, install, validate).
+	@ACR_NAME=$$(az acr list --resource-group $${RESOURCE_GROUP:-kaito-e2e-local} --query '[0].name' -o tsv) && \
+	echo "=== Building and pushing image to ACR ($$ACR_NAME) ===" && \
+	TOKEN=$$(az acr login --name "$$ACR_NAME" --expose-token --query accessToken -o tsv) && \
+	echo "$$TOKEN" | $(CONTAINER_ENGINE) login "$$ACR_NAME.azurecr.io" --username 00000000-0000-0000-0000-000000000000 --password-stdin && \
+	$(CONTAINER_ENGINE) build --platform linux/$(ARCH) -f docker/Dockerfile \
+		-t "$$ACR_NAME.azurecr.io/gpu-node-mocker:latest" . && \
+	$(CONTAINER_ENGINE) push "$$ACR_NAME.azurecr.io/gpu-node-mocker:latest" && \
+	SHADOW_CONTROLLER_IMAGE="$$ACR_NAME.azurecr.io/gpu-node-mocker:latest" $(MAKE) e2e-install
 	$(MAKE) e2e-validate
 	@echo ""
 	@echo "=== E2E environment is ready ==="

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,6 @@ VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
 IMG_TAG ?= $(VERSION)
 IMG ?= $(REGISTRY)/$(IMG_NAME):$(IMG_TAG)
 
-CONTAINER_ENGINE ?= $(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null)
 ARCH ?= amd64
 
 .PHONY: build
@@ -90,6 +89,8 @@ build: ## Build the gpu-node-mocker binary.
 .PHONY: test
 test: ## Run unit tests.
 	go test -v -race -count=1 ./pkg/... ./cmd/...
+
+CONTAINER_TOOL ?= $(shell command -v docker 2>/dev/null || command -v podman 2>/dev/null || echo docker)
 
 .PHONY: docker-build
 docker-build: ## Build docker image for the target ARCH.
@@ -159,18 +160,20 @@ e2e-dump: ## Dump cluster state for debugging.
 e2e-teardown: ## Tear down the E2E cluster.
 	hack/e2e/scripts/run-e2e-local.sh teardown
 
+USER_ID ?= $(shell whoami)
+E2E_CLUSTER_NAME ?= kaito-$(USER_ID)
+E2E_RESOURCE_GROUP ?= kaito-$(USER_ID)
+
 .PHONY: e2e-up
-e2e-up: e2e-setup ## One command to set up full local E2E env (build, cluster, push, install, validate).
-	@ACR_NAME=$$(az acr list --resource-group $${RESOURCE_GROUP:-kaito-e2e-local} --query '[0].name' -o tsv) && \
-	echo "=== Building and pushing image to ACR ($$ACR_NAME) ===" && \
-	TOKEN=$$(az acr login --name "$$ACR_NAME" --expose-token --query accessToken -o tsv) && \
-	echo "$$TOKEN" | $(CONTAINER_ENGINE) login "$$ACR_NAME.azurecr.io" --username 00000000-0000-0000-0000-000000000000 --password-stdin && \
-	$(CONTAINER_ENGINE) build --platform linux/$(ARCH) -f docker/Dockerfile \
-		-t "$$ACR_NAME.azurecr.io/gpu-node-mocker:latest" . && \
-	$(CONTAINER_ENGINE) push "$$ACR_NAME.azurecr.io/gpu-node-mocker:latest" && \
-	SHADOW_CONTROLLER_IMAGE="$$ACR_NAME.azurecr.io/gpu-node-mocker:latest" $(MAKE) e2e-install
-	$(MAKE) e2e-validate
-	@echo ""
-	@echo "=== E2E environment is ready ==="
-	@echo "Run tests with: make test-e2e"
-	@echo "Tear down with: make e2e-teardown"
+e2e-up: ## One command to set up full local E2E env (cluster, build, push, install, validate).
+	@export CLUSTER_NAME=$(E2E_CLUSTER_NAME) RESOURCE_GROUP=$(E2E_RESOURCE_GROUP) && \
+	hack/e2e/scripts/run-e2e-local.sh setup && \
+	hack/e2e/scripts/run-e2e-local.sh build-push && \
+	hack/e2e/scripts/run-e2e-local.sh install && \
+	hack/e2e/scripts/run-e2e-local.sh validate && \
+	echo "" && \
+	echo "=== E2E environment is ready ===" && \
+	echo "  Cluster: $(E2E_CLUSTER_NAME)" && \
+	echo "  Resource Group: $(E2E_RESOURCE_GROUP)" && \
+	echo "Run tests with: make test-e2e" && \
+	echo "Tear down with: CLUSTER_NAME=$(E2E_CLUSTER_NAME) RESOURCE_GROUP=$(E2E_RESOURCE_GROUP) make e2e-teardown"

--- a/hack/e2e/scripts/run-e2e-local.sh
+++ b/hack/e2e/scripts/run-e2e-local.sh
@@ -40,7 +40,7 @@ source "${REPO_ROOT}/versions.env"
 [ -n "${_KEDA}" ]  && KEDA_VERSION="${_KEDA}"
 [ -n "${_KKS}" ]   && KEDA_KAITO_SCALER_VERSION="${_KKS}"
 
-export KAITO_VERSION ISTIO_VERSION GATEWAY_API_VERSION BBR_VERSION KEDA_VERSION KEDA_KAITO_SCALER_VERSION
+export KAITO_VERSION ISTIO_VERSION GATEWAY_API_VERSION BBR_VERSION KEDA_VERSION KEDA_KAITO_SCALER_VERSION AKS_K8S_VERSION
 
 echo "=== Component versions (from versions.env) ==="
 echo "  KAITO_VERSION:             ${KAITO_VERSION}"
@@ -76,11 +76,22 @@ cleanup() {
   exit "${exit_code}"
 }
 
+CONTAINER_TOOL="${CONTAINER_TOOL:-$(command -v podman 2>/dev/null || command -v docker 2>/dev/null)}"
+
 derive_acr() {
   ACR_NAME="${ACR_NAME:-$(echo "${CLUSTER_NAME}acr" | tr -d '-' | head -c 50)}"
   ACR_LOGIN_SERVER=$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)
   export ACR_LOGIN_SERVER
   export SHADOW_CONTROLLER_IMAGE="${ACR_LOGIN_SERVER}/gpu-node-mocker:latest"
+}
+
+do_build_push() {
+  derive_acr
+  echo "=== Building and pushing image to ACR (${ACR_NAME}) ==="
+  TOKEN=$(az acr login --name "${ACR_NAME}" --expose-token --query accessToken -o tsv)
+  echo "${TOKEN}" | "${CONTAINER_TOOL}" login "${ACR_LOGIN_SERVER}" --username 00000000-0000-0000-0000-000000000000 --password-stdin
+  "${CONTAINER_TOOL}" build --platform linux/amd64 -f "${REPO_ROOT}/docker/Dockerfile" -t "${SHADOW_CONTROLLER_IMAGE}" "${REPO_ROOT}"
+  "${CONTAINER_TOOL}" push "${SHADOW_CONTROLLER_IMAGE}"
 }
 
 do_setup() {
@@ -113,8 +124,9 @@ do_teardown() {
 }
 
 case "${STEP}" in
-  setup)    do_setup ;;
-  install)  do_install ;;
+  setup)      do_setup ;;
+  build-push) do_build_push ;;
+  install)    do_install ;;
   validate) do_validate ;;
   test)     do_test ;;
   teardown) do_teardown ;;

--- a/hack/e2e/scripts/setup-cluster.sh
+++ b/hack/e2e/scripts/setup-cluster.sh
@@ -46,7 +46,8 @@ az aks create \
   --node-vm-size "${NODE_VM_SIZE}" \
   --enable-managed-identity \
   --attach-acr "${ACR_NAME}" \
-  --generate-ssh-keys
+  --generate-ssh-keys \
+  ${AKS_K8S_VERSION:+--kubernetes-version "${AKS_K8S_VERSION}"}
 
 echo "=== Fetching kubeconfig ==="
 az aks get-credentials \

--- a/versions.env
+++ b/versions.env
@@ -18,8 +18,11 @@ GO_VERSION="1.26.1"
 # KAITO workspace operator Helm chart version
 KAITO_VERSION="v0.9.1"
 
-# Istio version
-ISTIO_VERSION="1.29.0"
+# AKS Kubernetes version
+AKS_K8S_VERSION="1.34"
+
+# Istio version (must support AKS_K8S_VERSION — see https://istio.io/latest/docs/releases/supported-releases/)
+ISTIO_VERSION="1.29.2"
 
 # Gateway API CRD version
 GATEWAY_API_VERSION="v1.2.0"


### PR DESCRIPTION
## Summary
- Simplify `make e2e-up` so devs can run it with zero env vars — cluster and resource group default to `kaito-<whoami>`
- Move image build+push logic into `run-e2e-local.sh` as `do_build_push` step, using token-based ACR login (works with both Docker and Podman)
- Pin AKS Kubernetes version (1.34) in `versions.env` and bump Istio to 1.29.2 to fix `omitNil` template crash
- CI workflows unaffected — they set their own `CLUSTER_NAME`/`RESOURCE_GROUP` env vars

## Test plan
- [x] Full `make e2e-up` from scratch (cluster creation, ACR build+push, install, validate)
- [x] `make test-e2e` — 28/29 passed, 1 flaky (pre-existing)
- [x] Verified CI targets (`e2e-setup`, `e2e-push-image`, `e2e-install`) are unchanged