### PR TITLE
fix nightly e2e workflow

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -49,9 +49,11 @@ on:
         default: ''
 
 env:
-  RESOURCE_GROUP: "kaito-gw-e2e-nightly-rg-${{ github.run_id }}"
-  CLUSTER_NAME: "kaito-gw-e2e-nightly-aks-${{ github.run_id }}"
-  ACR_NAME: "kaitogwe2enightly${{ github.run_id }}acr"
+  # Names are kept short so that the AKS-managed node resource group
+  # ("MC_<RG>_<CLUSTER>_<LOCATION>") stays within the 80-char limit.
+  RESOURCE_GROUP: "kaito-nightly-rg-${{ github.run_id }}"
+  CLUSTER_NAME: "kaito-nightly-aks-${{ github.run_id }}"
+  ACR_NAME: "kaitonightly${{ github.run_id }}acr"
   GPU_MOCKER_IMAGE: "gpu-node-mocker:latest-${{ github.run_id }}"
   LOCATION: australiaeast
   NODE_COUNT: '3'


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->
fix the following error:

> ERROR: (InvalidParameter) The length of the node resource group name is too long. 
The maximum length is 80 and the length of the value provided is 89.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
