### PR TITLE
chore: bump llm-gateway-auth to 0.0.7-alpha

### DIFF
--- a/hack/e2e/scripts/install-components.sh
+++ b/hack/e2e/scripts/install-components.sh
@@ -311,9 +311,6 @@ install_bbr() {
 }
 
 install_llm_gateway_auth() {
-  # operator.webhook.enabled=false skips the validating webhook (which
-  # would otherwise require cert-manager). TODO: re-enable webhook +
-  # cert-manager once the install ordering is sorted out.
   echo "=== Installing LLM Gateway Auth ${LLM_GATEWAY_AUTH_VERSION} ==="
   helm upgrade --install llm-gateway-apikey \
     oci://mcr.microsoft.com/aks/kaito/helm/llm-gateway-apikey \
@@ -324,7 +321,6 @@ install_llm_gateway_auth() {
     --set operator.image.tag="${LLM_GATEWAY_AUTH_IMAGE_TAG}" \
     --set authz.image.repository=mcr.microsoft.com/aks/kaito/apikey-authz \
     --set authz.image.tag="${LLM_GATEWAY_AUTH_IMAGE_TAG}" \
-    --set operator.webhook.enabled=false \
     --set istio.enabled=true \
     --set istio.meshConfigConfigMap.patch=true \
     --set istio.gatewayNamespace=default \

--- a/versions.env
+++ b/versions.env
@@ -41,7 +41,7 @@ KEDA_VERSION="v2.19.0"
 KEDA_KAITO_SCALER_VERSION="v0.4.1"
 
 # LLM Gateway Auth (API key ext_authz) Helm chart version
-LLM_GATEWAY_AUTH_VERSION="0.0.4-alpha"
+LLM_GATEWAY_AUTH_VERSION="0.0.7-alpha"
 
 # LLM Gateway Auth container image tag (may differ from chart version)
-LLM_GATEWAY_AUTH_IMAGE_TAG="0.0.2-alpha"
+LLM_GATEWAY_AUTH_IMAGE_TAG="0.0.7-alpha"


### PR DESCRIPTION
The 0.0.7-alpha chart's webhook self-manages TLS via open-policy-agent/cert-controller, so cert-manager is no longer required. Drop the operator.webhook.enabled=false workaround and the associated TODO from the E2E install script.

- versions.env: LLM_GATEWAY_AUTH_VERSION 0.0.4-alpha -> 0.0.7-alpha, LLM_GATEWAY_AUTH_IMAGE_TAG 0.0.2-alpha -> 0.0.7-alpha
- hack/e2e/scripts/install-components.sh: remove --set operator.webhook.enabled=false and cert-manager TODO

**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
