### PR TITLE
feat(chart): exclude EPP metrics port from Istio sidecar interception

### DIFF
--- a/charts/modeldeployment/templates/epp-deployment.yaml
+++ b/charts/modeldeployment/templates/epp-deployment.yaml
@@ -15,6 +15,8 @@ spec:
       {{- include "modeldeployment.eppSelectorLabels" . | nindent 6 }}
   template:
     metadata:
+      annotations:
+        traffic.sidecar.istio.io/excludeInboundPorts: "{{ .Values.epp.metricsPort }}"
       labels:
         {{- include "modeldeployment.eppSelectorLabels" . | nindent 8 }}
     spec:

--- a/test/e2e/gpu_mocker_test.go
+++ b/test/e2e/gpu_mocker_test.go
@@ -390,6 +390,99 @@ var _ = Describe("GPU Mocker E2E", Ordered, func() {
 			})
 		})
 
+		Context("NodeClaim reconcile idempotency", func() {
+			It("should not create duplicate fake Nodes or Leases when the same NodeClaim is re-applied", func() {
+				clientset, err := utils.GetK8sClientset()
+				Expect(err).NotTo(HaveOccurred())
+				dynClient, err := utils.GetDynamicClient()
+				Expect(err).NotTo(HaveOccurred())
+
+				ctx := context.Background()
+
+				// Find an existing NodeClaim to re-apply.
+				nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+					LabelSelector: "kaito.sh/fake-node=true,kaito.sh/managed-by=gpu-mocker",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(nodes.Items).NotTo(BeEmpty(), "need at least one fake node")
+
+				targetNode := nodes.Items[0]
+				var ncName string
+				for _, ref := range targetNode.OwnerReferences {
+					if ref.Kind == "NodeClaim" {
+						ncName = ref.Name
+						break
+					}
+				}
+				Expect(ncName).NotTo(BeEmpty(),
+					"fake node %q should have a NodeClaim owner reference", targetNode.Name)
+
+				By("recording baseline fake node and lease counts")
+				baselineNodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+					LabelSelector: "kaito.sh/fake-node=true,kaito.sh/managed-by=gpu-mocker",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				baselineNodeCount := len(baselineNodes.Items)
+
+				baselineLeases, err := clientset.CoordinationV1().Leases("kube-node-lease").List(ctx, metav1.ListOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				// Count only leases that correspond to fake nodes.
+				fakeNodeNames := make(map[string]bool)
+				for _, n := range baselineNodes.Items {
+					fakeNodeNames[n.Name] = true
+				}
+				var baselineLeaseCount int
+				for _, l := range baselineLeases.Items {
+					if fakeNodeNames[l.Name] {
+						baselineLeaseCount++
+					}
+				}
+
+				By(fmt.Sprintf("re-applying NodeClaim %q to trigger duplicate reconcile", ncName))
+				nc, err := dynClient.Resource(utils.NodeClaimGVR).Get(ctx, ncName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Force a reconcile by updating a harmless annotation.
+				annotations := nc.GetAnnotations()
+				if annotations == nil {
+					annotations = make(map[string]string)
+				}
+				annotations["e2e-test/idempotency-trigger"] = fmt.Sprintf("%d", time.Now().UnixNano())
+				nc.SetAnnotations(annotations)
+				_, err = dynClient.Resource(utils.NodeClaimGVR).Update(ctx, nc, metav1.UpdateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Allow reconcile to process.
+				time.Sleep(10 * time.Second)
+
+				By("verifying no duplicate fake Nodes were created")
+				afterNodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{
+					LabelSelector: "kaito.sh/fake-node=true,kaito.sh/managed-by=gpu-mocker",
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(afterNodes.Items)).To(Equal(baselineNodeCount),
+					"re-applying NodeClaim should not create duplicate fake nodes (before=%d, after=%d)",
+					baselineNodeCount, len(afterNodes.Items))
+
+				By("verifying no duplicate Leases were created")
+				afterLeases, err := clientset.CoordinationV1().Leases("kube-node-lease").List(ctx, metav1.ListOptions{})
+				Expect(err).NotTo(HaveOccurred())
+				afterFakeNodeNames := make(map[string]bool)
+				for _, n := range afterNodes.Items {
+					afterFakeNodeNames[n.Name] = true
+				}
+				var afterLeaseCount int
+				for _, l := range afterLeases.Items {
+					if afterFakeNodeNames[l.Name] {
+						afterLeaseCount++
+					}
+				}
+				Expect(afterLeaseCount).To(Equal(baselineLeaseCount),
+					"re-applying NodeClaim should not create duplicate leases (before=%d, after=%d)",
+					baselineLeaseCount, afterLeaseCount)
+			})
+		})
+
 		Context("Shadow pod GC", func() {
 			It("should delete shadow pods via native Kubernetes GC when the original pod is removed", func() {
 				clientset, err := utils.GetK8sClientset()
@@ -434,7 +527,14 @@ var _ = Describe("GPU Mocker E2E", Ordered, func() {
 				oldShadowUID := shadow.UID
 
 				By(fmt.Sprintf("deleting original pod %s/%s (owner of shadow %q)", ownerPodNS, ownerPodName, shadow.Name))
-				err = clientset.CoreV1().Pods(ownerPodNS).Delete(ctx, ownerPodName, metav1.DeleteOptions{})
+				// Force-delete: the original pod lives on a fake node with no
+				// kubelet, so a graceful delete would leave it stuck in
+				// Terminating indefinitely (no kubelet to confirm shutdown).
+				// The GC only cascades once the owner is fully removed from
+				// the API server, so we must use GracePeriodSeconds=0.
+				err = clientset.CoreV1().Pods(ownerPodNS).Delete(ctx, ownerPodName, metav1.DeleteOptions{
+					GracePeriodSeconds: new(int64),
+				})
 				Expect(err).NotTo(HaveOccurred())
 
 				By("waiting for Kubernetes GC to delete the orphaned shadow pod")

--- a/test/e2e/model_routing_test.go
+++ b/test/e2e/model_routing_test.go
@@ -290,12 +290,6 @@ var _ = Describe("Model-Based Routing", Ordered, utils.GinkgoLabelRouting, func(
 		const numRequests = 5
 
 		It("should show EPP scheduler success counts matching requests sent", func() {
-			// TODO: EPP pods have Istio sidecars that intercept traffic on port 9090,
-			// causing 401 Unauthorized when accessing via K8s API pod proxy.
-			// Re-enable once EPP metrics port is excluded from Istio interception
-			// (e.g., via traffic.sidecar.istio.io/excludeInboundPorts annotation)
-			// or when we switch to scraping via the EPP Service instead of pod proxy.
-			Skip("EPP metrics port is intercepted by Istio sidecar (401 Unauthorized via pod proxy)")
 			clientset, err := utils.GetK8sClientset()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -629,6 +623,13 @@ var _ = Describe("Model-Based Routing", Ordered, utils.GinkgoLabelRouting, func(
 			successDiff := utils.DiffSnapshots(beforeSuccess, afterSuccess)
 			Expect(utils.TotalDelta(successDiff)).To(BeNumerically("==", 0),
 				"vllm:request_success_total should not increment for a rejected request")
+
+			By("verifying EPP scheduler success count incremented (request was routed, backend rejected it)")
+			afterSchedulerSuccess, err := utils.ScrapeEPPMetric(ctx, clientset, model, caseNamespace,
+				"inference_extension_scheduler_attempts_total", map[string]string{"status": "success"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(afterSchedulerSuccess).To(BeNumerically(">", 0),
+				"inference_extension_scheduler_attempts_total{status=success} should increment — EPP scheduled the request, backend rejected it")
 
 			// Verify subsequent valid requests still succeed — the rejection
 			// did not wedge the connection or the ext_proc filter chain.

--- a/test/e2e/prefix_cache_routing_test.go
+++ b/test/e2e/prefix_cache_routing_test.go
@@ -133,8 +133,26 @@ var _ = Describe("Prefix Cache Aware Routing", Ordered, utils.GinkgoLabelPrefixC
 				"vllm:prefix_cache_queries should increment on the sticky pod")
 			// prefix_cache_hits may stay 0 if the simulator doesn't implement
 			// real prefix caching (mode=random). Log for visibility.
-			if cacheHitsDiff[stickyPod] == 0 {
+			simulatorHasPrefixCache := cacheHitsDiff[stickyPod] > 0
+			if !simulatorHasPrefixCache {
 				GinkgoWriter.Printf("[INFO] vllm:prefix_cache_hits is 0 on %s \u2014 simulator may not implement real prefix caching\n", stickyPod)
+			}
+
+			By("verifying EPP prefix indexer metrics show non-trivial prefix matching")
+			hitRatio, err := utils.ScrapeEPPMetric(ctx, clientset, model, caseNamespace,
+				"inference_extension_prefix_indexer_hit_ratio", nil)
+			Expect(err).NotTo(HaveOccurred())
+			hitBytes, err := utils.ScrapeEPPMetric(ctx, clientset, model, caseNamespace,
+				"inference_extension_prefix_indexer_hit_bytes", nil)
+			Expect(err).NotTo(HaveOccurred())
+
+			if simulatorHasPrefixCache {
+				Expect(hitRatio).To(BeNumerically(">", 0),
+					"inference_extension_prefix_indexer_hit_ratio should be > 0 after repeated identical prompts")
+				Expect(hitBytes).To(BeNumerically(">", 0),
+					"inference_extension_prefix_indexer_hit_bytes should be > 0 after repeated identical prompts")
+			} else {
+				GinkgoWriter.Printf("[INFO] EPP prefix indexer hit_ratio=%.4f hit_bytes=%.0f \u2014 skipping strict assertion (simulator lacks real prefix caching)\n", hitRatio, hitBytes)
 			}
 		})
 	})
@@ -214,6 +232,15 @@ var _ = Describe("Prefix Cache Aware Routing", Ordered, utils.GinkgoLabelPrefixC
 			if cacheHitsDiff[podA] == 0 || cacheHitsDiff[podB] == 0 {
 				GinkgoWriter.Printf("[INFO] vllm:prefix_cache_hits is 0 \u2014 simulator may not implement real prefix caching\n")
 			}
+
+			By("verifying per-pod request counts match per-category expectations")
+			// diffA/diffB are vllm:request_success_total deltas, which serve
+			// as a proxy for prefix_cache_queries routing verification: each
+			// sticky pod must have received exactly the per-category count.
+			Expect(diffA[podA]).To(BeNumerically("==", float64(numPerCategory)),
+				"category A sticky pod %s should have received exactly %d requests", podA, numPerCategory)
+			Expect(diffB[podB]).To(BeNumerically("==", float64(numPerCategory)),
+				"category B sticky pod %s should have received exactly %d requests", podB, numPerCategory)
 		})
 	})
 
@@ -298,6 +325,19 @@ var _ = Describe("Prefix Cache Aware Routing", Ordered, utils.GinkgoLabelPrefixC
 			Expect(servingPod).NotTo(BeEmpty(), "a pod should have served the request")
 			Expect(servingPod).NotTo(Equal(stickyPod),
 				"request should have been served by a different pod after deletion")
+
+			By("verifying EPP scheduler success count incremented and failure count did not")
+			afterSchedSuccess, err := utils.ScrapeEPPMetric(ctx, clientset, model, caseNamespace,
+				"inference_extension_scheduler_attempts_total", map[string]string{"status": "success"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(afterSchedSuccess).To(BeNumerically(">", 0),
+				"inference_extension_scheduler_attempts_total{status=success} should be > 0 after re-routing")
+
+			afterSchedFailure, err := utils.ScrapeEPPMetric(ctx, clientset, model, caseNamespace,
+				"inference_extension_scheduler_attempts_total", map[string]string{"status": "failure"})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(afterSchedFailure).To(BeNumerically("==", 0),
+				"inference_extension_scheduler_attempts_total{status=failure} should not increment after graceful re-route")
 		})
 	})
 })


### PR DESCRIPTION
**Reason for Change**:
Exclude EPP metrics port from Istio sidecar interception.

Add `traffic.sidecar.istio.io/excludeInboundPorts` annotation to the EPP
pod template so the Istio sidecar does not intercept inbound traffic on
the metrics port (9090). Without this, scraping EPP /metrics via the K8s
API server pod-proxy returns 401 Unauthorized because the proxy strips
the mTLS client certificate that the sidecar expects.

With the annotation in place, remove the Skip() guard from the EPP
routing success metrics test and add the following EPP metric assertions
that were previously blocked:

- model_routing: verify inference_extension_scheduler_attempts_total
  after prompt-exceeds-max-context-length (proves EPP scheduled the
  request even though the backend rejected it)
- prefix_cache: verify inference_extension_prefix_indexer_hit_ratio and
  hit_bytes after repeated identical prompts (conditional on simulator
  prefix cache support)
- prefix_cache: verify inference_extension_scheduler_attempts_total
  success/failure after pod deletion fallback

Also add two missing infra tests to gpu_mocker_test.go:

- NodeClaim reconcile idempotency: re-apply an existing NodeClaim and
  verify no duplicate fake Nodes or Leases are created
- Different categories strict count: verify per-pod request counts
  match exact per-category expectations in prefix cache routing

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
