### PR TITLE
feat: separate image preparation from cluster setup for accurate E2E timing

### DIFF
--- a/.github/actions/e2e-base-setup/action.yaml
+++ b/.github/actions/e2e-base-setup/action.yaml
@@ -143,11 +143,18 @@ runs:
       shell: bash
       run: az login --identity
 
-    - name: Build gpu-node-mocker image
+    - name: Prepare gpu-node-mocker image
+      id: image
       shell: bash
       env:
+        RESOURCE_GROUP: ${{ inputs.resource-group }}
+        CLUSTER_NAME: ${{ inputs.cluster-name }}
+        ACR_NAME: ${{ inputs.acr-name }}
+        LOCATION: ${{ inputs.location }}
         IMG: ${{ inputs.gpu-mocker-image }}
-      run: make docker-build
+      run: |
+        OUTPUT=$(make e2e-prepare-image)
+        echo "image=$(echo "$OUTPUT" | grep '^image=' | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
 
     - name: Setup cluster
       shell: bash
@@ -159,16 +166,6 @@ runs:
         NODE_COUNT: ${{ inputs.node-count }}
         NODE_VM_SIZE: ${{ inputs.node-vm-size }}
       run: make e2e-setup
-
-    - name: Push gpu-node-mocker image
-      id: image
-      shell: bash
-      env:
-        ACR_NAME: ${{ inputs.acr-name }}
-        GPU_MOCKER_IMAGE: ${{ inputs.gpu-mocker-image }}
-      run: |
-        OUTPUT=$(make e2e-push-image)
-        echo "image=$(echo "$OUTPUT" | grep '^image=' | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
 
     - name: Install components
       shell: bash

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -161,7 +161,7 @@ jobs:
           echo "image=$(echo "$OUTPUT" | grep '^image=' | cut -d= -f2-)" >> "$GITHUB_OUTPUT"
         env:
           ACR_NAME: ${{ env.ACR_NAME }}
-          GPU_MOCKER_IMAGE: ${{ env.GPU_MOCKER_IMAGE }}
+          IMG: ${{ env.GPU_MOCKER_IMAGE }}
 
       - name: Install components
         run: make e2e-install

--- a/Makefile
+++ b/Makefile
@@ -147,17 +147,19 @@ e2e: ## Run full E2E cycle: setup cluster, install, validate, test, teardown.
 	hack/e2e/scripts/run-e2e-local.sh all
 
 .PHONY: e2e-setup
-e2e-setup: ## Create AKS cluster and build/push images.
+e2e-setup: ## Create AKS cluster (requires RG+ACR; run e2e-prepare-image first).
 	hack/e2e/scripts/run-e2e-local.sh setup
 
-GPU_MOCKER_IMAGE ?= gpu-node-mocker:latest
+.PHONY: e2e-prepare-image
+e2e-prepare-image: ## Create RG+ACR and build/push the gpu-node-mocker image to ACR.
+	hack/e2e/scripts/prepare-image.sh
 
 .PHONY: e2e-push-image
 e2e-push-image: ## Tag and push image to ACR. Sets SHADOW_CONTROLLER_IMAGE.
 	az acr login --name "$${ACR_NAME}" >&2; \
 	IMAGE_TAG="latest-$$(head -c 8 /dev/urandom | xxd -p)"; \
 	IMAGE="$${ACR_NAME}.azurecr.io/gpu-node-mocker:$${IMAGE_TAG}"; \
-	$(CONTAINER_TOOL) tag $(GPU_MOCKER_IMAGE) "$${IMAGE}" >&2; \
+	$(CONTAINER_TOOL) tag $(IMG) "$${IMAGE}" >&2; \
 	$(CONTAINER_TOOL) push "$${IMAGE}" >&2; \
 	echo "image=$${IMAGE}"
 
@@ -191,16 +193,20 @@ E2E_RESOURCE_GROUP ?= kaito-$(USER_ID)
 
 .PHONY: e2e-up
 e2e-up: ## One command to set up full local E2E env (cluster, build, push, install, validate).
-	@export CLUSTER_NAME=$(E2E_CLUSTER_NAME) RESOURCE_GROUP=$(E2E_RESOURCE_GROUP) && \
-	hack/e2e/scripts/run-e2e-local.sh setup && \
-	hack/e2e/scripts/run-e2e-local.sh build-push && \
-	hack/e2e/scripts/run-e2e-local.sh install && \
-	hack/e2e/scripts/run-e2e-local.sh validate && \
-	echo "" && \
-	echo "=== E2E environment is ready ===" && \
-	echo "  Cluster: $(E2E_CLUSTER_NAME)" && \
-	echo "  Resource Group: $(E2E_RESOURCE_GROUP)" && \
-	echo "Run tests with: make test-e2e" && \
+	@set -e; \
+	export CLUSTER_NAME=$(E2E_CLUSTER_NAME) RESOURCE_GROUP=$(E2E_RESOURCE_GROUP); \
+	IMAGE_LINE=$$(hack/e2e/scripts/prepare-image.sh | grep '^image='); \
+	export SHADOW_CONTROLLER_IMAGE=$${IMAGE_LINE#image=}; \
+	echo "Using SHADOW_CONTROLLER_IMAGE=$${SHADOW_CONTROLLER_IMAGE}"; \
+	hack/e2e/scripts/run-e2e-local.sh setup; \
+	hack/e2e/scripts/run-e2e-local.sh install; \
+	hack/e2e/scripts/run-e2e-local.sh validate; \
+	echo ""; \
+	echo "=== E2E environment is ready ==="; \
+	echo "  Cluster: $(E2E_CLUSTER_NAME)"; \
+	echo "  Resource Group: $(E2E_RESOURCE_GROUP)"; \
+	echo "  Image:   $${SHADOW_CONTROLLER_IMAGE}"; \
+	echo "Run tests with: make test-e2e"; \
 	echo "Tear down with: CLUSTER_NAME=$(E2E_CLUSTER_NAME) RESOURCE_GROUP=$(E2E_RESOURCE_GROUP) make e2e-teardown"
 
 ## --------------------------------------

--- a/hack/e2e/scripts/prepare-image.sh
+++ b/hack/e2e/scripts/prepare-image.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# prepare-image.sh — Create the resource group + ACR, then build and push
+# the gpu-node-mocker image into ACR.
+#
+# This step is intentionally split from setup-cluster.sh so that AKS-create
+# wall time can be measured in isolation. Both `az group create` and
+# `az acr create` are idempotent, so this script is safe to re-run.
+#
+# Environment variables:
+#   RESOURCE_GROUP   — Azure resource group name (default: kaito-rg)
+#   CLUSTER_NAME     — AKS cluster name          (default: kaito-aks)
+#   ACR_NAME         — ACR registry name         (default: <cluster_name>acr, sanitized)
+#   LOCATION         — Azure region              (default: australiaeast)
+#   IMG              — Local docker tag for the gpu-node-mocker image
+#                      (default: gpu-node-mocker:latest)
+#
+# Outputs (on stdout):
+#   image=<acr-fqdn>/gpu-node-mocker:<tag>
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../../.." && pwd)"
+
+RESOURCE_GROUP="${RESOURCE_GROUP:-kaito-rg}"
+CLUSTER_NAME="${CLUSTER_NAME:-kaito-aks}"
+# ACR names must be alphanumeric, 5-50 chars. Strip dashes from cluster name.
+ACR_NAME="${ACR_NAME:-$(echo "${CLUSTER_NAME}acr" | tr -d '-' | head -c 50)}"
+LOCATION="${LOCATION:-australiaeast}"
+IMG="${IMG:-gpu-node-mocker:latest}"
+
+# Verify the container tool used by the Makefile (docker/podman) is installed
+# and its daemon is reachable. Fail fast here so users get an actionable error
+# before `az group create` runs, instead of a cryptic failure midway through
+# `make docker-build`.
+CONTAINER_TOOL="${CONTAINER_TOOL:-$(command -v docker 2>/dev/null || command -v podman 2>/dev/null || true)}"
+if [[ -z "${CONTAINER_TOOL}" ]]; then
+  echo "Error: neither 'docker' nor 'podman' found in PATH." >&2
+  echo "Install Docker (e.g. 'sudo apt-get install docker.io') or set CONTAINER_TOOL." >&2
+  exit 1
+fi
+if ! "${CONTAINER_TOOL}" info &>/dev/null; then
+  echo "Error: '${CONTAINER_TOOL}' is installed but the daemon is not running." >&2
+  echo "Start it with: sudo systemctl start $(basename "${CONTAINER_TOOL}")" >&2
+  exit 1
+fi
+export CONTAINER_TOOL
+
+echo "=== Creating resource group ${RESOURCE_GROUP} in ${LOCATION} ===" >&2
+az group create --name "${RESOURCE_GROUP}" --location "${LOCATION}" >&2
+
+echo "=== Creating ACR ${ACR_NAME} ===" >&2
+az acr create --resource-group "${RESOURCE_GROUP}" --name "${ACR_NAME}" --sku Basic >&2
+
+echo "=== Building gpu-node-mocker image (${IMG}) ===" >&2
+IMG="${IMG}" make -C "${REPO_ROOT}" docker-build >&2
+
+echo "=== Pushing gpu-node-mocker image to ACR (${ACR_NAME}) ===" >&2
+ACR_NAME="${ACR_NAME}" IMG="${IMG}" make -C "${REPO_ROOT}" e2e-push-image

--- a/hack/e2e/scripts/run-e2e-local.sh
+++ b/hack/e2e/scripts/run-e2e-local.sh
@@ -4,7 +4,7 @@
 #
 # Usage:
 #   hack/e2e/scripts/run-e2e-local.sh           # full cycle: setup → install → validate → test → teardown
-#   hack/e2e/scripts/run-e2e-local.sh setup      # only create cluster + build images
+#   hack/e2e/scripts/run-e2e-local.sh setup      # only create AKS cluster (RG+ACR must already exist; run prepare-image.sh first)
 #   hack/e2e/scripts/run-e2e-local.sh install     # only install components (cluster must exist)
 #   hack/e2e/scripts/run-e2e-local.sh validate    # only validate components
 #   hack/e2e/scripts/run-e2e-local.sh test        # only run Go e2e tests
@@ -109,21 +109,6 @@ cleanup() {
   exit "${exit_code}"
 }
 
-CONTAINER_TOOL="${CONTAINER_TOOL:-$(command -v podman 2>/dev/null || command -v docker 2>/dev/null || true)}"
-
-require_container_tool() {
-  if [[ -z "${CONTAINER_TOOL}" ]]; then
-    echo "Error: neither 'docker' nor 'podman' found in PATH." >&2
-    echo "Install Docker (e.g. 'sudo apt-get install docker.io') or set CONTAINER_TOOL." >&2
-    exit 1
-  fi
-  if ! "${CONTAINER_TOOL}" info &>/dev/null; then
-    echo "Error: '${CONTAINER_TOOL}' is installed but the daemon is not running." >&2
-    echo "Start it with: sudo systemctl start $(basename "${CONTAINER_TOOL}")" >&2
-    exit 1
-  fi
-}
-
 # ── Step-level timing ─────────────────────────────────────────────────────
 # Tracks wall-clock per top-level do_<step> invocation so we can spot the
 # real bottleneck (cluster create vs. image build vs. component install vs.
@@ -162,23 +147,6 @@ print_step_timings() {
   echo "=================================================================="
 }
 
-derive_acr() {
-  ACR_NAME="${ACR_NAME:-$(echo "${CLUSTER_NAME}acr" | tr -d '-' | head -c 50)}"
-  ACR_LOGIN_SERVER=$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)
-  export ACR_LOGIN_SERVER
-  export SHADOW_CONTROLLER_IMAGE="${ACR_LOGIN_SERVER}/gpu-node-mocker:latest"
-}
-
-do_build_push() {
-  require_container_tool
-  derive_acr
-  echo "=== Building and pushing image to ACR (${ACR_NAME}) ==="
-  TOKEN=$(az acr login --name "${ACR_NAME}" --expose-token --query accessToken -o tsv)
-  echo "${TOKEN}" | "${CONTAINER_TOOL}" login "${ACR_LOGIN_SERVER}" --username 00000000-0000-0000-0000-000000000000 --password-stdin
-  "${CONTAINER_TOOL}" build --platform linux/amd64 -f "${REPO_ROOT}/docker/Dockerfile" -t "${SHADOW_CONTROLLER_IMAGE}" "${REPO_ROOT}"
-  "${CONTAINER_TOOL}" push "${SHADOW_CONTROLLER_IMAGE}"
-}
-
 do_setup() {
   echo "=== Setting up cluster ==="
   "${SCRIPT_DIR}/setup-cluster.sh"
@@ -186,7 +154,8 @@ do_setup() {
 
 do_install() {
   if [[ -z "${SHADOW_CONTROLLER_IMAGE:-}" ]]; then
-    derive_acr
+    echo "❌ SHADOW_CONTROLLER_IMAGE is not set. Run prepare-image.sh first and export the resulting image= value." >&2
+    exit 1
   fi
   echo "=== Installing components ==="
   "${SCRIPT_DIR}/install-components.sh"
@@ -216,7 +185,6 @@ do_teardown() {
 
 case "${STEP}" in
   setup)      time_step setup      do_setup ;;
-  build-push) time_step build-push do_build_push ;;
   install)    time_step install    do_install ;;
   validate)   time_step validate   do_validate ;;
   test)       time_step test       do_test ;;

--- a/hack/e2e/scripts/setup-cluster.sh
+++ b/hack/e2e/scripts/setup-cluster.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # ---------------------------------------------------------------------------
-# setup-cluster.sh — Create an AKS cluster + ACR for E2E testing.
+# setup-cluster.sh — Create an AKS cluster for E2E testing.
+#
+# Prerequisite: the resource group and ACR must already exist (created by
+# `prepare-image.sh` or the CI "Prepare gpu-node-mocker image" step). This
+# script intentionally only creates the AKS cluster so its wall time can be
+# measured in isolation.
 #
 # Environment variables (all required unless defaults are acceptable):
 #   RESOURCE_GROUP   — Azure resource group name  (default: kaito-rg)
@@ -9,9 +14,6 @@
 #   LOCATION         — Azure region               (default: australiaeast)
 #   NODE_COUNT       — Number of worker nodes      (default: 2)
 #   NODE_VM_SIZE     — VM SKU for the node pool    (default: Standard_D8s_v5)
-#
-# Outputs (exported for use by install-components.sh):
-#   ACR_LOGIN_SERVER — e.g. kaitoaksacr.azurecr.io
 # ---------------------------------------------------------------------------
 set -euo pipefail
 
@@ -85,21 +87,6 @@ case "${E2E_PROVIDER}" in
     ;;
 esac
 
-echo "=== Creating resource group ${RESOURCE_GROUP} in ${LOCATION} ==="
-az group create \
-  --name "${RESOURCE_GROUP}" \
-  --location "${LOCATION}"
-
-echo "=== Creating ACR ${ACR_NAME} ==="
-az acr create \
-  --resource-group "${RESOURCE_GROUP}" \
-  --name "${ACR_NAME}" \
-  --sku Basic
-
-ACR_LOGIN_SERVER=$(az acr show --name "${ACR_NAME}" --query loginServer -o tsv)
-export ACR_LOGIN_SERVER
-echo "ACR login server: ${ACR_LOGIN_SERVER}"
-
 echo "=== Creating AKS cluster ${CLUSTER_NAME} (provider=${E2E_PROVIDER}) ==="
 az aks create \
   --resource-group "${RESOURCE_GROUP}" \
@@ -127,6 +114,5 @@ kubectl wait --for=condition=ready nodes --all --timeout=300s
 
 echo ""
 echo "✅ AKS cluster ${CLUSTER_NAME} is ready."
-echo "   ACR: ${ACR_LOGIN_SERVER}"
 echo ""
 kubectl get nodes -o wide


### PR DESCRIPTION
- Add hack/e2e/scripts/prepare-image.sh to create RG+ACR and build/push the gpu-node-mocker image as a single, isolated step.
- Strip RG/ACR creation from setup-cluster.sh so it only times AKS creation; remove unused ACR_LOGIN_SERVER export.
- Add 'make e2e-prepare-image' target; update e2e-up to capture the pushed image via SHADOW_CONTROLLER_IMAGE.
- Drop derive_acr() and the build-push step from run-e2e-local.sh; do_install now fails fast when SHADOW_CONTROLLER_IMAGE is unset.
- Consolidate GPU_MOCKER_IMAGE into IMG across Makefile, scripts, and workflows.
- CI: e2e-base-setup action and e2e-nightly workflow call make e2e-prepare-image before make e2e-setup so each step's wall time is reported independently.

**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
