### PR TITLE
Refactor E2E install around the productionstack umbrella chart

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,13 +183,15 @@ e2e-validate: ## Validate all E2E components are healthy.
 e2e-dump: ## Dump cluster state for debugging.
 	hack/e2e/scripts/dump-cluster-state.sh
 
+USER_ID ?= $(shell whoami)
+# Honor pre-set CLUSTER_NAME / RESOURCE_GROUP env vars (e.g. from CI) so they
+# are not silently overwritten with the local-developer default of kaito-$(USER_ID).
+E2E_CLUSTER_NAME ?= $(if $(CLUSTER_NAME),$(CLUSTER_NAME),kaito-$(USER_ID))
+E2E_RESOURCE_GROUP ?= $(if $(RESOURCE_GROUP),$(RESOURCE_GROUP),kaito-$(USER_ID))
+
 .PHONY: e2e-teardown
 e2e-teardown: ## Tear down the E2E cluster.
-	hack/e2e/scripts/run-e2e-local.sh teardown
-
-USER_ID ?= $(shell whoami)
-E2E_CLUSTER_NAME ?= kaito-$(USER_ID)
-E2E_RESOURCE_GROUP ?= kaito-$(USER_ID)
+	CLUSTER_NAME=$(E2E_CLUSTER_NAME) RESOURCE_GROUP=$(E2E_RESOURCE_GROUP) hack/e2e/scripts/run-e2e-local.sh teardown
 
 .PHONY: e2e-up
 e2e-up: ## One command to set up full local E2E env (cluster, build, push, install, validate).

--- a/README.md
+++ b/README.md
@@ -51,9 +51,20 @@ namespaces and are shared by every model deployment:
 | Gateway API CRDs                     | _cluster-scoped_ | `GATEWAY_API_VERSION` (v1.2.0)          | kubectl        | Required for `Gateway`, `HTTPRoute`, `ReferenceGrant`.                                |
 | Istio control plane (`istiod`)       | `istio-system`   | `ISTIO_VERSION` (1.29.2)                | istioctl       | Implements the Gateway dataplane (Envoy) and ext_proc filter chain.                   |
 | GAIE CRDs                            | _cluster-scoped_ | latest                                  | kubectl        | `InferencePool`, `InferenceObjective`.                                                |
-| BBR (Body-Based Router)              | `istio-system`   | `BBR_VERSION` (v1.3.1)                  | helm           | Installed in Istio's rootNamespace so its EnvoyFilter applies cluster-wide; injects `X-Gateway-Model-Name`. |
-| `llm-gateway-auth` ([`kaito-project/llm-gateway-auth`](https://github.com/kaito-project/llm-gateway-auth)) | `llm-gateway-auth` | `LLM_GATEWAY_AUTH_VERSION` (0.0.7-alpha) | helm           | API-key ext_authz for the `inference-gateway`. Installs the `APIKey` CRD, the `apikey-operator` (reconciles `APIKey` → per-namespace Secret), and the `apikey-authz` ext_authz dataplane wired into Istio via `MeshConfig` + `AuthorizationPolicy`. |
-| KEDA + KEDA Kaito Scaler ([`kaito-project/keda-kaito-scaler`](https://github.com/kaito-project/keda-kaito-scaler), optional)  | `keda` (or `kube-system` when `E2E_PROVIDER=azure`) | `KEDA_VERSION` (v2.19.0), `KEDA_KAITO_SCALER_VERSION` (v0.5.1) | helm | Workload-metric autoscaling. With `E2E_PROVIDER=azure`, KEDA is provided by the AKS managed add-on in `kube-system` and the keda-kaito-scaler chart is installed alongside it. |
+| KEDA                                 | `keda` (upstream) / `kube-system` (azure) | `KEDA_VERSION` (v2.19.0) | helm (upstream) / AKS managed add-on (azure) | Workload-metric autoscaling control plane.                                            |
+| `productionstack` umbrella chart ([`charts/productionstack`](charts/productionstack)) | release in `kaito-system`; subcharts pinned per-namespace via `namespaceOverride` | in-tree (`charts/productionstack`) | helm | Single Helm release that bundles every cluster-level helper. Currently ships **two** subcharts: `body-based-routing` → `istio-system` (BBR ext_proc + cluster-wide `EnvoyFilter` injecting `X-Gateway-Model-Name`) and `keda-kaito-scaler` → KEDA's namespace (vLLM / `InferenceSet` metric aggregator for KEDA-driven autoscaling). |
+| `llm-gateway-auth` ([`kaito-project/llm-gateway-auth`](https://github.com/kaito-project/llm-gateway-auth)) | `llm-gateway-auth` | `LLM_GATEWAY_AUTH_VERSION` | helm           | API-key ext_authz for the `inference-gateway`. Installs the `APIKey` CRD, the `apikey-operator` (reconciles `APIKey` → per-namespace Secret), and the `apikey-authz` ext_authz dataplane wired into Istio via `MeshConfig` + `AuthorizationPolicy`. |
+
+The `productionstack` umbrella chart consolidates the BBR and KEDA-Kaito-Scaler installs into a **single `helm install`**. The E2E suite installs it via [`hack/e2e/scripts/install-components.sh`](hack/e2e/scripts/install-components.sh) with the following overrides:
+
+```sh
+helm upgrade --install productionstack charts/productionstack \
+  --namespace kaito-system --create-namespace \
+  --set body-based-routing.namespaceOverride=istio-system \
+  --set keda-kaito-scaler.namespaceOverride="${KEDA_NAMESPACE}"
+```
+
+Each subchart can be independently disabled via `<subchart>.enabled=false` (see [`charts/productionstack/README.md`](charts/productionstack/README.md) for the full value reference). Additional cluster-level components will be folded into this umbrella over time.
 
 ### Step 2. modelharness (one-time per workload namespace)
 

--- a/charts/modeldeployment/templates/httproute.yaml
+++ b/charts/modeldeployment/templates/httproute.yaml
@@ -12,9 +12,22 @@ spec:
       name: {{ include "modeldeployment.gatewayName" . | quote }}
   rules:
     - matches:
+        # Two match entries are OR'd by the Gateway API spec: a request is
+        # routed to this deployment if EITHER the BBR-injected routed-model
+        # header (X-Gateway-Model-Name) OR the base-model header
+        # (X-Gateway-Base-Model-Name, used for adapter / LoRA requests where
+        # the client-visible model differs from the underlying base) matches
+        # this deployment's name.
         - headers:
             - type: Exact
               name: X-Gateway-Model-Name
+              value: {{ include "modeldeployment.name" . | quote }}
+          path:
+            type: PathPrefix
+            value: /
+        - headers:
+            - type: Exact
+              name: X-Gateway-Base-Model-Name
               value: {{ include "modeldeployment.name" . | quote }}
           path:
             type: PathPrefix

--- a/charts/modeldeployment/values.yaml
+++ b/charts/modeldeployment/values.yaml
@@ -25,7 +25,7 @@ instanceType: "Standard_NV36ads_A10_v5"
 
 # replicas is the desired number of InferenceSet replicas. Also wired to the
 # scaledobject.kaito.sh/min-replicas annotation.
-replicas: 2
+replicas: 1
 
 # enableScaling toggles KAITO ScaledObject auto-provisioning. When false,
 # none of the scaledobject.kaito.sh/* annotations are rendered on the
@@ -35,7 +35,7 @@ enableScaling: false
 # maxReplicas is the upper bound for autoscaling. Only used when
 # enableScaling is true. Wired to the scaledobject.kaito.sh/max-replicas
 # annotation.
-maxReplicas: 5
+maxReplicas: 3
 
 # scalingThreshold is the queue depth threshold used by the ScaledObject.
 # Only used when enableScaling is true. Wired to the

--- a/charts/modelharness/templates/envoyfilter-not-found.yaml
+++ b/charts/modelharness/templates/envoyfilter-not-found.yaml
@@ -20,7 +20,8 @@ Why a catch-all is REQUIRED (and not just a UX nicety):
   of model name. Removing this template re-opens that bypass.
 
 The patch is anchored to BBR's filter name as a `subFilter` so it
-attaches to the same HCM that `install_bbr` injects BBR into. The
+attaches to the same HCM that the productionstack umbrella chart's
+`body-based-routing` subchart injects BBR into. The
 `workloadSelector` scopes it to this namespace's Gateway pod only.
 */}}
 apiVersion: networking.istio.io/v1alpha3

--- a/charts/productionstack/.helmignore
+++ b/charts/productionstack/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/productionstack/Chart.yaml
+++ b/charts/productionstack/Chart.yaml
@@ -1,0 +1,49 @@
+apiVersion: v2
+name: productionstack
+description: |
+  Umbrella Helm chart that installs all CLUSTER-LEVEL components and CRDs
+  required by the Kaito production stack: body-based routing (BBR),
+  KEDA Kaito scaler, LLM gateway auth, and other shared infrastructure.
+
+  This chart is intended to be consumed as a dependency of the top-level
+  `kaito` Helm chart. Each component is shipped as a subchart under
+  `charts/` and can be enabled or disabled individually via the
+  `<component>.enabled` toggle in values.yaml. Component-specific values
+  are passed through by nesting them under the subchart's name, e.g.:
+
+      body-based-routing:
+        enabled: true
+        bbr:
+          replicas: 2
+
+  Adding a new cluster-level component is a matter of dropping its chart
+  under `charts/` and appending a new entry to the `dependencies` list
+  below (with a matching `<name>.enabled` toggle in values.yaml).
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+keywords:
+  - kaito
+  - production-stack
+  - inference
+  - gateway-api-inference-extension
+  - keda
+home: https://github.com/kaito-project/production-stack
+sources:
+  - https://github.com/kaito-project/production-stack
+maintainers:
+  - name: kaito-project
+    url: https://github.com/kaito-project
+
+dependencies:
+  - name: body-based-routing
+    version: 0.1.0
+    condition: body-based-routing.enabled
+    tags:
+      - gateway
+      - routing
+  - name: keda-kaito-scaler
+    version: 0.5.1
+    condition: keda-kaito-scaler.enabled
+    tags:
+      - autoscaling

--- a/charts/productionstack/README.md
+++ b/charts/productionstack/README.md
@@ -1,0 +1,171 @@
+# productionstack
+
+Umbrella Helm chart that installs all **cluster-level** components and
+CRDs required by the [Kaito](https://github.com/kaito-project/kaito)
+production stack. It is designed to be consumed as a Helm
+**dependency** of the top-level `kaito` chart so a single
+`helm install kaito ...` pulls in every shared piece of infrastructure
+the inference data plane relies on.
+
+## Bundled components
+
+| Subchart             | Purpose                                                                                                  | Toggle                              | Default install namespace |
+|----------------------|----------------------------------------------------------------------------------------------------------|-------------------------------------|---------------------------|
+| `body-based-routing` | Cluster-wide singleton Body-Based Router (BBR) ext_proc service + Istio `EnvoyFilter` wiring it into every inference Gateway. | `body-based-routing.enabled` (default `true`) | `istio-system` |
+| `keda-kaito-scaler`  | KEDA external scaler that aggregates vLLM / `InferenceSet` metrics for workload-aware autoscaling.       | `keda-kaito-scaler.enabled` (default `true`)  | `keda` |
+
+Each subchart exposes a `namespaceOverride` value that pins **all of
+its namespaced resources** to a specific namespace, independent of the
+Helm release namespace passed via `--namespace`. The defaults above
+are baked into [values.yaml](./values.yaml); see
+[Per-subchart install namespace](#per-subchart-install-namespace) for
+details.
+
+Additional cluster-level components (e.g. `llm-gateway-auth`) will be
+added as new subcharts under [`charts/`](./charts/) with a matching
+`<name>.enabled` toggle.
+
+## Layout
+
+```
+charts/productionstack/
+├── Chart.yaml                 # umbrella chart metadata + dependencies
+├── values.yaml                # top-level toggles + subchart value pass-through
+├── templates/
+│   └── NOTES.txt              # post-install summary (no resources of its own)
+└── charts/
+    ├── body-based-routing/    # BBR ext_proc + Istio EnvoyFilter
+    └── keda-kaito-scaler/     # KEDA external scaler
+```
+
+The umbrella chart itself ships **no Kubernetes resources** — every
+manifest is rendered by a subchart. This keeps the umbrella thin and
+avoids accidental coupling between components.
+
+## Install standalone
+
+```sh
+# istio-system and keda must already exist (Helm only auto-creates the
+# release namespace).
+kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+kubectl create namespace keda          --dry-run=client -o yaml | kubectl apply -f -
+
+helm dependency update charts/productionstack
+helm upgrade --install productionstack charts/productionstack \
+  --namespace kaito-system \
+  --create-namespace \
+  --wait
+```
+
+With the default values BBR lands in `istio-system` and the KEDA
+scaler in `keda`, regardless of the `--namespace` value above; only
+the Helm release metadata Secret lives in the release namespace.
+
+## Per-subchart install namespace
+
+Helm itself only accepts a single `--namespace` per release. To
+install each subchart into its **own** namespace inside a single
+`helm install`, every subchart in this umbrella exposes a
+`namespaceOverride` value. When set, all of that subchart's
+**namespaced** resources are rendered into the override namespace
+instead of the release namespace; cluster-scoped resources
+(`ClusterRole`, `ClusterRoleBinding`) are unaffected.
+
+```yaml
+# my-values.yaml
+body-based-routing:
+  namespaceOverride: istio-system     # required: BBR EnvoyFilter must live here
+keda-kaito-scaler:
+  namespaceOverride: keda
+```
+
+Caveats:
+
+1. Target namespaces **must already exist**. `helm install
+   --create-namespace` only creates the release namespace, not the
+   override targets.
+2. The Helm release metadata Secret is stored in the release
+   namespace, but `helm uninstall` still cleans up resources in every
+   override namespace because Helm tracks the rendered manifest.
+3. Set `namespaceOverride: ""` to opt out and inherit the release
+   namespace (standard Helm behavior).
+
+## Install only a subset of components
+
+Disable any subchart by setting its `enabled` toggle to `false`:
+
+```sh
+helm upgrade --install productionstack charts/productionstack \
+  --namespace istio-system \
+  --set body-based-routing.enabled=true \
+  --set keda-kaito-scaler.enabled=false
+```
+
+## Override subchart values
+
+Nest the override under the subchart's name (which matches the
+subchart's `Chart.yaml` `name:` field). For example, to run two BBR
+replicas and bump the keda-kaito-scaler log level:
+
+```yaml
+# my-values.yaml
+body-based-routing:
+  enabled: true
+  bbr:
+    replicas: 2
+
+keda-kaito-scaler:
+  enabled: true
+  log:
+    level: 3
+```
+
+```sh
+helm upgrade --install productionstack charts/productionstack \
+  --namespace istio-system \
+  -f my-values.yaml
+```
+
+See each subchart's own README / values.yaml for the full set of
+supported keys:
+
+- [`charts/body-based-routing/README.md`](./charts/body-based-routing/README.md)
+- [`charts/keda-kaito-scaler/values.yaml`](./charts/keda-kaito-scaler/values.yaml)
+
+## Consume as a dependency of the kaito chart
+
+Add an entry to the parent chart's `Chart.yaml`:
+
+```yaml
+# charts/kaito/Chart.yaml
+dependencies:
+  - name: productionstack
+    version: 0.1.0
+    repository: "file://../productionstack"   # or an OCI / HTTP repo URL
+    condition: productionstack.enabled
+```
+
+Then forward overrides in the parent's `values.yaml`:
+
+```yaml
+# charts/kaito/values.yaml
+productionstack:
+  enabled: true
+  body-based-routing:
+    enabled: true
+  keda-kaito-scaler:
+    enabled: true
+```
+
+Run `helm dependency update charts/kaito` to vendor this chart into
+the parent's `charts/` directory.
+
+## Adding a new cluster-level component
+
+1. Drop the component's chart directory under
+   [`charts/`](./charts/) (e.g. `charts/llm-gateway-auth/`).
+2. Append a new entry to `dependencies:` in [`Chart.yaml`](./Chart.yaml)
+   with `condition: <name>.enabled`.
+3. Add a `<name>.enabled` toggle (and any documented overrides) to
+   [`values.yaml`](./values.yaml).
+4. Mention it in the table above and in `templates/NOTES.txt`.

--- a/charts/productionstack/charts/body-based-routing/.helmignore
+++ b/charts/productionstack/charts/body-based-routing/.helmignore
@@ -1,0 +1,18 @@
+# Patterns to ignore when building Helm packages.
+.DS_Store
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/productionstack/charts/body-based-routing/Chart.yaml
+++ b/charts/productionstack/charts/body-based-routing/Chart.yaml
@@ -1,0 +1,12 @@
+apiVersion: v2
+name: body-based-routing
+description: |
+  Cluster-wide Body-Based Router (BBR) for the Gateway API Inference
+  Extension. BBR runs as a single shared ext_proc service that every
+  Istio-managed inference Gateway in the cluster consults to extract
+  the OpenAI-style `model` field from the request body and surface it
+  as the `X-Gateway-Model-Name` HTTP header so per-model HTTPRoutes
+  can match.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"

--- a/charts/productionstack/charts/body-based-routing/README.md
+++ b/charts/productionstack/charts/body-based-routing/README.md
@@ -1,0 +1,120 @@
+# body-based-routing
+
+Helm chart that installs a **cluster-wide singleton** Body-Based Router
+(BBR) for the Gateway API Inference Extension. BBR runs as a single
+shared `ext_proc` service in `istio-system`; every Istio-managed
+inference Gateway in the cluster — including per-namespace Gateways
+provisioned by the `modelharness` chart — consults it via a single
+`EnvoyFilter` to extract the OpenAI-style `model` field from the
+request body and surface it as the `X-Gateway-Model-Name` HTTP header.
+
+This chart is shipped as a **subchart of the umbrella
+[`productionstack`](../../README.md) chart** and is meant to be
+installed either via the umbrella (preferred for production stacks)
+or directly for ad-hoc / development use. As a subchart it is
+automatically toggleable via `body-based-routing.enabled` and pinned
+to `istio-system` via `body-based-routing.namespaceOverride` in the
+parent values.
+
+The chart itself is forked from
+[`sigs.k8s.io/gateway-api-inference-extension/config/charts/body-based-routing`](https://github.com/kubernetes-sigs/gateway-api-inference-extension/tree/main/config/charts/body-based-routing).
+The diffs vs upstream are deliberate, documented in the template
+comments, and recapped here:
+
+| Change | Why |
+|---|---|
+| `provider.name` default flipped from `none` → `istio` | This repo only ships the Istio data plane today, so the EnvoyFilter is always wanted out of the box. |
+| `EnvoyFilter` has **no** `spec.targetRefs` and the `inferenceGateway.name` value is removed | Upstream pins the filter to a single Gateway named `inference-gateway` in the EnvoyFilter's own namespace (`targetRefs` is namespace-local in Istio). This fork needs the filter to fan out to every per-namespace Gateway provisioned across the cluster, so `targetRefs` is omitted and selection happens via `match.context: GATEWAY` alone. |
+| Default `provider.istio.envoyFilter.operation` flipped from `INSERT_FIRST` to `INSERT_BEFORE`, anchored on `envoy.filters.http.router` | Enforces the gateway HTTP filter-chain order required by this repo: `ext_authz (if any) → bbr → router (HTTPRoute → epp / model-not-found)`. The terminal `router` filter is always present, so this anchor works on both auth-enabled and auth-disabled gateways (anchoring on `ext_authz` would silently no-op on auth-disabled gateways). |
+| New `bbr.secureServing` toggle (default `false`) | Upstream always serves over a self-signed cert and always renders a `DestinationRule` with `tls.mode=SIMPLE, insecureSkipVerify=true`. We default to plaintext HTTP/2 to avoid the per-request self-signed-cert TLS handshake; the request never leaves the pod network and Istio mTLS is sufficient defense in depth. The `--secure-serving=<bool>` flag is rendered automatically from this value and MUST NOT be duplicated in `bbr.flags`. |
+| `DestinationRule` is only rendered when `bbr.secureServing=true` | When BBR runs plaintext HTTP/2 no upstream TLS config is needed; the unconditional upstream DestinationRule becomes dead config. |
+| `bbr.multiNamespace` value removed; RBAC is **always** cluster-wide | Upstream defaults `multiNamespace: false` and renders a namespace-scoped `Role`/`RoleBinding`, which would leave BBR blind to the LoRA-adapter → base-model ConfigMaps living in workload namespaces and silently break adapter-aware routing. This fork ships a single `ClusterRole` + `ClusterRoleBinding` unconditionally. |
+| New `namespaceOverride` value | Lets the umbrella `productionstack` chart install BBR into `istio-system` even when the parent Helm release lives in a different namespace (Helm itself supports only one `--namespace` per release). Empty string falls back to the release namespace. |
+| GKE provider template dropped | Upstream offers a `provider.name=gke` rendering path; this repo only ships the Istio data plane today. Reintroduce when a GKE-backed E2E lane lands. |
+| Image tag pinned (`v1.5.0`) instead of upstream `main` | Reproducible installs; `main` is a moving floating tag in the upstream staging registry. |
+| `app.kubernetes.io/*` labels added via `bbr.labels` / `bbr.selectorLabels` helpers; ConfigMap-reader `ClusterRole` name is release-scoped (`<bbr.name>-<release>-configmap-reader`) | Lets multiple unrelated releases coexist on the same cluster and makes `kubectl ... -l app.kubernetes.io/name=body-based-routing` work for ops. |
+
+## Install via the umbrella chart (recommended)
+
+When consumed through [`productionstack`](../../README.md) the umbrella
+chart already pins this subchart to `istio-system`, so a single
+`helm install` of the parent is enough:
+
+```sh
+# istio-system must already exist (Helm only auto-creates the release namespace)
+kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+
+helm upgrade --install productionstack charts/productionstack \
+  --namespace kaito-system --create-namespace --wait
+```
+
+Override BBR-specific values by nesting them under `body-based-routing:`
+in the parent values (see [`charts/productionstack/values.yaml`](../../values.yaml)).
+
+## Install standalone (ad-hoc / dev)
+
+The chart MUST be installed into Istio's root namespace
+(`istio-system`) so the rendered cluster-wide EnvoyFilter is visible
+to all gateways:
+
+```sh
+helm upgrade --install body-based-router \
+  charts/productionstack/charts/body-based-routing \
+  --namespace istio-system \
+  --create-namespace \
+  --wait
+```
+
+Override the filter anchor when a different placement is required:
+
+```sh
+helm upgrade --install body-based-router \
+  charts/productionstack/charts/body-based-routing \
+  --namespace istio-system \
+  --set provider.istio.envoyFilter.operation=INSERT_FIRST \
+  --set provider.istio.envoyFilter.anchorSubFilter="" \
+  --wait
+```
+
+## Filter chain order (with auth enabled)
+
+```
+┌──────────┐   ┌─────┐   ┌────────────────────────────────────────────────────┐
+│ ext_authz│──▶│ bbr │──▶│ router  ─┬─ HTTPRoute(model=X) ─▶ EPP ─▶ vLLM pod │
+└──────────┘   └─────┘   │          └─ catch-all ─▶ direct_response 404      │
+                         └────────────────────────────────────────────────────┘
+```
+
+* `ext_authz` runs first so unauthenticated requests are rejected
+  before BBR ever sees the body — no wasted parse work, no chance of
+  leaking the `model` field through telemetry.
+* `bbr` parses the JSON body once per request and writes
+  `X-Gateway-Model-Name`.
+* The router uses that header to match a per-deployment HTTPRoute
+  (which forwards to the InferencePool / EPP) or falls through to the
+  catch-all 404 EnvoyFilter rendered by the `modelharness` chart.
+
+## Configuration
+
+| Parameter                                        | Default                                                                       | Description                                                                                                                    |
+|--------------------------------------------------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
+| `namespaceOverride`                              | `""`                                                                          | Pin every namespaced resource (+ EnvoyFilter upstream FQDN) to this namespace. Empty ⇒ inherit the Helm release namespace. Used by the umbrella chart to force `istio-system`. |
+| `bbr.name`                                       | `body-based-router`                                                           | Name of the Deployment / Service.                                                                                              |
+| `bbr.replicas`                                   | `1`                                                                           | Replica count. BBR is stateless; bump for HA.                                                                                  |
+| `bbr.image.{registry,repository,tag,pullPolicy}` | upstream staging registry, tag `v1.5.0`                                       | Container image coordinates. Pinned tag (upstream defaults to `main`).                                                          |
+| `bbr.port`                                       | `9004`                                                                        | ext_proc gRPC port.                                                                                                            |
+| `bbr.healthCheckPort`                            | `9005`                                                                        | gRPC health-check port.                                                                                                        |
+| `bbr.secureServing`                              | `false`                                                                       | When `true` BBR serves over a self-signed cert and a DestinationRule with `insecureSkipVerify=true` is rendered. The `--secure-serving=<bool>` cmd-line flag is auto-generated from this value. |
+| `bbr.flags`                                      | `{ v: 3 }`                                                                    | Extra `--key=value` cmd-line flags. `secure-serving` is rendered separately and MUST NOT be set here.                          |
+| `bbr.plugins`                                    | upstream defaults                                                             | Plugin pipeline. Empty list ⇒ runner auto-loads its built-in defaults.                                                          |
+| `bbr.tracing.*`                                  | disabled                                                                      | OpenTelemetry exporter configuration.                                                                                          |
+| `provider.name`                                  | `istio`                                                                       | `istio` ⇒ render the EnvoyFilter; `none` ⇒ Deployment + Service + RBAC only. (Upstream defaults to `none`.)                    |
+| `provider.supportedEvents.*`                     | all `true`                                                                    | HTTP lifecycle events Envoy forwards to BBR.                                                                                   |
+| `provider.istio.envoyFilter.operation`           | `INSERT_BEFORE`                                                               | Envoy filter-chain placement op. (Upstream defaults to `INSERT_FIRST`.)                                                         |
+| `provider.istio.envoyFilter.anchorSubFilter`     | `envoy.filters.http.router`                                                   | Anchor filter name for INSERT_BEFORE / INSERT_AFTER. The terminal `router` filter is always present on every Istio Gateway HCM chain, so this default works on both auth-enabled and auth-disabled gateways. (Upstream defaults to `""`.) |
+
+## Uninstall
+
+```sh
+helm uninstall body-based-router --namespace istio-system
+```

--- a/charts/productionstack/charts/body-based-routing/templates/NOTES.txt
+++ b/charts/productionstack/charts/body-based-routing/templates/NOTES.txt
@@ -1,0 +1,15 @@
+Body-Based Router (BBR) installed cluster-wide.
+
+  Release          : {{ .Release.Name }}
+  Namespace        : {{ .Release.Namespace }}
+  Service          : {{ .Values.bbr.name }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.bbr.port }}
+  Provider         : {{ .Values.provider.name }}
+  Secure serving   : {{ .Values.bbr.secureServing }}
+{{- if eq .Values.provider.name "istio" }}
+  Filter operation : {{ .Values.provider.istio.envoyFilter.operation }}{{ if .Values.provider.istio.envoyFilter.anchorSubFilter }} (anchor: {{ .Values.provider.istio.envoyFilter.anchorSubFilter }}){{ end }}
+
+  The rendered EnvoyFilter has NO targetRefs and is scoped to
+  `match.context: GATEWAY`, so it attaches to every Istio-managed
+  Gateway in the mesh. Per-namespace Gateways therefore see BBR
+  automatically — no extra wiring needed per workload namespace.
+{{- end }}

--- a/charts/productionstack/charts/body-based-routing/templates/_helpers.tpl
+++ b/charts/productionstack/charts/body-based-routing/templates/_helpers.tpl
@@ -1,0 +1,48 @@
+{{/*
+Common labels stamped on every chart-rendered object so cluster
+operators can list / select all BBR resources with a single label
+selector (e.g. `kubectl -n istio-system get all -l app.kubernetes.io/name=body-based-routing`).
+*/}}
+{{- define "bbr.labels" -}}
+app.kubernetes.io/name: body-based-routing
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+
+{{/*
+Selector labels — the subset of `bbr.labels` that is stable across
+rolling upgrades (so the Deployment/Service selectors are not
+invalidated when the chart version bumps).
+*/}}
+{{- define "bbr.selectorLabels" -}}
+app: {{ .Values.bbr.name }}
+app.kubernetes.io/name: body-based-routing
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+ServiceAccount name. Suffixed with the Helm release name so multiple
+copies of the chart cannot collide on a single SA in the same
+namespace (defense in depth — the chart itself is intended to be
+installed at most once per cluster, but this keeps `helm install`
+idempotent across release-name changes during development).
+*/}}
+{{- define "bbr.serviceAccountName" -}}
+{{ .Values.bbr.name }}-{{ .Release.Name }}
+{{- end }}
+
+{{/*
+Install namespace for every namespaced resource rendered by this chart.
+
+Defaults to the Helm release namespace, but can be overridden via
+`namespaceOverride` so the chart can be installed into a different
+namespace than the surrounding umbrella release (e.g. forced into
+`istio-system` when the parent chart is installed elsewhere). When
+overridden, the target namespace MUST already exist — `helm install
+--create-namespace` only creates the release namespace.
+*/}}
+{{- define "bbr.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end }}

--- a/charts/productionstack/charts/body-based-routing/templates/bbr.yaml
+++ b/charts/productionstack/charts/body-based-routing/templates/bbr.yaml
@@ -1,0 +1,97 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Values.bbr.name }}
+  namespace: {{ include "bbr.namespace" . }}
+  labels:
+    {{- include "bbr.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.bbr.replicas | default 1 }}
+  selector:
+    matchLabels:
+      {{- include "bbr.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "bbr.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ include "bbr.serviceAccountName" . }}
+      containers:
+        - name: bbr
+          image: "{{ .Values.bbr.image.registry }}/{{ .Values.bbr.image.repository }}:{{ .Values.bbr.image.tag }}"
+          imagePullPolicy: {{ .Values.bbr.image.pullPolicy }}
+          args:
+            - "--streaming"
+            # Render --secure-serving from the dedicated toggle (NOT the
+            # generic flags map below) so values.yaml has a single
+            # source of truth and we cannot accidentally render the
+            # flag twice.
+            - "--secure-serving={{ .Values.bbr.secureServing }}"
+            {{- range $key, $value := .Values.bbr.flags }}
+            - --{{ $key }}={{ $value }}
+            {{- end }}
+            {{- range .Values.bbr.plugins }}
+            - --plugin
+            {{- if .json }}
+            - {{ printf "%s:%s:%s" .type .name (toJson .json) | quote }}
+            {{- else }}
+            - {{ printf "%s:%s" .type .name | quote }}
+            {{- end }}
+            {{- end }}
+            {{- if .Values.bbr.tracing.enabled }}
+            - --tracing=true
+            {{- else }}
+            - --tracing=false
+            {{- end }}
+          env:
+            {{- if .Values.bbr.tracing.enabled }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Values.bbr.tracing.otelServiceName }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.bbr.tracing.otelExporterEndpoint }}
+            - name: OTEL_RESOURCE_ATTRIBUTES_NODE_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: spec.nodeName
+            - name: OTEL_RESOURCE_ATTRIBUTES_POD_NAME
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: metadata.name
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: 'k8s.namespace.name=$(NAMESPACE),k8s.node.name=$(OTEL_RESOURCE_ATTRIBUTES_NODE_NAME),k8s.pod.name=$(OTEL_RESOURCE_ATTRIBUTES_POD_NAME)'
+            - name: OTEL_TRACES_SAMPLER
+              value: {{ .Values.bbr.tracing.sampling.sampler | quote }}
+            - name: OTEL_TRACES_SAMPLER_ARG
+              value: {{ .Values.bbr.tracing.sampling.samplerArg | quote }}
+            - name: OTEL_TRACES_EXPORTER
+              value: otlp
+            {{- end }}
+          ports:
+            - name: grpc-ext-proc
+              containerPort: {{ .Values.bbr.port }}
+            - name: grpc-health
+              containerPort: {{ .Values.bbr.healthCheckPort }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.bbr.name }}
+  namespace: {{ include "bbr.namespace" . }}
+  labels:
+    {{- include "bbr.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  selector:
+    {{- include "bbr.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: grpc-ext-proc
+      protocol: TCP
+      port: {{ .Values.bbr.port }}
+      targetPort: {{ .Values.bbr.port }}
+      # HTTP2 (h2c) so Envoy's outbound cluster speaks plaintext
+      # gRPC. When `bbr.secureServing=true` this is still HTTP/2 — the
+      # only difference is the rendered DestinationRule below adds an
+      # upstream TLS context.
+      appProtocol: HTTP2

--- a/charts/productionstack/charts/body-based-routing/templates/istio.yaml
+++ b/charts/productionstack/charts/body-based-routing/templates/istio.yaml
@@ -1,0 +1,89 @@
+{{- if eq .Values.provider.name "istio" }}
+# ─────────────────────────────────────────────────────────────────────────────
+# Cluster-wide BBR EnvoyFilter.
+#
+# Notable differences vs the upstream chart in
+# sigs.k8s.io/gateway-api-inference-extension/config/charts/body-based-routing:
+#
+#   * NO `spec.targetRefs`. The upstream chart hard-codes a targetRefs
+#     pointing at a single Gateway named `inference-gateway` in the
+#     EnvoyFilter's own namespace. Istio's EnvoyFilter `targetRefs` is
+#     namespace-local (no `namespace` field), which would prevent this
+#     filter from attaching to per-namespace Gateways provisioned by
+#     each E2E case (e.g. `e2e-prefix-cache`, `e2e-auth`, …) and break
+#     model-name extraction across the cluster. By omitting targetRefs
+#     and pinning `match.context: GATEWAY`, this filter fans out to
+#     every Istio-managed Gateway pod in the mesh while leaving
+#     sidecars untouched.
+#
+#   * Default `operation: INSERT_BEFORE` anchored on the terminal
+#     `envoy.filters.http.router` filter (always present on every
+#     Istio-managed Gateway HCM chain), giving the order:
+#       ext_authz (if any)  →  bbr  →  router (HTTPRoute → epp / not-found)
+#     Anchoring on ext_authz instead would silently no-op on every
+#     auth-disabled gateway (no CUSTOM AuthorizationPolicy ⇒ no
+#     ext_authz filter ⇒ patch skipped). Override via
+#     `provider.istio.envoyFilter.{operation,anchorSubFilter}` when a
+#     different placement is required.
+#
+#   * When `bbr.secureServing=false` (the default in this fork) NO
+#     DestinationRule is rendered, so Envoy speaks plaintext HTTP/2 to
+#     BBR. A DestinationRule with `tls.mode=SIMPLE,
+#     insecureSkipVerify=true` is rendered only when secureServing is
+#     enabled.
+# ─────────────────────────────────────────────────────────────────────────────
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: {{ .Values.bbr.name }}
+  namespace: {{ include "bbr.namespace" . }}
+  labels:
+    {{- include "bbr.labels" . | nindent 4 }}
+spec:
+  configPatches:
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+              {{- if .Values.provider.istio.envoyFilter.anchorSubFilter }}
+              subFilter:
+                name: {{ .Values.provider.istio.envoyFilter.anchorSubFilter }}
+              {{- end }}
+      patch:
+        operation: {{ .Values.provider.istio.envoyFilter.operation }}
+        value:
+          name: envoy.filters.http.ext_proc.bbr
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.ext_proc.v3.ExternalProcessor
+            failure_mode_allow: false
+            allow_mode_override: true
+            processing_mode:
+              request_header_mode: {{ if .Values.provider.supportedEvents.requestHeaders }}"SEND"{{ else }}"SKIP"{{ end }}
+              response_header_mode: {{ if .Values.provider.supportedEvents.responseHeaders }}"SEND"{{ else }}"SKIP"{{ end }}
+              request_body_mode: {{ if .Values.provider.supportedEvents.requestBody }}"FULL_DUPLEX_STREAMED"{{ else }}"NONE"{{ end }}
+              response_body_mode: {{ if .Values.provider.supportedEvents.responseBody }}"FULL_DUPLEX_STREAMED"{{ else }}"NONE"{{ end }}
+              request_trailer_mode: {{ if .Values.provider.supportedEvents.requestTrailers }}"SEND"{{ else }}"SKIP"{{ end }}
+              response_trailer_mode: {{ if .Values.provider.supportedEvents.responseTrailers }}"SEND"{{ else }}"SKIP"{{ end }}
+            grpc_service:
+              envoy_grpc:
+                cluster_name: outbound|{{ .Values.bbr.port }}||{{ .Values.bbr.name }}.{{ include "bbr.namespace" . }}.svc.cluster.local
+{{- if .Values.bbr.secureServing }}
+---
+apiVersion: networking.istio.io/v1
+kind: DestinationRule
+metadata:
+  name: {{ .Values.bbr.name }}
+  namespace: {{ include "bbr.namespace" . }}
+  labels:
+    {{- include "bbr.labels" . | nindent 4 }}
+spec:
+  host: {{ .Values.bbr.name }}.{{ include "bbr.namespace" . }}.svc.cluster.local
+  trafficPolicy:
+    tls:
+      mode: SIMPLE
+      insecureSkipVerify: true
+{{- end }}
+{{- end }}

--- a/charts/productionstack/charts/body-based-routing/templates/rbac.yaml
+++ b/charts/productionstack/charts/body-based-routing/templates/rbac.yaml
@@ -1,0 +1,42 @@
+# Cluster-wide ConfigMap watch.
+#
+# BBR is deployed as a CLUSTER-WIDE singleton in Istio's root namespace,
+# while the LoRA-adapter → base-model ConfigMaps consumed by the
+# default `base-model-to-header` plugin live in workload namespaces
+# alongside each model deployment. The controller-runtime cache MUST
+# therefore watch ConfigMaps cluster-wide; a namespace-scoped Role
+# would leave the adapters store empty and silently break
+# adapter-aware routing.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.bbr.name }}-{{ .Release.Name }}-configmap-reader
+  labels:
+    {{- include "bbr.labels" . | nindent 4 }}
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "list", "watch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.bbr.name }}-{{ .Release.Name }}-configmap-reader
+  labels:
+    {{- include "bbr.labels" . | nindent 4 }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "bbr.serviceAccountName" . }}
+    namespace: {{ include "bbr.namespace" . }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.bbr.name }}-{{ .Release.Name }}-configmap-reader
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "bbr.serviceAccountName" . }}
+  namespace: {{ include "bbr.namespace" . }}
+  labels:
+    {{- include "bbr.labels" . | nindent 4 }}

--- a/charts/productionstack/charts/body-based-routing/values.yaml
+++ b/charts/productionstack/charts/body-based-routing/values.yaml
@@ -1,0 +1,153 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# body-based-routing chart values.
+#
+# Design intent for this fork:
+#   1. BBR is a CLUSTER-WIDE singleton. Install once into Istio's root
+#      namespace (istio-system) and all Istio-managed Gateways across
+#      every workload namespace consume it via a single EnvoyFilter.
+#      See README.md for the rationale (and trade-off analysis vs the
+#      per-namespace alternative).
+#
+#   2. BBR is launched in INSECURE serving mode (--secure-serving=false)
+#      so the ext_proc gRPC listener speaks plaintext HTTP/2. Istio's
+#      EnvoyFilter wires the upstream cluster as a plain HTTP/2
+#      `outbound|<port>||body-based-router.istio-system.svc.cluster.local`
+#      with no upstream TLS and no DestinationRule, eliminating the
+#      self-signed-cert handshake hop on every inference request.
+#
+#   3. The Envoy HTTP filter chain order on every inference Gateway is:
+#         ext_authz  →  bbr  →  router (HTTPRoute match → epp / not-found)
+#      To enforce that order, BBR's EnvoyFilter is inserted AFTER the
+#      Istio CUSTOM ext_authz filter (anchorSubFilter below). The
+#      llm-gateway-apikey chart MUST be installed before this chart so
+#      the anchor filter exists; otherwise the patch silently no-ops
+#      and BBR will never run.
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Install namespace for every namespaced resource rendered by this
+# chart (Deployment, Service, ServiceAccount, RBAC, EnvoyFilter,
+# optional DestinationRule). Also drives the upstream cluster FQDN
+# (`<svc>.<ns>.svc.cluster.local`) baked into the rendered EnvoyFilter.
+# Empty string ⇒ inherit the Helm release namespace (standard Helm
+# behavior).
+#
+# Set this when the chart is consumed as a subchart of an umbrella
+# release installed into a different namespace than where BBR must
+# actually run. BBR MUST live in Istio's root namespace
+# (`istio-system`) so the cluster-wide EnvoyFilter is visible to every
+# Istio-managed Gateway, so pin this to `istio-system` whenever the
+# umbrella release lives elsewhere. The target namespace MUST already
+# exist — Helm only auto-creates the release namespace.
+namespaceOverride: ""
+
+bbr:
+  # Singleton Deployment + Service name. Kept identical to the upstream
+  # default so any tooling that hard-codes `body-based-router` (the
+  # upstream chart's default) continues to work.
+  name: body-based-router
+
+  # One replica is sufficient. BBR is stateless and per-request work is
+  # cheap (regex/JSON field extraction); the bottleneck is the gateway
+  # data plane, not BBR. Bump this if you need HA.
+  replicas: 1
+
+  image:
+    registry: us-central1-docker.pkg.dev/k8s-staging-images
+    repository: gateway-api-inference-extension/bbr
+    tag: v1.5.0
+    pullPolicy: Always
+
+  # ext_proc gRPC port. Must match the cluster_name port in the
+  # rendered EnvoyFilter (templates/istio.yaml).
+  port: 9004
+  # gRPC health-check port consumed by liveness/readiness probes (and
+  # by the GKE provider's HealthCheckPolicy when that provider is wired
+  # up — not used in this repo, kept for upstream parity).
+  healthCheckPort: 9005
+
+  # When true, BBR's ext_proc gRPC listener serves over a self-signed
+  # TLS certificate and the rendered EnvoyFilter wires an upstream
+  # DestinationRule with `tls.mode=SIMPLE, insecureSkipVerify=true`.
+  # When false (the default in this fork), BBR runs plaintext HTTP/2
+  # and no DestinationRule is rendered. See top-of-file note (2).
+  secureServing: false
+
+  # Extra cmd-line flags forwarded to BBR as `--<key>=<value>`. The
+  # `secure-serving` flag is rendered automatically from
+  # `bbr.secureServing` above and MUST NOT be duplicated here.
+  flags:
+    # Log verbosity.
+    v: 3
+
+  # BBR plugin pipeline. When this list is non-empty the runner skips
+  # its built-in default auto-load, so the two entries below replicate
+  # upstream's default behavior (extract `model` body field into
+  # `X-Gateway-Model-Name`, then map base-model aliases to their
+  # canonical model names).
+  plugins:
+    - type: body-field-to-header
+      name: model-extractor
+      json:
+        fieldName: model
+        headerName: X-Gateway-Model-Name
+    - type: base-model-to-header
+      name: base-model-mapper
+
+  tracing:
+    enabled: false
+    otelServiceName: "gateway-api-inference-extension/bbr"
+    otelExporterEndpoint: "http://localhost:4317"
+    sampling:
+      sampler: "parentbased_traceidratio"
+      samplerArg: "0.1"
+
+provider:
+  # `istio` renders the EnvoyFilter that wires BBR into every
+  # Istio-managed Gateway in the cluster. Set to `none` to render only
+  # the Deployment + Service + RBAC (useful for non-Istio providers
+  # that wire BBR via their own mechanism).
+  name: istio
+
+  # Which HTTP lifecycle events Envoy forwards to BBR. Defaults match
+  # upstream. Only `requestHeaders` + `requestBody` are required for
+  # the default plugin pipeline above; flip the response/trailer
+  # toggles off in your overrides if your plugins do not need them
+  # (each extra event is an extra round-trip per request).
+  supportedEvents:
+    requestHeaders: true
+    requestBody: true
+    requestTrailers: true
+    responseHeaders: true
+    responseBody: true
+    responseTrailers: true
+
+  istio:
+    envoyFilter:
+      # Filter-chain placement.
+      #
+      # BBR injects `X-Gateway-Model-Name` from the JSON request body
+      # so the per-Gateway HTTPRoute (and the Istio-injected
+      # InferencePool ext_proc filter that points at EPP) can route
+      # the request to the correct deployment / pod. For that to work
+      # BBR MUST run BEFORE the InferencePool ext_proc filter — if
+      # ext_proc runs first, it resolves its per-route override at a
+      # time when the BBR-injected header is not yet present, so the
+      # route falls through to the catch-all and ext_proc silently
+      # uses its default `cluster: dummy` config (a no-op). Requests
+      # then bypass EPP entirely and Envoy load-balances directly
+      # across the InferencePool selector pods (round-robin), which
+      # breaks every EPP-driven feature (prefix-cache routing,
+      # KV-cache awareness, queue scoring, …). See
+      # `test/e2e/prefix_cache_routing_test.go` for the regression.
+      #
+      # Anchor on Istio's auto-injected
+      # `envoy.filters.http.ext_proc` (InferencePool) and INSERT_BEFORE
+      # so the final chain is:
+      #   istio.metadata_exchange → bbr → ext_proc (InferencePool) → … → router
+      #
+      # On gateways without an InferencePool the InferencePool
+      # ext_proc filter is absent and this patch silently no-ops; BBR
+      # is unused on those gateways anyway because no HTTPRoute
+      # matches on the BBR-injected header.
+      operation: INSERT_BEFORE
+      anchorSubFilter: envoy.filters.http.ext_proc

--- a/charts/productionstack/charts/keda-kaito-scaler/Chart.yaml
+++ b/charts/productionstack/charts/keda-kaito-scaler/Chart.yaml
@@ -1,0 +1,24 @@
+apiVersion: v2
+name: keda-kaito-scaler
+description: A Helm chart for Kaito keda-kaito-scaler component.
+
+# A chart can be either an 'application' or a 'library' chart.
+#
+# Application charts are a collection of templates that can be packaged into versioned archives
+# to be deployed.
+#
+# Library charts provide useful utilities or functions for the chart developer. They're included as
+# a dependency of application charts to inject those utilities and functions into the rendering
+# pipeline. Library charts do not define any templates and therefore cannot be deployed.
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.5.1
+
+# This is the version number of the application being deployed. This version number should be
+# incremented each time you make changes to the application. Versions are not expected to
+# follow Semantic Versioning. They should reflect the version the application is using.
+# It is recommended to use it with quotes.
+appVersion: "v0.5.1"

--- a/charts/productionstack/charts/keda-kaito-scaler/README.md
+++ b/charts/productionstack/charts/keda-kaito-scaler/README.md
@@ -1,0 +1,163 @@
+# keda-kaito-scaler
+
+Helm chart for the [`keda-kaito-scaler`](https://github.com/kaito-project/keda-kaito-scaler)
+external scaler — a [KEDA](https://keda.sh/) gRPC scaler that aggregates
+per-pod metrics from Kaito `InferenceSet` workloads (vLLM inference
+pods) and exposes a single summed metric value to KEDA's
+`ScaledObject` machinery so the underlying Deployment / `InferenceSet`
+can be scaled in and out based on real workload pressure (e.g. running
+requests, queued tokens) rather than CPU/memory only.
+
+This chart is intended to be consumed either standalone or as part of
+the umbrella [`productionstack`](../../README.md) chart.
+
+## What gets installed
+
+| Kind                 | Name                                  | Scope        | Purpose                                                                                |
+|----------------------|---------------------------------------|--------------|----------------------------------------------------------------------------------------|
+| `Deployment`         | `keda-kaito-scaler`                   | Namespaced   | The scaler controller pod (gRPC server + reconciler).                                  |
+| `Service`            | `keda-kaito-scaler-svc`               | Namespaced   | Exposes the gRPC `ExternalScaler` API consumed by `keda-operator`.                     |
+| `ServiceAccount`     | `keda-kaito-scaler-sa`                | Namespaced   | Identity used by the controller pod.                                                   |
+| `Secret` (×2)        | `keda-kaito-scaler-{server,client}-certs` | Namespaced | mTLS material the controller mounts at `/tmp/keda-kaito-scaler-certs/{server,client}`. Generated/rotated by the controller itself (`--cert-duration`). |
+| `ClusterRole`        | `keda-kaito-scaler-clusterrole`       | Cluster      | Read `kaito.sh/{inferencesets,workspaces}`; create/update `keda.sh/{scaledobjects,clustertriggerauthentications}`; manage leases, events, secrets. |
+| `ClusterRoleBinding` | `keda-kaito-scaler-clusterrole-binding` | Cluster    | Binds the ClusterRole to the ServiceAccount.                                           |
+
+The chart **does not** install KEDA itself. KEDA (`keda-operator`,
+`keda-operator-metrics-apiserver`) must already be running in the
+cluster, typically in the `keda` namespace.
+
+## Install standalone
+
+```sh
+# Pre-create the target namespace; Helm --create-namespace only creates
+# the release namespace, which may differ from namespaceOverride.
+kubectl create namespace keda --dry-run=client -o yaml | kubectl apply -f -
+
+helm upgrade --install keda-kaito-scaler \
+  charts/productionstack/charts/keda-kaito-scaler \
+  --namespace keda \
+  --create-namespace \
+  --wait
+```
+
+Verify the scaler is registered:
+
+```sh
+kubectl -n keda get pods -l app.kubernetes.io/name=keda-kaito-scaler
+kubectl -n keda logs deploy/keda-kaito-scaler | head
+```
+
+## Install as a subchart of `productionstack`
+
+The umbrella chart pins `keda-kaito-scaler.namespaceOverride: keda` by
+default, so the scaler lands in the `keda` namespace regardless of the
+Helm release namespace:
+
+```sh
+helm upgrade --install productionstack charts/productionstack \
+  --namespace kaito-system \
+  --create-namespace
+```
+
+To override individual values from the parent, nest them under the
+subchart name:
+
+```yaml
+# parent values.yaml
+keda-kaito-scaler:
+  enabled: true
+  replicaCount: 2
+  log:
+    level: 3
+```
+
+## Wiring it into KEDA
+
+Reference the scaler from a KEDA `ScaledObject` with the
+`external-push` (or `external`) trigger type, pointing at the service
+FQDN rendered by this chart:
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: my-inference-set
+  namespace: my-workload-ns
+spec:
+  scaleTargetRef:
+    apiVersion: kaito.sh/v1alpha1
+    kind: InferenceSet
+    name: my-inference-set
+  triggers:
+    - type: external
+      metadata:
+        scalerAddress: keda-kaito-scaler-svc.keda.svc.cluster.local:10450
+        # Plus scaler-specific metadata; see the keda-kaito-scaler repo.
+```
+
+In practice the controller in this chart **creates the `ScaledObject`
+itself** for each `InferenceSet` it watches (that's why the
+`ClusterRole` grants `scaledobjects` create/delete), so end users
+normally only author the `InferenceSet` and let the controller wire
+KEDA up.
+
+## Per-subchart install namespace
+
+This chart exposes `namespaceOverride` so a single
+`helm install` of the parent umbrella chart can place each subchart
+into its own namespace. When set, every namespaced resource
+(`Deployment`, `Service`, `ServiceAccount`, the two `Secrets`) and the
+`ClusterRoleBinding`'s `subjects[].namespace` are pinned to the
+override. The controller's `--working-namespace` flag is also wired to
+the same value so its lease and self-managed secrets live alongside
+the pod.
+
+Set `namespaceOverride: ""` to fall back to the standard Helm
+`--namespace` behavior.
+
+## Configuration
+
+| Parameter                  | Default                                  | Description                                                                                                  |
+|----------------------------|------------------------------------------|--------------------------------------------------------------------------------------------------------------|
+| `replicaCount`             | `1`                                      | Number of controller replicas. Leader election (via the lease grant in the ClusterRole) makes >1 safe.       |
+| `certDuration`             | `43800h` (5 years)                       | Lifetime of the self-signed mTLS certs the controller generates and rotates.                                 |
+| `nameOverrider`            | `""`                                     | Overrides the chart name used in labels (does **not** rename the workload resources).                        |
+| `namespaceOverride`        | `""`                                     | Install namespace for all namespaced resources. Empty ⇒ inherit the release namespace. See above.            |
+| `log.level`                | `3`                                      | klog verbosity (`--v`). Bump to `5` for debug logging.                                                        |
+| `image.registry`           | `ghcr.io`                                | Container image registry.                                                                                    |
+| `image.repository`         | `kaito-project/keda-kaito-scaler`        | Container image repository.                                                                                  |
+| `image.tag`                | `0.5.1`                                  | Container image tag.                                                                                         |
+| `image.pullSecrets`        | `[]`                                     | `imagePullSecrets` for the pod spec.                                                                         |
+| `ports.grpc`               | `10450`                                  | gRPC `ExternalScaler` port exposed via the Service.                                                          |
+| `ports.metrics`            | `10451`                                  | Prometheus metrics port (`--metrics-port`). Not currently fronted by a Service.                              |
+| `ports.grpcHealth`         | `10452`                                  | gRPC health-check port consumed by liveness/readiness probes.                                                |
+| `resources.requests.cpu`   | `200m`                                   | Controller container CPU request.                                                                            |
+| `resources.requests.memory`| `256Mi`                                  | Controller container memory request.                                                                         |
+| `resources.limits.cpu`     | `2000m`                                  | Controller container CPU limit.                                                                              |
+| `resources.limits.memory`  | `512Mi`                                  | Controller container memory limit.                                                                           |
+
+## Upgrade
+
+The mTLS certs are managed by the controller itself, not by Helm, so
+`helm upgrade` will not touch the two `*-certs` Secrets. The
+controller will rotate them on its own schedule based on
+`certDuration`.
+
+## Uninstall
+
+```sh
+helm uninstall keda-kaito-scaler --namespace keda
+```
+
+Helm removes everything the chart created, including the
+cluster-scoped `ClusterRole` and `ClusterRoleBinding`. Any
+`ScaledObject` resources the controller has provisioned for
+`InferenceSet`s are **not** cleaned up by Helm — delete the parent
+`InferenceSet` first (or remove them with `kubectl delete
+scaledobject`).
+
+## Links
+
+- Upstream repo: <https://github.com/kaito-project/keda-kaito-scaler>
+- KEDA external scalers: <https://keda.sh/docs/latest/concepts/external-scalers/>
+- Umbrella chart: [`charts/productionstack`](../../README.md)

--- a/charts/productionstack/charts/keda-kaito-scaler/templates/_helpers.tpl
+++ b/charts/productionstack/charts/keda-kaito-scaler/templates/_helpers.tpl
@@ -1,0 +1,47 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "keda-kaito-scaler.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "keda-kaito-scaler.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "keda-kaito-scaler.labels" -}}
+helm.sh/chart: {{ include "keda-kaito-scaler.chart" . }}
+{{ include "keda-kaito-scaler.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "keda-kaito-scaler.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "keda-kaito-scaler.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Install namespace for every namespaced resource rendered by this chart.
+
+Defaults to the Helm release namespace, but can be overridden via
+`namespaceOverride` so the chart can be installed into a different
+namespace than the surrounding umbrella release (e.g. pinned to
+`keda` when the parent chart is installed elsewhere). When
+overridden, the target namespace MUST already exist — `helm install
+--create-namespace` only creates the release namespace.
+*/}}
+{{- define "keda-kaito-scaler.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
+{{- end }}

--- a/charts/productionstack/charts/keda-kaito-scaler/templates/clusterrole-auto-generated.yaml
+++ b/charts/productionstack/charts/keda-kaito-scaler/templates/clusterrole-auto-generated.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: keda-kaito-scaler-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - list
+  - update
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+- apiGroups:
+  - kaito.sh
+  resources:
+  - inferencesets
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - kaito.sh
+  resources:
+  - workspaces
+  verbs:
+  - list
+  - watch
+- apiGroups:
+  - keda.sh
+  resources:
+  - clustertriggerauthentications
+  verbs:
+  - create
+  - get
+  - patch
+  - update
+- apiGroups:
+  - keda.sh
+  resources:
+  - scaledobjects
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - update
+  - watch

--- a/charts/productionstack/charts/keda-kaito-scaler/templates/keda-kaito-scaler.yaml
+++ b/charts/productionstack/charts/keda-kaito-scaler/templates/keda-kaito-scaler.yaml
@@ -1,0 +1,137 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keda-kaito-scaler-client-certs
+  namespace: {{ include "keda-kaito-scaler.namespace" . }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: keda-kaito-scaler-server-certs
+  namespace: {{ include "keda-kaito-scaler.namespace" . }}
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: keda-kaito-scaler-sa
+  namespace: {{ include "keda-kaito-scaler.namespace" . }}
+  labels:
+    {{- include "keda-kaito-scaler.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: keda-kaito-scaler-clusterrole-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: keda-kaito-scaler-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: keda-kaito-scaler-sa
+  namespace: {{ include "keda-kaito-scaler.namespace" . }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keda-kaito-scaler-svc
+  namespace: {{ include "keda-kaito-scaler.namespace" . }}
+  labels:
+    {{- include "keda-kaito-scaler.labels" . | nindent 4 }}
+spec:
+  ports:
+    - name: grpc
+      port: {{ .Values.ports.grpc }}
+      protocol: TCP
+      targetPort: grpc-server
+  selector:
+    {{- include "keda-kaito-scaler.selectorLabels" . | nindent 4 }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    {{- include "keda-kaito-scaler.labels" . | nindent 4 }}
+  name: keda-kaito-scaler
+  namespace: {{ include "keda-kaito-scaler.namespace" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "keda-kaito-scaler.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "keda-kaito-scaler.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- if not (empty .Values.image.pullSecrets) }}
+      imagePullSecrets:
+{{ toYaml .Values.image.pullSecrets | indent 8 }}
+      {{- end }}
+      tolerations:
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/master
+        - effect: NoSchedule
+          key: node-role.kubernetes.io/control-plane
+      containers:
+        - args:
+            - --v={{ .Values.log.level }}
+            - --metrics-port={{ .Values.ports.metrics }}
+            - --grpc-health-port={{ .Values.ports.grpcHealth }}
+            - --working-namespace={{ include "keda-kaito-scaler.namespace" . }}
+            {{- if .Values.certDuration }}
+            - --cert-duration={{ .Values.certDuration }}
+            {{- end }}
+          command:
+            - /keda-kaito-scaler
+          image: {{ .Values.image.registry }}/{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}
+          imagePullPolicy: IfNotPresent
+          name: keda-kaito-scaler
+          ports:
+            - containerPort: {{ .Values.ports.grpc }}
+              name: grpc-server
+              protocol: TCP
+            - containerPort: {{ .Values.ports.metrics }}
+              name: metrics
+              protocol: TCP
+            - containerPort: {{ .Values.ports.grpcHealth }}
+              name: grpc-health
+              protocol: TCP
+          livenessProbe:
+            grpc:
+              port: {{ .Values.ports.grpcHealth }}
+              service: liveness
+            initialDelaySeconds: 30
+            timeoutSeconds: 2
+            periodSeconds: 10
+            failureThreshold: 3
+          readinessProbe:
+            grpc:
+              port: {{ .Values.ports.grpcHealth }}
+              service: readiness
+            initialDelaySeconds: 30
+            timeoutSeconds: 2
+            periodSeconds: 10
+            failureThreshold: 2
+          {{- if .Values.resources }}
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: server-certs
+              mountPath: /tmp/keda-kaito-scaler-certs/server
+              readOnly: true
+            - name: client-certs
+              mountPath: /tmp/keda-kaito-scaler-certs/client
+              readOnly: true
+      volumes:
+        - name: server-certs
+          secret:
+            secretName: keda-kaito-scaler-server-certs
+            defaultMode: 0644
+        - name: client-certs
+          secret:
+            secretName: keda-kaito-scaler-client-certs
+            defaultMode: 0644
+      serviceAccountName: keda-kaito-scaler-sa

--- a/charts/productionstack/charts/keda-kaito-scaler/values.yaml
+++ b/charts/productionstack/charts/keda-kaito-scaler/values.yaml
@@ -1,0 +1,39 @@
+log:
+  level: 3
+
+replicaCount: 1
+certDuration: 43800h
+nameOverrider: ""
+
+# Install namespace for every namespaced resource rendered by this chart
+# (Deployment, Service, ServiceAccount, Secrets) and the namespace
+# referenced by the ClusterRoleBinding subject + the controller's
+# --working-namespace flag. Empty string ⇒ inherit the Helm release
+# namespace (the standard Helm behavior).
+#
+# Set this when the chart is consumed as a subchart of an umbrella
+# release that is installed into a different namespace than where the
+# scaler should actually run (e.g. parent installed into
+# `kaito-system`, scaler pinned to `keda`). The target namespace MUST
+# already exist — Helm only auto-creates the release namespace.
+namespaceOverride: ""
+
+image:
+    registry: ghcr.io
+    repository: kaito-project/keda-kaito-scaler
+    tag: 0.5.1
+    pullSecrets: []
+
+ports:
+  grpc: 10450
+  metrics: 10451
+  grpcHealth: 10452
+
+resources:
+  limits:
+    cpu: 2000m
+    memory: 512Mi
+  requests:
+    cpu: 200m
+    memory: 256Mi
+  

--- a/charts/productionstack/templates/NOTES.txt
+++ b/charts/productionstack/templates/NOTES.txt
@@ -1,0 +1,13 @@
+productionstack {{ .Chart.AppVersion }} installed in namespace {{ .Release.Namespace }}.
+
+Enabled cluster-level components:
+{{- if index .Values "body-based-routing" "enabled" }}
+  - body-based-routing (BBR ext_proc + Istio EnvoyFilter)
+{{- end }}
+{{- if index .Values "keda-kaito-scaler" "enabled" }}
+  - keda-kaito-scaler (KEDA external scaler for vLLM / InferenceSet)
+{{- end }}
+
+To inspect rendered resources for a single component, use:
+  helm get manifest {{ .Release.Name }} --namespace {{ .Release.Namespace }} \
+    | yq 'select(.metadata.labels."app.kubernetes.io/part-of" == "productionstack")'

--- a/charts/productionstack/values.yaml
+++ b/charts/productionstack/values.yaml
@@ -1,0 +1,57 @@
+# ─────────────────────────────────────────────────────────────────────────────
+# productionstack — umbrella chart values.
+#
+# This chart bundles every CLUSTER-LEVEL component and CRD needed by the
+# Kaito production stack. Each component is a Helm subchart under
+# `charts/` and is independently toggleable via `<component>.enabled`.
+#
+# Per-subchart install namespace
+# ──────────────────────────────
+# Helm itself only accepts a single `--namespace` for the whole release.
+# To install each subchart into its OWN namespace inside a single
+# `helm install`, every subchart in this umbrella exposes a
+# `namespaceOverride` value. When set, all of that subchart's
+# namespaced resources are rendered into the override namespace
+# instead of the release namespace; cluster-scoped resources
+# (ClusterRole, ClusterRoleBinding, EnvoyFilter targeting handled via
+# context) are unaffected.
+#
+# Caveats:
+#   1. Target namespaces MUST already exist. `helm install
+#      --create-namespace` only creates the RELEASE namespace, not the
+#      override targets.
+#   2. The Helm release metadata (Secret) is still stored in the
+#      release namespace, but `helm uninstall` correctly cleans up
+#      resources in every override namespace because it tracks the
+#      rendered manifest, not the namespace.
+#
+# Override a subchart's own values by nesting them under the subchart
+# name. The keys below mirror each subchart's `values.yaml` exactly;
+# see the subchart's own README for the full set of supported keys.
+#
+# Example — install BBR into istio-system and the scaler into keda
+# while the umbrella release itself lives in kaito-system:
+#   helm upgrade --install productionstack charts/productionstack \
+#     --namespace kaito-system --create-namespace \
+#     --set body-based-routing.namespaceOverride=istio-system \
+#     --set keda-kaito-scaler.namespaceOverride=keda
+# (`istio-system` and `keda` must already exist.)
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Body-Based Router (BBR) for the Gateway API Inference Extension.
+# Cluster-wide singleton; install once into Istio's root namespace.
+# See charts/body-based-routing/README.md for the full value reference.
+body-based-routing:
+  enabled: true
+  # MUST be Istio's root namespace so the rendered EnvoyFilter is
+  # visible to every Istio-managed Gateway in the mesh. Override only
+  # if you have moved Istio's root namespace.
+  namespaceOverride: istio-system
+
+# KEDA external scaler for vLLM / InferenceSet workloads.
+# See charts/keda-kaito-scaler/values.yaml for the full value reference.
+keda-kaito-scaler:
+  enabled: true
+  # Co-locate with the KEDA control plane by default. Set to "" to
+  # inherit the umbrella release namespace instead.
+  namespaceOverride: keda

--- a/hack/e2e/scripts/install-components.sh
+++ b/hack/e2e/scripts/install-components.sh
@@ -9,30 +9,49 @@
 #
 # Phase 1 (parallel, no deps):
 #   - KAITO workspace operator
-#   - Gateway API CRDs
-#   - GWIE CRDs (InferencePool, InferenceModel)
-#   - KEDA
-#   - KEDA Kaito Scaler         (no dep on KEDA at chart-install time;
-#                                only emits ScaledObjects later, so safe
-#                                to install in parallel with KEDA)
+#   - GAIE CRDs                  (server-side apply of the
+#                                 gateway-api-inference-extension manifests;
+#                                 not covered by any AKS managed add-on
+#                                 today, so the same install runs for
+#                                 both upstream and azure providers).
 #   - gpu-node-mocker            (no install-time dep on KAITO CRDs; the
 #                                 binary discovery-checks `karpenter.sh/v1
 #                                 NodeClaim` at startup and exits if the
 #                                 CRD is not yet served, so kubelet retries
 #                                 until KAITO finishes installing it)
-#   - BBR chart prefetch (git clone fork repo only)
+#   - productionstack            (helm-installed from the in-tree umbrella
+#                                 chart at charts/productionstack. Bundles
+#                                 body-based-routing → istio-system and
+#                                 keda-kaito-scaler → ${KEDA_NAMESPACE}
+#                                 in a single helm release, replacing
+#                                 the previous separate install_bbr +
+#                                 install_keda_kaito_scaler steps. The
+#                                 BBR subchart ships an EnvoyFilter that
+#                                 requires the Istio control plane to be
+#                                 up; Istio is installed by
+#                                 setup-cluster.sh BEFORE this script
+#                                 runs, so phase1 has no Istio race.)
 #
 # (Catch-all 404 handling is now provided by an EnvoyFilter
 # direct_response rendered per-namespace by charts/modelharness — no
 # cluster-shared Service is required, so install_model_not_found has
 # been removed from this script.)
 #
-# Phase 2 (parallel, depends on Phase 1):
-#   - Istio                      (after Gateway API CRDs)
-#
-# Phase 3 (parallel, depends on Istio):
-#   - BBR (Body-Based Router)    (helm install into istio-system)
-#   - LLM Gateway Auth           (apikeys.kaito.sh CRD + AuthorizationPolicy)
+# Phase 2 (depends on Phase 1):
+#   - LLM Gateway Auth           (apikeys.kaito.sh CRD + cluster-wide
+#                                 ext_authz CUSTOM provider; depends on
+#                                 Istio being installed in Phase 1).
+#                                 The per-namespace AuthorizationPolicy
+#                                 that activates ext_authz on each
+#                                 Gateway pod is rendered later by the
+#                                 modelharness chart at test time; its
+#                                 placement in the Envoy filter chain
+#                                 lands BEFORE BBR because BBR's
+#                                 EnvoyFilter is anchored on
+#                                 envoy.filters.http.ext_authz with
+#                                 INSERT_AFTER, giving the runtime
+#                                 order: ext_authz → bbr → router
+#                                 (HTTPRoute → epp / model-not-found).
 #
 # Per-namespace shared resources (Gateway, catch-all HTTPRoute,
 # ReferenceGrant, AuthorizationPolicy, APIKey CR) are NOT installed by
@@ -41,31 +60,38 @@
 # test/e2e/utils/setup.go EnsureNamespace).
 #
 # Environment variables (must be set by caller, e.g. run-e2e-local.sh or CI):
-#   ISTIO_VERSION             — Istio version
-#   GATEWAY_API_VERSION       — Gateway API CRD version
 #   BBR_VERSION               — BBR release version (informational only)
-#   KEDA_VERSION              — KEDA Helm chart version
 #   KEDA_KAITO_SCALER_VERSION — KEDA Kaito Scaler Helm chart version
+#                               (informational only — the productionstack
+#                               umbrella chart vendors the subchart in-tree
+#                               so this version is not used at install time)
 #   LLM_GATEWAY_AUTH_VERSION  — LLM Gateway Auth Helm chart version
 #   LLM_GATEWAY_AUTH_IMAGE_TAG — LLM Gateway Auth container image tag
 #   SHADOW_CONTROLLER_IMAGE   — gpu-node-mocker image (default: ghcr.io/kaito-project/gpu-node-mocker:latest)
 #   INSTALL_PARALLEL          — set to "0" to disable parallelism (default: 1)
+#
+# Note: KEDA, Gateway API base CRDs, and the Istio control plane are
+# installed by hack/e2e/scripts/setup-cluster.sh so both the upstream
+# and azure providers converge on the same prerequisite state before
+# this script runs. GAIE (Gateway API Inference Extension) CRDs stay
+# in phase1-base here.
 # ---------------------------------------------------------------------------
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # Validate required version variables are set.
-: "${ISTIO_VERSION:?ISTIO_VERSION is not set. Source versions.env or export it before calling this script.}"
-: "${GATEWAY_API_VERSION:?GATEWAY_API_VERSION is not set. Source versions.env or export it before calling this script.}"
 : "${BBR_VERSION:?BBR_VERSION is not set. Source versions.env or export it before calling this script.}"
-: "${KEDA_VERSION:?KEDA_VERSION is not set. Source versions.env or export it before calling this script.}"
 : "${KEDA_KAITO_SCALER_VERSION:?KEDA_KAITO_SCALER_VERSION is not set. Source versions.env or export it before calling this script.}"
 : "${LLM_GATEWAY_AUTH_VERSION:?LLM_GATEWAY_AUTH_VERSION is not set. Source versions.env or export it before calling this script.}"
 : "${LLM_GATEWAY_AUTH_IMAGE_TAG:?LLM_GATEWAY_AUTH_IMAGE_TAG is not set. Source versions.env or export it before calling this script.}"
 SHADOW_CONTROLLER_IMAGE="${SHADOW_CONTROLLER_IMAGE:-ghcr.io/kaito-project/gpu-node-mocker:latest}"
 INSTALL_PARALLEL="${INSTALL_PARALLEL:-1}"
 E2E_PROVIDER="${E2E_PROVIDER:-upstream}"
+
+# Source the shared run_phase / fmt_dur helpers.
+# shellcheck source=lib-parallel.sh
+source "${SCRIPT_DIR}/lib-parallel.sh"
 
 # Derive KEDA install namespace from provider when not explicitly provided.
 #   upstream -> install KEDA via Helm into the dedicated `keda` namespace.
@@ -88,10 +114,7 @@ export KEDA_NAMESPACE
 echo "=== Component versions ==="
 echo "  E2E_PROVIDER:              ${E2E_PROVIDER}"
 echo "  KEDA_NAMESPACE:            ${KEDA_NAMESPACE}"
-echo "  ISTIO_VERSION:             ${ISTIO_VERSION}"
-echo "  GATEWAY_API_VERSION:       ${GATEWAY_API_VERSION}"
 echo "  BBR_VERSION:               ${BBR_VERSION}"
-echo "  KEDA_VERSION:              ${KEDA_VERSION}"
 echo "  KEDA_KAITO_SCALER_VERSION: ${KEDA_KAITO_SCALER_VERSION}"
 echo "  LLM_GATEWAY_AUTH_VERSION:  ${LLM_GATEWAY_AUTH_VERSION}"
 echo "  LLM_GATEWAY_AUTH_IMAGE_TAG:${LLM_GATEWAY_AUTH_IMAGE_TAG}"
@@ -100,115 +123,18 @@ echo "  INSTALL_PARALLEL:          ${INSTALL_PARALLEL}"
 echo ""
 
 # ── Shared state across functions ─────────────────────────────────────────
-LOGDIR="$(mktemp -d -t e2e-install-XXXXXX)"
-BBR_CHART_TMPDIR="$(mktemp -d -t bbr-chart-XXXXXX)"
-BBR_CHART_SUBPATH="config/charts/body-based-routing"
-trap 'rm -rf "${BBR_CHART_TMPDIR}" "${LOGDIR}"' EXIT
+# Path to the in-tree productionstack umbrella chart, resolved relative
+# to the repo root (this script lives at hack/e2e/scripts/install-components.sh,
+# so ../../.. from SCRIPT_DIR is the repo root). The umbrella chart
+# bundles body-based-routing and keda-kaito-scaler as subcharts, so a
+# single `helm install` covers both components.
+PRODUCTIONSTACK_CHART_DIR="${SCRIPT_DIR}/../../../charts/productionstack"
 
-# ── Helper: format an elapsed-seconds count as a human-friendly duration ──
-fmt_dur() {
-  local s="$1"
-  if (( s < 60 )); then
-    printf '%ds' "${s}"
-  else
-    printf '%dm%02ds' "$((s/60))" "$((s%60))"
-  fi
-}
-
-# ── Helper: run a list of functions in parallel and aggregate logs ────────
-# Usage: run_phase <phase-name> <fn1> <fn2> ...
-#
-# Per-task and per-phase wall-clock timings are printed at the end of each
-# phase; the master summary is printed once after the final phase.
-PHASE_TIMINGS=()  # "<phase-name>=<seconds>"
-TASK_TIMINGS=()   # "<phase-name>/<task>=<seconds>"
-run_phase() {
-  local phase="$1"; shift
-  local phase_dir="${LOGDIR}/${phase}"
-  mkdir -p "${phase_dir}"
-  local phase_start=${SECONDS}
-
-  if [[ "${INSTALL_PARALLEL}" != "1" || $# -le 1 ]]; then
-    # Sequential fallback (or single-task phase): stream output directly.
-    for fn in "$@"; do
-      echo ""
-      echo "── [${phase}] ${fn} ──"
-      local task_start=${SECONDS}
-      "${fn}"
-      local task_dur=$((SECONDS - task_start))
-      TASK_TIMINGS+=("${phase}/${fn}=${task_dur}")
-      echo "  ⏱  [${phase}] ${fn} took $(fmt_dur "${task_dur}")"
-    done
-    PHASE_TIMINGS+=("${phase}=$((SECONDS - phase_start))")
-    echo ""
-    echo "⏱  Phase '${phase}' total: $(fmt_dur "$((SECONDS - phase_start))")"
-    return 0
-  fi
-
-  echo ""
-  echo "── [${phase}] launching $# tasks in parallel: $* ──"
-  local pids=() names=() task_starts=()
-  for fn in "$@"; do
-    local task_start=${SECONDS}
-    (
-      set -e
-      "${fn}"
-    ) >"${phase_dir}/${fn}.log" 2>&1 &
-    pids+=($!)
-    names+=("${fn}")
-    task_starts+=("${task_start}")
-  done
-
-  local rc=0
-  local failed=()
-  local task_durs=()
-  for i in "${!pids[@]}"; do
-    if wait "${pids[$i]}"; then
-      local d=$((SECONDS - task_starts[i]))
-      task_durs+=("${d}")
-      echo "  ✅ [${phase}] ${names[$i]} ($(fmt_dur "${d}"))"
-      TASK_TIMINGS+=("${phase}/${names[$i]}=${d}")
-    else
-      local d=$((SECONDS - task_starts[i]))
-      task_durs+=("${d}")
-      echo "  ❌ [${phase}] ${names[$i]} ($(fmt_dur "${d}"))"
-      TASK_TIMINGS+=("${phase}/${names[$i]}=${d}")
-      failed+=("${names[$i]}")
-      rc=1
-    fi
-  done
-
-  # Always replay logs so users can see what each parallel task did.
-  for n in "${names[@]}"; do
-    echo ""
-    echo "────── [${phase}] ${n} log ──────"
-    cat "${phase_dir}/${n}.log"
-  done
-
-  local phase_dur=$((SECONDS - phase_start))
-  PHASE_TIMINGS+=("${phase}=${phase_dur}")
-  echo ""
-  echo "⏱  Phase '${phase}' total: $(fmt_dur "${phase_dur}") (longest task gates this phase)"
-
-  if [[ $rc -ne 0 ]]; then
-    echo ""
-    echo "❌ Phase '${phase}' failed: ${failed[*]}"
-  fi
-  return "${rc}"
-}
-
-# ── 0. Ensure helm + istioctl are available (sequential prep) ─────────────
+# ── 0. Ensure helm is available (sequential prep) ───────────────────────
 if ! command -v helm &>/dev/null; then
   echo "Installing helm..."
   curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash
 fi
-
-if ! command -v istioctl &>/dev/null; then
-  echo "Installing istioctl ${ISTIO_VERSION}..."
-  curl -L https://istio.io/downloadIstio | ISTIO_VERSION="${ISTIO_VERSION}" sh -
-  export PATH="${PWD}/istio-${ISTIO_VERSION}/bin:${PATH}"
-fi
-echo "Using istioctl: $(command -v istioctl)"
 
 # ── Component install functions ───────────────────────────────────────────
 
@@ -245,26 +171,6 @@ install_kaito() {
     echo "⚠️  KAITO pods not ready yet — continuing (will re-check later)."
 }
 
-install_gateway_api_crds() {
-  if [[ "${E2E_PROVIDER}" == "azure" ]]; then
-    echo "=== Skipping upstream Gateway API CRDs (provider=azure, AKS managed Gateway API add-on is enabled) ==="
-    echo "Verifying gateways.gateway.networking.k8s.io is served..."
-    # The managed add-on installs the standard-channel CRDs at cluster-create
-    # time. Block briefly in case the install hasn't propagated yet.
-    for _ in $(seq 1 30); do
-      if kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1; then
-        echo "  ✅ gateways CRD is served by the managed add-on"
-        return 0
-      fi
-      sleep 2
-    done
-    echo "  ❌ Managed Gateway API CRDs not present after 60s — falling back to upstream install"
-  fi
-
-  echo "=== Installing Gateway API CRDs ${GATEWAY_API_VERSION} ==="
-  kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
-}
-
 install_gwie_crds() {
   # Use server-side apply (--server-side --force-conflicts) instead of the
   # default client-side apply. install_gwie_crds runs in parallel with
@@ -279,46 +185,6 @@ install_gwie_crds() {
   echo "=== Installing GWIE CRDs ==="
   kubectl apply --server-side --force-conflicts \
     -f "https://github.com/kubernetes-sigs/gateway-api-inference-extension/releases/latest/download/manifests.yaml"
-}
-
-install_keda() {
-  if [[ "${E2E_PROVIDER}" == "azure" ]]; then
-    echo "=== Skipping Helm KEDA install (provider=azure, AKS managed KEDA add-on is enabled) ==="
-    echo "Verifying managed KEDA in ${KEDA_NAMESPACE}..."
-    # The managed add-on installs KEDA at cluster-create time; wait briefly
-    # in case the controller rollout has not fully completed.
-    kubectl -n "${KEDA_NAMESPACE}" rollout status deployment/keda-operator --timeout=180s || true
-    kubectl -n "${KEDA_NAMESPACE}" rollout status deployment/keda-operator-metrics-apiserver --timeout=180s || true
-    return 0
-  fi
-
-  echo "=== Installing KEDA ${KEDA_VERSION} ==="
-  helm repo add kedacore https://kedacore.github.io/charts 2>/dev/null || true
-  helm repo update kedacore
-  helm upgrade --install keda kedacore/keda \
-    --version "${KEDA_VERSION}" \
-    --namespace "${KEDA_NAMESPACE}" \
-    --create-namespace \
-    --wait --timeout=300s
-
-  echo "⏳ Waiting for KEDA operator..."
-  kubectl -n "${KEDA_NAMESPACE}" rollout status deployment/keda-operator --timeout=180s || true
-  kubectl -n "${KEDA_NAMESPACE}" rollout status deployment/keda-operator-metrics-apiserver --timeout=180s || true
-}
-
-prefetch_bbr_chart() {
-  # We install BBR from the rambohe-ch fork's `support-insecure-serving` branch
-  # so that BBR can be launched in insecure-serving mode (no TLS on the
-  # ext_proc gRPC listener), which matches the plaintext ext_proc cluster
-  # wired up by the Istio EnvoyFilter rendered by the chart. The chart is
-  # fetched via a shallow git clone into a temp directory; the BBR_VERSION
-  # variable is retained for log clarity but is not used as a chart version
-  # pin in this branch.
-  local repo="https://github.com/rambohe-ch/gateway-api-inference-extension.git"
-  local ref="support-insecure-serving"
-  echo "=== Prefetching BBR chart from ${repo} (branch: ${ref}) ==="
-  git clone --depth 1 --branch "${ref}" "${repo}" "${BBR_CHART_TMPDIR}/gaie" >/dev/null
-  echo "BBR chart cloned to ${BBR_CHART_TMPDIR}/gaie/${BBR_CHART_SUBPATH}"
 }
 
 install_gpu_mocker() {
@@ -339,82 +205,61 @@ install_gpu_mocker() {
   kubectl -n kaito-system rollout status deployment/gpu-node-mocker --timeout=420s || true
 }
 
-install_istio() {
-  echo "=== Installing Istio ${ISTIO_VERSION} ==="
-  istioctl install \
-    --set profile=minimal \
-    --set hub=docker.io/istio \
-    --set tag="${ISTIO_VERSION}" \
-    --set "values.pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true" \
-    -y
 
-  echo "⏳ Waiting for istiod..."
-  kubectl -n istio-system rollout status deployment/istiod --timeout=180s
-}
-
-install_keda_kaito_scaler() {
-  echo "=== Installing KEDA Kaito Scaler ${KEDA_KAITO_SCALER_VERSION} into ${KEDA_NAMESPACE} ==="
-  helm repo add keda-kaito-scaler https://kaito-project.github.io/keda-kaito-scaler/charts/kaito-project 2>/dev/null || true
-  helm repo update keda-kaito-scaler
-  helm upgrade --install keda-kaito-scaler keda-kaito-scaler/keda-kaito-scaler \
-    --version "${KEDA_KAITO_SCALER_VERSION}" \
-    --namespace "${KEDA_NAMESPACE}" \
-    --create-namespace \
-    --wait --timeout=300s
-
-  echo "⏳ Waiting for keda-kaito-scaler..."
-  kubectl -n "${KEDA_NAMESPACE}" rollout status deployment -l app.kubernetes.io/name=keda-kaito-scaler --timeout=180s || true
-}
-
-install_bbr() {
-  # Installed into istio-system (Istio's rootNamespace) so that the
-  # EnvoyFilter rendered by the chart applies cluster-wide to every
-  # Istio-managed gateway, including per-case Gateways provisioned in
-  # isolated namespaces by the e2e framework. Without this, the BBR
-  # EnvoyFilter would be namespace-scoped to `default` and per-case
-  # Gateways would never see the body-based-routing ext_proc filter,
-  # breaking model name extraction and downstream HTTPRoute matching.
-  # The chart also rewrites the ext_proc cluster_name FQDN to
-  # `body-based-router.istio-system.svc.cluster.local` automatically.
+install_productionstack() {
+  # The productionstack umbrella chart at charts/productionstack bundles
+  # both body-based-routing and keda-kaito-scaler as in-tree subcharts.
+  # A single `helm install` covers both components, replacing the
+  # previous separate install_bbr + install_keda_kaito_scaler steps.
   #
-  # NOTE: The fork's chart template already pins the BBR EnvoyFilter to
-  # `match.context: GATEWAY`, so the previous post-install JSON patch that
-  # scoped the filter to gateway HCMs only is no longer needed.
-  echo "=== Installing BBR (rambohe-ch fork, insecure-serving mode) ==="
-  helm upgrade --install body-based-router "${BBR_CHART_TMPDIR}/gaie/${BBR_CHART_SUBPATH}" \
-    --namespace istio-system \
-    --set provider.name=istio \
-    --set bbr.secureServing=false \
-    --wait
+  # Per-subchart install namespaces are pinned via each subchart's
+  # `namespaceOverride` value (Helm itself only accepts a single
+  # `--namespace` per release):
+  #   * body-based-routing → istio-system  (Istio's rootNamespace, so
+  #     the chart-rendered EnvoyFilter applies cluster-wide to every
+  #     Istio-managed Gateway; the chart defaults to INSERT_AFTER
+  #     anchored on envoy.filters.http.ext_authz, giving the runtime
+  #     order: ext_authz → bbr → router → epp/not-found).
+  #   * keda-kaito-scaler  → ${KEDA_NAMESPACE}  (must be co-located with
+  #     the KEDA control plane so KEDA can resolve the
+  #     ClusterTriggerAuthentication Secrets it ships).
+  #
+  # The Helm release metadata Secret itself lives in `kaito-system`;
+  # `helm uninstall productionstack -n kaito-system` correctly cleans
+  # up resources across all override namespaces.
+  #
+  # Phase-1 parallelism note:
+  #   install_productionstack runs in parallel with KAITO and friends in
+  #   phase1-base. The BBR subchart's EnvoyFilter requires the Istio
+  #   control plane (CRDs + istiod) to be up, but Istio is installed by
+  #   setup-cluster.sh BEFORE install-components.sh runs, so there is no
+  #   in-phase race — we just need to ensure the per-subchart target
+  #   namespaces exist (Helm only auto-creates the release namespace,
+  #   not the override targets).
+
+  echo "⏳ Ensuring per-subchart target namespaces exist..."
+  kubectl create namespace istio-system --dry-run=client -o yaml | kubectl apply -f -
+  kubectl create namespace "${KEDA_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
+
+  echo "=== Installing productionstack umbrella chart ==="
+  echo "    body-based-routing → istio-system (BBR ${BBR_VERSION})"
+  echo "    keda-kaito-scaler  → ${KEDA_NAMESPACE} (vendored ${KEDA_KAITO_SCALER_VERSION})"
+  helm upgrade --install productionstack "${PRODUCTIONSTACK_CHART_DIR}" \
+    --namespace kaito-system \
+    --create-namespace \
+    --set body-based-routing.enabled=true \
+    --set body-based-routing.namespaceOverride=istio-system \
+    --set keda-kaito-scaler.enabled=true \
+    --set keda-kaito-scaler.namespaceOverride="${KEDA_NAMESPACE}" \
+    --wait --timeout=300s
 
   echo "⏳ Waiting for BBR..."
   kubectl -n istio-system rollout status deployment/body-based-router --timeout=120s 2>/dev/null || \
     kubectl -n istio-system wait --for=condition=ready pod -l app=body-based-router --timeout=120s 2>/dev/null || \
     echo "⚠️  BBR not ready yet — continuing."
 
-  # Strip `spec.targetRefs` from the rendered EnvoyFilter.
-  #
-  # The fork's chart hard-codes a `targetRefs` block pointing at a single
-  # Gateway named `inference-gateway` in the EnvoyFilter's own namespace
-  # (`istio-system`). Istio's EnvoyFilter `targetRefs` is namespace-local
-  # (no `namespace` field), so the filter never attaches to:
-  #   - the cluster-wide `inference-gateway` Gateway in `default`, nor
-  #   - the per-case e2e Gateways provisioned in isolated namespaces
-  #     (e.g., `e2e-prefix-cache`, `e2e-auth`, `e2e-gpu-mocker`, …).
-  # The BBR ext_proc filter therefore never runs, `x-gateway-model-name`
-  # is never injected, and every model-name-based HTTPRoute falls through
-  # to the catch-all `model-not-found` Service — surfaced in tests as
-  # `404 model_not_found` from the gateway.
-  #
-  # Removing `spec.targetRefs` lets Istio fan the filter out cluster-wide;
-  # combined with the chart's existing `match.context: GATEWAY`, this
-  # restores the previous "applies to every Istio-managed gateway, no
-  # sidecars" behavior. Run as a JSON Patch `remove` (idempotent guarded
-  # with `|| true` so subsequent reinstalls don't fail).
-  echo "⏳ Removing spec.targetRefs from body-based-router EnvoyFilter so it applies to all gateways..."
-  kubectl -n istio-system patch envoyfilter body-based-router --type=json \
-    -p='[{"op":"remove","path":"/spec/targetRefs"}]' 2>/dev/null || \
-    echo "⚠️  Failed to remove targetRefs from body-based-router EnvoyFilter (may already be removed)."
+  echo "⏳ Waiting for keda-kaito-scaler..."
+  kubectl -n "${KEDA_NAMESPACE}" rollout status deployment -l app.kubernetes.io/name=keda-kaito-scaler --timeout=180s || true
 }
 
 install_llm_gateway_auth() {
@@ -451,39 +296,14 @@ install_llm_gateway_auth() {
 
 run_phase phase1-base \
   install_kaito \
-  install_gateway_api_crds \
   install_gwie_crds \
-  install_keda \
-  install_keda_kaito_scaler \
   install_gpu_mocker \
-  prefetch_bbr_chart
+  install_productionstack
 
-run_phase phase2-istio \
-  install_istio
-
-run_phase phase3-istio-filters \
-  install_bbr \
+run_phase phase2-istio-filters \
   install_llm_gateway_auth
 
 echo ""
 echo "✅ All components installed."
 
-# ── Timing summary ────────────────────────────────────────────────────────
-echo ""
-echo "================ install-components.sh timing summary ================"
-TOTAL=0
-for entry in "${PHASE_TIMINGS[@]}"; do
-  name="${entry%%=*}"
-  secs="${entry##*=}"
-  TOTAL=$((TOTAL + secs))
-  printf '  phase  %-30s %s\n' "${name}" "$(fmt_dur "${secs}")"
-done
-printf '  TOTAL  %-30s %s\n' "(sum of phase wall-clocks)" "$(fmt_dur "${TOTAL}")"
-echo ""
-echo "  Per-task wall-clocks (within a parallel phase, the longest task gates the phase):"
-for entry in "${TASK_TIMINGS[@]}"; do
-  name="${entry%%=*}"
-  secs="${entry##*=}"
-  printf '    %-50s %s\n' "${name}" "$(fmt_dur "${secs}")"
-done
-echo "======================================================================"
+print_timing_summary "install-components.sh timing summary"

--- a/hack/e2e/scripts/lib-parallel.sh
+++ b/hack/e2e/scripts/lib-parallel.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# lib-parallel.sh — Common parallel-install helpers for E2E scripts.
+#
+# Sourced by hack/e2e/scripts/setup-cluster.sh and
+# hack/e2e/scripts/install-components.sh. Provides:
+#
+#   fmt_dur <seconds>            — human-friendly duration formatter
+#   run_phase <name> <fn>...     — run a list of shell functions in
+#                                  parallel (or sequentially when
+#                                  INSTALL_PARALLEL=0 or a single task),
+#                                  capture per-task logs, aggregate
+#                                  output at the end, and record
+#                                  timings in PHASE_TIMINGS / TASK_TIMINGS.
+#
+# Callers must source this file BEFORE invoking run_phase. INSTALL_PARALLEL
+# defaults to 1 (parallel on); set to 0 for sequential debugging.
+# ---------------------------------------------------------------------------
+
+# Guard against double-sourcing so the trap / arrays survive re-source.
+if [[ "${__E2E_LIB_PARALLEL_SOURCED:-}" == "1" ]]; then
+  return 0
+fi
+__E2E_LIB_PARALLEL_SOURCED=1
+
+INSTALL_PARALLEL="${INSTALL_PARALLEL:-1}"
+
+# Per-process scratch dir for parallel-task logs. Cleaned up on shell exit.
+LIB_PARALLEL_LOGDIR="$(mktemp -d -t e2e-parallel-XXXXXX)"
+trap 'rm -rf "${LIB_PARALLEL_LOGDIR}"' EXIT
+
+# Public timing arrays. Callers may print these at end-of-run.
+PHASE_TIMINGS=()  # "<phase-name>=<seconds>"
+TASK_TIMINGS=()   # "<phase-name>/<task>=<seconds>"
+
+# ── fmt_dur ───────────────────────────────────────────────────────────────
+# Format an elapsed-seconds count as a human-friendly duration.
+fmt_dur() {
+  local s="$1"
+  if (( s < 60 )); then
+    printf '%ds' "${s}"
+  else
+    printf '%dm%02ds' "$((s/60))" "$((s%60))"
+  fi
+}
+
+# ── run_phase ─────────────────────────────────────────────────────────────
+# Run a list of zero-arg shell functions in parallel and aggregate logs.
+# Usage: run_phase <phase-name> <fn1> <fn2> ...
+#
+# Sequential fallback is taken when INSTALL_PARALLEL!=1 OR the phase has
+# only a single task (no point forking + buffering for one task).
+run_phase() {
+  local phase="$1"; shift
+  local phase_dir="${LIB_PARALLEL_LOGDIR}/${phase}"
+  mkdir -p "${phase_dir}"
+  local phase_start=${SECONDS}
+
+  if [[ "${INSTALL_PARALLEL}" != "1" || $# -le 1 ]]; then
+    # Sequential fallback (or single-task phase): stream output directly.
+    for fn in "$@"; do
+      echo ""
+      echo "── [${phase}] ${fn} ──"
+      local task_start=${SECONDS}
+      "${fn}"
+      local task_dur=$((SECONDS - task_start))
+      TASK_TIMINGS+=("${phase}/${fn}=${task_dur}")
+      echo "  ⏱  [${phase}] ${fn} took $(fmt_dur "${task_dur}")"
+    done
+    PHASE_TIMINGS+=("${phase}=$((SECONDS - phase_start))")
+    echo ""
+    echo "⏱  Phase '${phase}' total: $(fmt_dur "$((SECONDS - phase_start))")"
+    return 0
+  fi
+
+  echo ""
+  echo "── [${phase}] launching $# tasks in parallel: $* ──"
+  local pids=() names=() task_starts=()
+  for fn in "$@"; do
+    local task_start=${SECONDS}
+    (
+      set -e
+      "${fn}"
+    ) >"${phase_dir}/${fn}.log" 2>&1 &
+    pids+=($!)
+    names+=("${fn}")
+    task_starts+=("${task_start}")
+  done
+
+  local rc=0
+  local failed=()
+  for i in "${!pids[@]}"; do
+    if wait "${pids[$i]}"; then
+      local d=$((SECONDS - task_starts[i]))
+      echo "  ✅ [${phase}] ${names[$i]} ($(fmt_dur "${d}"))"
+      TASK_TIMINGS+=("${phase}/${names[$i]}=${d}")
+    else
+      local d=$((SECONDS - task_starts[i]))
+      echo "  ❌ [${phase}] ${names[$i]} ($(fmt_dur "${d}"))"
+      TASK_TIMINGS+=("${phase}/${names[$i]}=${d}")
+      failed+=("${names[$i]}")
+      rc=1
+    fi
+  done
+
+  # Always replay logs so users can see what each parallel task did.
+  for n in "${names[@]}"; do
+    echo ""
+    echo "────── [${phase}] ${n} log ──────"
+    cat "${phase_dir}/${n}.log"
+  done
+
+  local phase_dur=$((SECONDS - phase_start))
+  PHASE_TIMINGS+=("${phase}=${phase_dur}")
+  echo ""
+  echo "⏱  Phase '${phase}' total: $(fmt_dur "${phase_dur}") (longest task gates this phase)"
+
+  if [[ $rc -ne 0 ]]; then
+    echo ""
+    echo "❌ Phase '${phase}' failed: ${failed[*]}"
+  fi
+  return "${rc}"
+}
+
+# ── print_timing_summary ──────────────────────────────────────────────────
+# Print a wall-clock summary of every phase + task recorded so far in
+# PHASE_TIMINGS / TASK_TIMINGS. Intended to be called once at end-of-run.
+# Usage: print_timing_summary <title>
+print_timing_summary() {
+  local title="${1:-timing summary}"
+  echo ""
+  echo "================ ${title} ================"
+  local total=0 entry name secs
+  for entry in "${PHASE_TIMINGS[@]}"; do
+    name="${entry%%=*}"
+    secs="${entry##*=}"
+    total=$((total + secs))
+    printf '  phase  %-30s %s\n' "${name}" "$(fmt_dur "${secs}")"
+  done
+  printf '  TOTAL  %-30s %s\n' "(sum of phase wall-clocks)" "$(fmt_dur "${total}")"
+  echo ""
+  echo "  Per-task wall-clocks (within a parallel phase, the longest task gates the phase):"
+  for entry in "${TASK_TIMINGS[@]}"; do
+    name="${entry%%=*}"
+    secs="${entry##*=}"
+    printf '    %-50s %s\n' "${name}" "$(fmt_dur "${secs}")"
+  done
+  echo "======================================================================"
+}

--- a/hack/e2e/scripts/setup-cluster.sh
+++ b/hack/e2e/scripts/setup-cluster.sh
@@ -8,14 +8,22 @@
 # measured in isolation.
 #
 # Environment variables (all required unless defaults are acceptable):
-#   RESOURCE_GROUP   — Azure resource group name  (default: kaito-rg)
-#   CLUSTER_NAME     — AKS cluster name           (default: kaito-aks)
-#   ACR_NAME         — ACR registry name           (default: <cluster_name>acr, sanitized)
-#   LOCATION         — Azure region               (default: australiaeast)
-#   NODE_COUNT       — Number of worker nodes      (default: 2)
-#   NODE_VM_SIZE     — VM SKU for the node pool    (default: Standard_D8s_v5)
+#   RESOURCE_GROUP        — Azure resource group name  (default: kaito-rg)
+#   CLUSTER_NAME          — AKS cluster name           (default: kaito-aks)
+#   ACR_NAME              — ACR registry name           (default: <cluster_name>acr, sanitized)
+#   LOCATION              — Azure region               (default: australiaeast)
+#   NODE_COUNT            — Number of worker nodes      (default: 2)
+#   NODE_VM_SIZE          — VM SKU for the node pool    (default: Standard_D8s_v5)
+#   E2E_PROVIDER          — upstream|azure              (default: upstream)
+#   GATEWAY_API_VERSION   — Gateway API CRD version    (sourced from versions.env)
+#   KEDA_VERSION          — KEDA Helm chart version    (sourced from versions.env)
+#   ISTIO_VERSION         — Istio control-plane version (sourced from versions.env)
+#   KEDA_NAMESPACE        — Override the namespace KEDA is installed into
+#                           (derived from E2E_PROVIDER when unset)
 # ---------------------------------------------------------------------------
 set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 RESOURCE_GROUP="${RESOURCE_GROUP:-kaito-rg}"
 CLUSTER_NAME="${CLUSTER_NAME:-kaito-aks}"
@@ -112,7 +120,163 @@ az aks get-credentials \
 echo "=== Waiting for all nodes to be Ready ==="
 kubectl wait --for=condition=ready nodes --all --timeout=300s
 
+# ─────────────────────────────────────────────────────────────────────────
+# Cluster-prep components (KEDA + Gateway API base CRDs + Istio)
+#
+# These pieces sit BETWEEN cluster creation and application install:
+# they are infrastructure prerequisites every E2E run needs, and on AKS
+# some of them are sourced from managed add-ons enabled at cluster-create
+# time (KEDA, base Gateway API CRDs). Installing them here keeps the
+# upstream and azure provider paths converging into the SAME end state
+# before install-components.sh runs — that script is therefore
+# provider-agnostic and never has to branch on E2E_PROVIDER for these
+# components.
+#
+# Per-provider behavior:
+#   azure    → managed KEDA + managed Gateway API CRDs are already
+#              installed by `az aks create --enable-keda
+#              --enable-gateway-api`. We only wait for their controllers
+#              / CRDs to be served. Istio is still installed via
+#              istioctl here.
+#   upstream → install KEDA via Helm into a dedicated `keda` namespace
+#              and apply the upstream Gateway API base CRDs via kubectl.
+#              Istio is installed via istioctl.
+#
+# Istio is installed here (rather than in install-components.sh's
+# phase1-base) so the productionstack umbrella chart — which ships an
+# EnvoyFilter requiring networking.istio.io/v1alpha3 to be Established
+# — can install in parallel with KAITO et al. without racing on the
+# Istio control plane being up.
+#
+# GAIE (Gateway API Inference Extension) CRDs are installed later by
+# install-components.sh in phase1-base — no AKS managed add-on covers
+# them today, and keeping them in install-components.sh lets the apply
+# run in parallel with the KAITO install (which bundles the same CRDs).
+# ─────────────────────────────────────────────────────────────────────────
+
+# Validate the versions required by this section. Defaults can be sourced
+# from versions.env via run-e2e-local.sh / CI before calling this script.
+: "${GATEWAY_API_VERSION:?GATEWAY_API_VERSION is not set. Source versions.env or export it before calling this script.}"
+: "${KEDA_VERSION:?KEDA_VERSION is not set. Source versions.env or export it before calling this script.}"
+: "${ISTIO_VERSION:?ISTIO_VERSION is not set. Source versions.env or export it before calling this script.}"
+
+# Derive KEDA install namespace from provider when not explicitly provided.
+if [[ -z "${KEDA_NAMESPACE:-}" ]]; then
+  case "${E2E_PROVIDER}" in
+    upstream) KEDA_NAMESPACE="keda" ;;
+    azure)    KEDA_NAMESPACE="kube-system" ;;
+  esac
+fi
+export KEDA_NAMESPACE
+
+# Ensure helm is available for the upstream KEDA install. (Prep is done
+# sequentially before fan-out so all parallel tasks see helm on PATH.)
+if ! command -v helm &>/dev/null; then
+  echo "=== Installing helm ==="
+  curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-4 | bash
+fi
+
+# Ensure istioctl is available before fan-out so the parallel install
+# task does not need to download it under a forked subshell.
+if ! command -v istioctl &>/dev/null; then
+  echo "=== Installing istioctl ${ISTIO_VERSION} ==="
+  curl -L https://istio.io/downloadIstio | ISTIO_VERSION="${ISTIO_VERSION}" sh -
+  export PATH="${PWD}/istio-${ISTIO_VERSION}/bin:${PATH}"
+fi
+echo "Using istioctl: $(command -v istioctl)"
+
+# Source the shared run_phase / fmt_dur helpers so KEDA, Gateway API
+# CRDs, and Istio can install concurrently.
+# shellcheck source=lib-parallel.sh
+source "${SCRIPT_DIR}/lib-parallel.sh"
+
+# ── KEDA ──────────────────────────────────────────────────────────────────
+install_keda() {
+  case "${E2E_PROVIDER}" in
+    azure)
+      echo "=== Verifying managed KEDA add-on in ${KEDA_NAMESPACE} ==="
+      kubectl -n "${KEDA_NAMESPACE}" rollout status deployment/keda-operator --timeout=180s || true
+      kubectl -n "${KEDA_NAMESPACE}" rollout status deployment/keda-operator-metrics-apiserver --timeout=180s || true
+      ;;
+    upstream)
+      echo "=== Installing KEDA ${KEDA_VERSION} via Helm into ${KEDA_NAMESPACE} ==="
+      helm repo add kedacore https://kedacore.github.io/charts 2>/dev/null || true
+      helm repo update kedacore
+      helm upgrade --install keda kedacore/keda \
+        --version "${KEDA_VERSION}" \
+        --namespace "${KEDA_NAMESPACE}" \
+        --create-namespace \
+        --wait --timeout=300s
+      echo "⏳ Waiting for KEDA operator..."
+      kubectl -n "${KEDA_NAMESPACE}" rollout status deployment/keda-operator --timeout=180s || true
+      kubectl -n "${KEDA_NAMESPACE}" rollout status deployment/keda-operator-metrics-apiserver --timeout=180s || true
+      ;;
+  esac
+}
+
+# ── Gateway API base CRDs ────────────────────────────────────────────────
+install_gateway_api_crds() {
+  case "${E2E_PROVIDER}" in
+    azure)
+      echo "=== Verifying managed Gateway API CRDs are served ==="
+      # The managed add-on installs the standard-channel CRDs at
+      # cluster-create time. Block briefly in case the install hasn't
+      # propagated yet, then fall back to upstream install if it never does.
+      local served=0
+      for _ in $(seq 1 30); do
+        if kubectl get crd gateways.gateway.networking.k8s.io >/dev/null 2>&1; then
+          echo "  ✅ gateways CRD is served by the managed add-on"
+          served=1
+          break
+        fi
+        sleep 2
+      done
+      if [[ "${served}" -ne 1 ]]; then
+        echo "  ❌ Managed Gateway API CRDs not present after 60s — falling back to upstream install"
+        kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
+      fi
+      ;;
+    upstream)
+      echo "=== Installing Gateway API CRDs ${GATEWAY_API_VERSION} ==="
+      kubectl apply -f "https://github.com/kubernetes-sigs/gateway-api/releases/download/${GATEWAY_API_VERSION}/standard-install.yaml"
+      ;;
+  esac
+}
+
+# GAIE (Gateway API Inference Extension) CRDs are installed by
+# install-components.sh in phase1-base (same for every provider — no
+# AKS managed add-on covers them today). Keeping them there lets the
+# install run in parallel with KAITO, which bundles the same CRDs.
+
+# ── Istio control plane ──────────────────────────────────────────────────
+# Install the istiod control plane (Istio core CRDs + namespace + istiod
+# Deployment) into istio-system. The EnvoyFilter CRD that the
+# productionstack BBR subchart depends on is part of "Istio core" and is
+# therefore Established before istiod's rollout completes.
+install_istio() {
+  echo "=== Installing Istio ${ISTIO_VERSION} ==="
+  istioctl install \
+    --set profile=minimal \
+    --set hub=docker.io/istio \
+    --set tag="${ISTIO_VERSION}" \
+    --set "values.pilot.env.ENABLE_GATEWAY_API_INFERENCE_EXTENSION=true" \
+    -y
+
+  echo "⏳ Waiting for istiod..."
+  kubectl -n istio-system rollout status deployment/istiod --timeout=300s
+}
+
+# Fan out the three independent installs in parallel. They share no
+# runtime state and each writes to a distinct set of API objects, so the
+# longest task gates this phase.
+run_phase cluster-prep \
+  install_keda \
+  install_gateway_api_crds \
+  install_istio
+
 echo ""
 echo "✅ AKS cluster ${CLUSTER_NAME} is ready."
 echo ""
 kubectl get nodes -o wide
+
+print_timing_summary "setup-cluster.sh timing summary"

--- a/test/e2e/cases.go
+++ b/test/e2e/cases.go
@@ -104,6 +104,14 @@ const (
 	// of a single model, fake-node and shadow-pod inventory churn,
 	// background load to assert no 5xx during transitions).
 	CaseScaling = "scaling"
+
+	// CaseFilterOrder covers filter_order_test.go — verifies the Envoy
+	// HTTP filter chain execution order on a per-namespace Gateway:
+	//   ext_authz  →  ext_proc.bbr  →  ext_proc (InferencePool/EPP)  →  router
+	// The case provisions an API-key-enabled deployment so that
+	// ext_authz, BBR, EPP and the catch-all route are all exercised by
+	// the same dataplane.
+	CaseFilterOrder = "filter-order"
 )
 
 // CaseDeployments enumerates the full set of ModelDeploymentValues required
@@ -197,6 +205,22 @@ var CaseDeployments = map[string][]utils.ModelDeploymentValues{
 			Replicas:             1,
 			InstanceType:         "Standard_NV36ads_A10_v5",
 			NetworkPolicyEnabled: true,
+		},
+	},
+	CaseFilterOrder: {
+		{
+			// Auth-enabled deployment so the full Envoy HTTP filter
+			// chain (ext_authz → bbr → ext_proc(EPP) → router) is
+			// materialised on this case's per-namespace Gateway. Two
+			// replicas let the load / endpoint-picker assertions in
+			// filter_order_test.go observe non-trivial routing
+			// decisions across more than one shadow pod.
+			Name:              "filter-order-phi",
+			Namespace:         "e2e-filter-order",
+			Model:             presetPhi,
+			Replicas:          2,
+			InstanceType:      "Standard_NV36ads_A10_v5",
+			AuthAPIKeyEnabled: true,
 		},
 	},
 	CaseScaling: {

--- a/test/e2e/filter_order_test.go
+++ b/test/e2e/filter_order_test.go
@@ -1,0 +1,640 @@
+/*
+Copyright 2026 The KAITO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kaito-project/production-stack/test/e2e/utils"
+)
+
+// Filter execution order tests.
+//
+// What this verifies (and why):
+//
+//	The per-namespace Istio Gateway provisioned by charts/modelharness
+//	must materialise the following Envoy HTTP filter chain on every
+//	inference request:
+//
+//	    envoy.filters.http.ext_authz            (llm-gateway-apikey)
+//	  → envoy.filters.http.ext_proc.bbr          (body-based-routing)
+//	  → envoy.filters.http.ext_proc              (InferencePool/EPP)
+//	  → envoy.filters.http.router                (HTTPRoute → vLLM pod
+//	                                              OR catch-all 404)
+//
+//	If this order ever drifts the regressions are silent: e.g. the
+//	`model-not-found` catch-all silently bypasses ext_authz
+//	(charts/modelharness/templates/envoyfilter-not-found.yaml), or BBR
+//	runs after the InferencePool ext_proc and EPP routing falls through
+//	to round-robin (charts/productionstack/charts/body-based-routing/
+//	values.yaml). Both have shipped at least once in main, so we treat
+//	the order as a property worth its own regression suite.
+//
+//	The case-level deployment (CaseFilterOrder in cases.go) is
+//	auth-enabled so a single namespace exercises every filter in the
+//	chain.
+var _ = Describe("Filter execution order",
+	Ordered, utils.GinkgoLabelFilterOrder, utils.GinkgoLabelSmoke, func() {
+
+		var (
+			ctx          context.Context
+			caseURL      string
+			caseNS       string
+			modelName    string
+			apiKey       string
+			hostHeader   string
+			gatewayLabel string
+		)
+
+		BeforeAll(func() {
+			ctx = context.Background()
+			caseURL = InstallCase(CaseFilterOrder)
+			caseNS = CaseNamespace(CaseFilterOrder)
+			dep := CaseDeployments[CaseFilterOrder][0]
+			modelName = dep.Name
+			hostHeader = caseNS + ".gw.example.com"
+			gatewayLabel = "gateway.networking.k8s.io/gateway-name=" + CaseGatewayName(CaseFilterOrder)
+
+			// Bearer token used by every "happy path" request below. Issued
+			// by the apikey-operator from the APIKey CR rendered by the
+			// modelharness chart (see charts/modelharness/templates/apikey.yaml).
+			Eventually(func() (string, error) {
+				return utils.GetAPIKeyFromSecret(ctx, caseNS)
+			}, 60*time.Second, 2*time.Second).ShouldNot(BeEmpty(),
+				"API key Secret should be created in %s", caseNS)
+			var err error
+			apiKey, err = utils.GetAPIKeyFromSecret(ctx, caseNS)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterAll(func() {
+			UninstallCase(CaseFilterOrder)
+		})
+
+		// sendAuth sends a /v1/chat/completions request with the given
+		// bearer token. Pass "" to omit the Authorization header entirely
+		// (SendChatCompletionWithAuth treats "" as "do not set header").
+		sendAuth := func(model, token string) (*http.Response, error) {
+			return utils.SendChatCompletionWithAuth(caseURL, model, "hello", token, hostHeader)
+		}
+
+		// sendRaw posts an arbitrary body to /v1/chat/completions, optionally
+		// attaching a bearer token. Used by tests that need a malformed body
+		// (missing model field, non-JSON, …) or want to drive the request
+		// without going through SendChatCompletion's JSON marshaller.
+		sendRaw := func(body []byte, contentType, token string) (*http.Response, error) {
+			if err := utils.EnsurePortForwards(); err != nil {
+				return nil, err
+			}
+			url := utils.ResolveGatewayURL(caseURL) + "/v1/chat/completions"
+			req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(body))
+			if err != nil {
+				return nil, err
+			}
+			req.Header.Set("Content-Type", contentType)
+			if token != "" {
+				req.Header.Set("Authorization", "Bearer "+token)
+			}
+			req.Host = hostHeader
+			client := &http.Client{Timeout: utils.HTTPTimeout}
+			return client.Do(req)
+		}
+
+		// ─────────────────────────────────────────────────────────────────
+		// P0 — ext_authz must run before the router (and the catch-all)
+		// ─────────────────────────────────────────────────────────────────
+
+		Context("P0: ext_authz precedes router / catch-all", func() {
+
+			// A1 — Without an Authorization header the response MUST be 401
+			// even when the model is unknown. If the router executed before
+			// ext_authz, the unknown-model request would hit the catch-all
+			// `model-not-found-direct` EnvoyFilter and return 404; that is
+			// exactly the silent-bypass regression called out in
+			// charts/modelharness/templates/envoyfilter-not-found.yaml.
+			It("A1: unauth'd + unknown model returns 401, not 404", func() {
+				Eventually(func() int {
+					resp, err := sendAuth("does-not-exist-model", "")
+					if err != nil {
+						return 0
+					}
+					defer resp.Body.Close()
+					return resp.StatusCode
+				}, 2*time.Minute, 5*time.Second).Should(Equal(http.StatusUnauthorized),
+					"unauth'd request with an unknown model must be rejected by ext_authz (401), not by the catch-all (404)")
+			})
+
+			// A2 — An unauth'd request must NOT reach BBR. We assert this by
+			// snapshotting the BBR pod's log size before and after sending
+			// the unauth'd request, and grep'ing the new log lines for the
+			// unique correlation prompt. BBR's default `body-field-to-header`
+			// plugin logs the extracted model name (at -v=3 which the chart
+			// pins), so any execution would surface in the logs.
+			It("A2: unauth'd request never reaches BBR", func() {
+				clientset, err := utils.GetK8sClientset()
+				Expect(err).NotTo(HaveOccurred())
+
+				bbrNS := "istio-system"
+				bbrPod, err := firstRunningPod(ctx, bbrNS,
+					"app.kubernetes.io/name=body-based-routing")
+				Expect(err).NotTo(HaveOccurred(),
+					"BBR pod should be running in %s", bbrNS)
+
+				before, err := utils.GetPodLogs(clientset, bbrNS, bbrPod, "bbr")
+				Expect(err).NotTo(HaveOccurred())
+				beforeLen := len(before)
+
+				// Use a unique model value so we can grep for it after.
+				needle := fmt.Sprintf("a2-no-bbr-%d", time.Now().UnixNano())
+				resp, err := sendAuth(needle, "")
+				Expect(err).NotTo(HaveOccurred())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+
+				// Give BBR's log writer time to flush — if it would have run.
+				time.Sleep(3 * time.Second)
+
+				after, err := utils.GetPodLogs(clientset, bbrNS, bbrPod, "bbr")
+				Expect(err).NotTo(HaveOccurred())
+				delta := after
+				if len(after) >= beforeLen {
+					delta = after[beforeLen:]
+				}
+				Expect(delta).NotTo(ContainSubstring(needle),
+					"BBR should not have seen the unauth'd request body; found needle %q in new log slice", needle)
+			})
+
+			// B2 — Sanity counter-test for A2: a fully authenticated request
+			// for the same unique model needle must *increase* BBR log
+			// output. Without this, A2 could pass even if BBR was simply
+			// silent.
+			It("A2 sanity: authenticated request DOES exercise BBR", func() {
+				clientset, err := utils.GetK8sClientset()
+				Expect(err).NotTo(HaveOccurred())
+
+				bbrNS := "istio-system"
+				bbrPod, err := firstRunningPod(ctx, bbrNS,
+					"app.kubernetes.io/name=body-based-routing")
+				Expect(err).NotTo(HaveOccurred())
+
+				before, err := utils.GetPodLogs(clientset, bbrNS, bbrPod, "bbr")
+				Expect(err).NotTo(HaveOccurred())
+				beforeLen := len(before)
+
+				// Send a valid request and wait for it to complete.
+				resp, err := sendAuth(modelName, apiKey)
+				Expect(err).NotTo(HaveOccurred())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+
+				time.Sleep(3 * time.Second)
+
+				after, err := utils.GetPodLogs(clientset, bbrNS, bbrPod, "bbr")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(after)).To(BeNumerically(">", beforeLen),
+					"BBR log size should grow after a valid authenticated request (proves the A2 needle-absence is meaningful)")
+			})
+		})
+
+		// ─────────────────────────────────────────────────────────────────
+		// P0 — bbr must run before EPP / router; the full chain must
+		// actually deliver requests to the workload pod (vLLM).
+		// ─────────────────────────────────────────────────────────────────
+
+		Context("P0: bbr precedes EPP, full chain delivers traffic", func() {
+
+			// B2 — Send N valid authenticated requests, then assert that
+			// vLLM's `vllm:request_success_total{model_name=<modelName>}`
+			// (scraped per-pod by ScrapeRequestSuccessTotal) grew by at
+			// least N. This proves: ext_authz allowed the request through →
+			// BBR injected the X-Gateway-Model-Name header → the HTTPRoute
+			// matched on that header → EPP picked a backend → router
+			// forwarded to a real vLLM pod. If BBR ran *after* EPP, the
+			// HTTPRoute would miss and the request would hit the catch-all
+			// 404, never updating vLLM's success counter.
+			const requestCount = 5
+			It("B2: N valid requests increase vLLM request_success_total by ≥N", func() {
+				clientset, err := utils.GetK8sClientset()
+				Expect(err).NotTo(HaveOccurred())
+
+				before, err := utils.ScrapeRequestSuccessTotal(ctx, clientset, caseNS, modelName)
+				Expect(err).NotTo(HaveOccurred())
+
+				for i := 0; i < requestCount; i++ {
+					resp, err := sendAuth(modelName, apiKey)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(resp.StatusCode).To(Equal(http.StatusOK),
+						"valid auth'd request %d should succeed", i)
+					resp.Body.Close()
+				}
+
+				Eventually(func() float64 {
+					after, err := utils.ScrapeRequestSuccessTotal(ctx, clientset, caseNS, modelName)
+					if err != nil {
+						return -1
+					}
+					diff := utils.DiffSnapshots(before, after)
+					return utils.TotalDelta(diff)
+				}, 60*time.Second, 3*time.Second).Should(BeNumerically(">=", float64(requestCount)),
+					"vLLM success counter must grow by ≥%d (proves BBR→EPP→router→pod path ran)", requestCount)
+			})
+
+			// B1 — At least one vLLM shadow pod must have received traffic.
+			// Together with B2 this rules out the failure mode where EPP is
+			// bypassed and the request lands on the catch-all (in which
+			// case the per-pod delta map would be entirely zero).
+			It("B1: at least one shadow pod's per-pod counter increased", func() {
+				clientset, err := utils.GetK8sClientset()
+				Expect(err).NotTo(HaveOccurred())
+
+				before, err := utils.ScrapeRequestSuccessTotal(ctx, clientset, caseNS, modelName)
+				Expect(err).NotTo(HaveOccurred())
+
+				resp, err := sendAuth(modelName, apiKey)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
+				resp.Body.Close()
+
+				Eventually(func() int {
+					after, err := utils.ScrapeRequestSuccessTotal(ctx, clientset, caseNS, modelName)
+					if err != nil {
+						return 0
+					}
+					diff := utils.DiffSnapshots(before, after)
+					active := 0
+					for _, d := range diff {
+						if d > 0 {
+							active++
+						}
+					}
+					return active
+				}, 60*time.Second, 3*time.Second).Should(BeNumerically(">=", 1),
+					"EPP must pick a real pod (at least one shadow pod's success counter grew)")
+			})
+		})
+
+		// ─────────────────────────────────────────────────────────────────
+		// P0 — Static proof of filter chain order via Envoy admin
+		// /config_dump on the Gateway pod.
+		// ─────────────────────────────────────────────────────────────────
+
+		Context("P0: Envoy filter chain order (config_dump)", func() {
+
+			// F1 — Read the HCM's `http_filters` list directly from the
+			// Gateway pod's Envoy admin port and assert the relative order
+			// of the four filters we care about. This is the strongest
+			// possible assertion because it does not depend on any business
+			// request behaviour: it checks the rendered xDS config itself.
+			It("F1: HCM filter order is ext_authz → bbr → ext_proc → router", func() {
+				gwPod, err := firstRunningPod(ctx, caseNS, gatewayLabel)
+				Expect(err).NotTo(HaveOccurred(),
+					"per-namespace Gateway pod should be Running")
+
+				dump, err := kubectlExec(caseNS, gwPod,
+					"curl", "-s", "http://127.0.0.1:15000/config_dump")
+				Expect(err).NotTo(HaveOccurred(),
+					"failed to read Envoy admin /config_dump from %s/%s", caseNS, gwPod)
+
+				filters := extractGatewayHTTPFilterNames(dump)
+				Expect(filters).NotTo(BeEmpty(),
+					"could not parse any HCM http_filters out of /config_dump (first 2k bytes: %s)",
+					truncate(dump, 2000))
+
+				idx := func(prefix string) int {
+					for i, f := range filters {
+						if strings.HasPrefix(f, prefix) {
+							return i
+						}
+					}
+					return -1
+				}
+				authIdx := idx("envoy.filters.http.ext_authz")
+				bbrIdx := idx("envoy.filters.http.ext_proc.bbr")
+				eppIdx := -1
+				// EPP ext_proc is named generically; pick the first
+				// `envoy.filters.http.ext_proc*` that is NOT the BBR one.
+				for i, f := range filters {
+					if strings.HasPrefix(f, "envoy.filters.http.ext_proc") &&
+						!strings.HasPrefix(f, "envoy.filters.http.ext_proc.bbr") {
+						eppIdx = i
+						break
+					}
+				}
+				routerIdx := idx("envoy.filters.http.router")
+
+				Expect(authIdx).To(BeNumerically(">=", 0),
+					"ext_authz must be present on the auth-enabled Gateway; got filters=%v", filters)
+				Expect(bbrIdx).To(BeNumerically(">=", 0),
+					"bbr ext_proc must be present; got filters=%v", filters)
+				Expect(eppIdx).To(BeNumerically(">=", 0),
+					"InferencePool ext_proc must be present; got filters=%v", filters)
+				Expect(routerIdx).To(BeNumerically(">=", 0),
+					"router must be present; got filters=%v", filters)
+
+				Expect(authIdx).To(BeNumerically("<", bbrIdx),
+					"ext_authz must precede BBR (got %v)", filters)
+				Expect(bbrIdx).To(BeNumerically("<", eppIdx),
+					"BBR must precede InferencePool ext_proc (got %v)", filters)
+				Expect(eppIdx).To(BeNumerically("<", routerIdx),
+					"InferencePool ext_proc must precede router (got %v)", filters)
+			})
+		})
+
+		// ─────────────────────────────────────────────────────────────────
+		// P1 — bbr ↔ router interaction, invalid-key + unknown-model
+		// ─────────────────────────────────────────────────────────────────
+
+		Context("P1: catch-all preserves auth, BBR controls header injection", func() {
+
+			// D2 — Invalid bearer token on an unknown model name must
+			// still return 401, not 404. This is the dual of A1: an attacker
+			// supplying an invalid key combined with an unknown model
+			// previously slipped through to the unauthenticated catch-all.
+			It("D2: invalid API key + unknown model returns 401, not 404", func() {
+				Eventually(func() int {
+					resp, err := sendAuth("does-not-exist-model", "invalid-key-12345")
+					if err != nil {
+						return 0
+					}
+					defer resp.Body.Close()
+					return resp.StatusCode
+				}, 60*time.Second, 5*time.Second).Should(Equal(http.StatusUnauthorized),
+					"invalid token + unknown model must be rejected by ext_authz (401), not by catch-all (404)")
+			})
+
+			// E1 — Request body with no `model` field. BBR cannot inject
+			// X-Gateway-Model-Name, the HTTPRoute header match fails, and
+			// the router falls through to the catch-all 404. Because the
+			// request *is* authenticated, the 404 (with the OpenAI-style
+			// `model_not_found` body) proves the chain's BBR-decided header
+			// drove the route choice (the router did NOT run before BBR).
+			It("E1: authed request with missing model field returns 404 model_not_found", func() {
+				body := []byte(`{"messages":[{"role":"user","content":"hello"}]}`)
+				resp, err := sendRaw(body, "application/json", apiKey)
+				Expect(err).NotTo(HaveOccurred())
+				defer resp.Body.Close()
+
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound),
+					"authed request without `model` should fall through to catch-all 404")
+				errResp, err := utils.ParseErrorResponse(resp)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(errResp.ErrorCode()).To(Equal("model_not_found"))
+			})
+		})
+
+		// ─────────────────────────────────────────────────────────────────
+		// P2 — Coverage of secondary properties
+		// ─────────────────────────────────────────────────────────────────
+
+		Context("P2: EPP isolation, catch-all transits BBR, content-type handling", func() {
+
+			// A3 — An unauth'd request must not reach EPP. EPP runs at
+			// --v=1 (see charts/modeldeployment/templates/epp-deployment.yaml)
+			// and logs the inference pool name plus the request model. We
+			// snapshot EPP logs around the unauth'd request and look for
+			// the request-specific needle.
+			It("A3: unauth'd request never reaches the EPP pod", func() {
+				clientset, err := utils.GetK8sClientset()
+				Expect(err).NotTo(HaveOccurred())
+
+				eppPods, err := utils.GetEPPPods(ctx, clientset, modelName, caseNS)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(eppPods).NotTo(BeEmpty())
+				eppPod := eppPods[0].Name
+
+				before, err := utils.GetPodLogs(clientset, caseNS, eppPod, "epp")
+				Expect(err).NotTo(HaveOccurred())
+				beforeLen := len(before)
+
+				needle := fmt.Sprintf("a3-no-epp-%d", time.Now().UnixNano())
+				resp, err := sendAuth(needle, "")
+				Expect(err).NotTo(HaveOccurred())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
+
+				time.Sleep(3 * time.Second)
+
+				after, err := utils.GetPodLogs(clientset, caseNS, eppPod, "epp")
+				Expect(err).NotTo(HaveOccurred())
+				delta := after
+				if len(after) >= beforeLen {
+					delta = after[beforeLen:]
+				}
+				Expect(delta).NotTo(ContainSubstring(needle),
+					"EPP should not have observed the unauth'd request; needle %q surfaced in new log slice", needle)
+			})
+
+			// D3 — Catch-all path is still preceded by BBR (otherwise we
+			// could not maintain the ordering invariant for malformed
+			// requests). Snapshot BBR logs around an authed request for an
+			// unknown model and assert BBR's log grew.
+			It("D3: authed + unknown model still transits BBR (catch-all path)", func() {
+				clientset, err := utils.GetK8sClientset()
+				Expect(err).NotTo(HaveOccurred())
+
+				bbrNS := "istio-system"
+				bbrPod, err := firstRunningPod(ctx, bbrNS,
+					"app.kubernetes.io/name=body-based-routing")
+				Expect(err).NotTo(HaveOccurred())
+
+				before, err := utils.GetPodLogs(clientset, bbrNS, bbrPod, "bbr")
+				Expect(err).NotTo(HaveOccurred())
+				beforeLen := len(before)
+
+				resp, err := sendAuth("d3-unknown-model", apiKey)
+				Expect(err).NotTo(HaveOccurred())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound),
+					"unknown model with valid auth should hit catch-all 404")
+
+				time.Sleep(3 * time.Second)
+
+				after, err := utils.GetPodLogs(clientset, bbrNS, bbrPod, "bbr")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(len(after)).To(BeNumerically(">", beforeLen),
+					"BBR log must grow even for catch-all paths (proves BBR runs before router on every request)")
+			})
+
+			// E2 — Non-JSON Content-Type. BBR's body-field-to-header plugin
+			// (gateway-api-inference-extension) attempts JSON-unmarshal on
+			// every request body regardless of the Content-Type header, so
+			// a syntactically-valid JSON payload with Content-Type=text/plain
+			// still has its `model` field extracted into X-Gateway-Model-Name
+			// and the request routes successfully (HTTP 200). The contract
+			// we care about here is that mismatched Content-Type does not
+			// crash any filter or produce a 5xx — the exact 2xx/4xx outcome
+			// depends on whether BBR can parse the body and is intentionally
+			// not asserted to avoid flaking on filter internals.
+			It("E2: non-JSON Content-Type does not cause 5xx", func() {
+				body := []byte(`{"model":"` + modelName + `","messages":[{"role":"user","content":"hi"}]}`)
+				resp, err := sendRaw(body, "text/plain", apiKey)
+				Expect(err).NotTo(HaveOccurred())
+				defer resp.Body.Close()
+				Expect(resp.StatusCode).To(BeNumerically("<", 500),
+					"non-JSON content-type must not crash any filter (no 5xx)")
+			})
+		})
+	})
+
+// firstRunningPod returns the name of the first Running pod that matches
+// labelSelector in the given namespace. Uses the shared GetK8sClientset
+// so callers don't have to plumb the clientset through.
+func firstRunningPod(ctx context.Context, namespace, labelSelector string) (string, error) {
+	clientset, err := utils.GetK8sClientset()
+	if err != nil {
+		return "", err
+	}
+	pods, err := clientset.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labelSelector,
+		FieldSelector: "status.phase=Running",
+	})
+	if err != nil {
+		return "", fmt.Errorf("list pods in %s with %q: %w", namespace, labelSelector, err)
+	}
+	if len(pods.Items) == 0 {
+		return "", fmt.Errorf("no Running pods in %s match %q", namespace, labelSelector)
+	}
+	return pods.Items[0].Name, nil
+}
+
+// kubectlExec runs `kubectl exec` and returns the combined stdout/stderr.
+// We shell out (rather than using the K8s REST exec subresource) to stay
+// consistent with the rest of this suite which already shells out for
+// port-forward / helm / kubectl operations.
+func kubectlExec(namespace, pod string, command ...string) (string, error) {
+	args := append([]string{"exec", "-n", namespace, pod, "--"}, command...)
+	cmd := exec.Command("kubectl", args...)
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
+	if err := cmd.Run(); err != nil {
+		return out.String(), fmt.Errorf("kubectl %s: %w (output: %s)",
+			strings.Join(args, " "), err, truncate(out.String(), 1000))
+	}
+	return out.String(), nil
+}
+
+// extractGatewayHTTPFilterNames parses an Envoy /config_dump JSON blob and
+// returns the names of HTTP filters configured on the Gateway-context
+// listener (i.e. inbound listener serving Gateway traffic).
+//
+// /config_dump structure (simplified):
+//
+//	{ "configs": [
+//	    { "@type": ".../ListenersConfigDump",
+//	      "dynamic_listeners": [
+//	        { "active_state": {
+//	            "listener": {
+//	              "filter_chains": [
+//	                { "filters": [
+//	                    { "typed_config": {
+//	                        "@type": ".../HttpConnectionManager",
+//	                        "http_filters": [{"name":"..."}, ...] }} ] } ] } } ] } ] }
+//
+// We walk every dynamic_listener and return the first listener that
+// contains at least one ext_authz + ext_proc + router filter (which is
+// the inference-traffic HCM on the Gateway). This avoids hard-coding the
+// listener name (Istio generates a number-suffixed name per Gateway pod).
+func extractGatewayHTTPFilterNames(configDump string) []string {
+	var root struct {
+		Configs []map[string]json.RawMessage `json:"configs"`
+	}
+	if err := json.Unmarshal([]byte(configDump), &root); err != nil {
+		return nil
+	}
+
+	for _, cfg := range root.Configs {
+		raw, ok := cfg["dynamic_listeners"]
+		if !ok {
+			continue
+		}
+		var listeners []struct {
+			ActiveState struct {
+				Listener struct {
+					FilterChains []struct {
+						Filters []struct {
+							TypedConfig struct {
+								Type        string `json:"@type"`
+								HTTPFilters []struct {
+									Name string `json:"name"`
+								} `json:"http_filters"`
+							} `json:"typed_config"`
+						} `json:"filters"`
+					} `json:"filter_chains"`
+				} `json:"listener"`
+			} `json:"active_state"`
+		}
+		if err := json.Unmarshal(raw, &listeners); err != nil {
+			continue
+		}
+		for _, l := range listeners {
+			for _, fc := range l.ActiveState.Listener.FilterChains {
+				for _, f := range fc.Filters {
+					if !strings.Contains(f.TypedConfig.Type, "HttpConnectionManager") {
+						continue
+					}
+					names := make([]string, 0, len(f.TypedConfig.HTTPFilters))
+					for _, hf := range f.TypedConfig.HTTPFilters {
+						names = append(names, hf.Name)
+					}
+					if hasInferenceFilters(names) {
+						return names
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// hasInferenceFilters returns true when the HCM's http_filters list is
+// the one serving inference traffic (i.e. carries both an ext_authz and a
+// router). On Istio Gateway pods there is usually a single dynamic HCM,
+// but we keep the check defensive in case sidecar / metrics listeners
+// also appear in /config_dump.
+func hasInferenceFilters(names []string) bool {
+	var hasAuthz, hasRouter bool
+	for _, n := range names {
+		if strings.HasPrefix(n, "envoy.filters.http.ext_authz") {
+			hasAuthz = true
+		}
+		if strings.HasPrefix(n, "envoy.filters.http.router") {
+			hasRouter = true
+		}
+	}
+	return hasAuthz && hasRouter
+}
+
+// truncate returns s capped at n bytes, with an ellipsis suffix when
+// truncated. Used to keep error messages bounded.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	return s[:n] + "…"
+}

--- a/test/e2e/gpu_mocker_test.go
+++ b/test/e2e/gpu_mocker_test.go
@@ -339,15 +339,40 @@ var _ = Describe("GPU Mocker E2E", Ordered, func() {
 
 				ctx := context.Background()
 
-				// Find a fake node belonging to our case.
-				nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{
-					LabelSelector: "kaito.sh/fake-node=true,kaito.sh/managed-by=gpu-mocker",
+				// Find a fake node hosting one of THIS case's original pods.
+				// Fake nodes are cluster-scoped, so picking any fake node by
+				// label alone (kaito.sh/fake-node=true) can target a node that
+				// belongs to a different test case running in parallel — the
+				// subsequent NodeClaim deletion would then disrupt that case's
+				// pods (e.g. evicting a routing-phi inference pod) and surface
+				// as flaky failures in unrelated specs (load distribution,
+				// shadow pod GC). Scoping the target to a node that hosts a
+				// pod in caseNamespace guarantees isolation between cases.
+				deploymentName := caseDeployments[0].Name
+				pods, err := clientset.CoreV1().Pods(caseNamespace).List(ctx, metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("inferenceset.kaito.sh/created-by=%s", deploymentName),
 				})
 				Expect(err).NotTo(HaveOccurred())
-				Expect(nodes.Items).NotTo(BeEmpty(), "need at least one fake node")
+				Expect(pods.Items).NotTo(BeEmpty(),
+					"need at least one original pod in %s for deployment %q", caseNamespace, deploymentName)
 
-				// Pick the first fake node and find its owning NodeClaim.
-				targetNode := nodes.Items[0]
+				var targetNodeName string
+				for _, p := range pods.Items {
+					if strings.HasPrefix(p.Spec.NodeName, "fake-") {
+						targetNodeName = p.Spec.NodeName
+						break
+					}
+				}
+				Expect(targetNodeName).NotTo(BeEmpty(),
+					"no original pod for %q is scheduled on a fake- node yet", deploymentName)
+
+				targetNode, err := clientset.CoreV1().Nodes().Get(ctx, targetNodeName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred(), "fake node %q should exist", targetNodeName)
+				Expect(targetNode.Labels).To(HaveKeyWithValue("kaito.sh/fake-node", "true"),
+					"node %q should be a fake node", targetNodeName)
+				Expect(targetNode.Labels).To(HaveKeyWithValue("kaito.sh/managed-by", "gpu-mocker"),
+					"node %q should be managed by gpu-mocker", targetNodeName)
+
 				var ncName string
 				for _, ref := range targetNode.OwnerReferences {
 					if ref.Kind == "NodeClaim" {

--- a/test/e2e/modeldeployment_chart_test.go
+++ b/test/e2e/modeldeployment_chart_test.go
@@ -154,10 +154,14 @@ var _ = Describe("ModelDeployment Chart", utils.GinkgoLabelInferenceSet, func() 
 			Expect(ok).To(BeTrue())
 			Expect(parentRef["name"]).To(Equal(gatewayName))
 
-			// Verify the HTTPRoute matches the deploymentName in the
-			// X-Gateway-Model-Name header (this is what user requests carry
-			// in their `model` field). Multiple deployments of the same
-			// preset can coexist in a namespace under distinct deploymentNames.
+			// Verify the HTTPRoute matches the deploymentName in either the
+			// X-Gateway-Model-Name header (BBR-injected routed-model header,
+			// what user requests carry in their `model` field) or the
+			// X-Gateway-Base-Model-Name header (used for adapter / LoRA
+			// requests where the client-visible model differs from the
+			// underlying base). The two match entries are OR'd by Gateway
+			// API semantics. Multiple deployments of the same preset can
+			// coexist in a namespace under distinct deploymentNames.
 			rules, found, _ := unstructured.NestedSlice(hr.Object, "spec", "rules")
 			Expect(found).To(BeTrue())
 			Expect(rules).To(HaveLen(1))
@@ -165,15 +169,18 @@ var _ = Describe("ModelDeployment Chart", utils.GinkgoLabelInferenceSet, func() 
 			Expect(ok).To(BeTrue())
 			matches, ok := rule["matches"].([]interface{})
 			Expect(ok).To(BeTrue())
-			Expect(matches).To(HaveLen(1))
-			match := matches[0].(map[string]interface{})
-			headers, ok := match["headers"].([]interface{})
-			Expect(ok).To(BeTrue())
-			Expect(headers).To(HaveLen(1))
-			header := headers[0].(map[string]interface{})
-			Expect(header["name"]).To(Equal("X-Gateway-Model-Name"))
-			Expect(header["value"]).To(Equal(deploymentName),
-				"HTTPRoute header match value should equal the deploymentName, not the preset")
+			Expect(matches).To(HaveLen(2))
+			expectedHeaderNames := []string{"X-Gateway-Model-Name", "X-Gateway-Base-Model-Name"}
+			for i, expectedName := range expectedHeaderNames {
+				match := matches[i].(map[string]interface{})
+				headers, ok := match["headers"].([]interface{})
+				Expect(ok).To(BeTrue())
+				Expect(headers).To(HaveLen(1))
+				header := headers[0].(map[string]interface{})
+				Expect(header["name"]).To(Equal(expectedName))
+				Expect(header["value"]).To(Equal(deploymentName),
+					"HTTPRoute header match value should equal the deploymentName, not the preset")
+			}
 
 			backendRefs, ok := rule["backendRefs"].([]interface{})
 			Expect(ok).To(BeTrue())

--- a/test/e2e/prefix_cache_routing_test.go
+++ b/test/e2e/prefix_cache_routing_test.go
@@ -32,6 +32,23 @@ import (
 // correctly routes requests with the same prefix to the same backend pod,
 // leveraging KV-cache locality for better performance.
 //
+// Prompt length / BlockSizeTokens note:
+//   The EPP prefix-cache-scorer hashes the prompt into fixed-size token
+//   blocks (`BlockSizeTokens`, default 16 — see
+//   sigs.k8s.io/gateway-api-inference-extension/pkg/epp/framework/plugins/
+//   requestcontrol/dataproducer/approximateprefix/types.go).  Only FULL
+//   blocks are recorded in the per-pod LRU index that drives the sticky
+//   routing decision.  Prompts shorter than one block produce zero hashes
+//   and the scorer contributes nothing — routing then falls back to the
+//   queue-scorer / KV-cache-scorer weights and the "sticky pod" assertion
+//   becomes flaky.
+//
+//   Each prompt below is sized to span at least eight full 16-token
+//   blocks (~128 tokens ≈ ~512+ ASCII characters, using the GAIE
+//   averageCharactersPerToken = 4 heuristic) so the scorer always has
+//   multiple block hashes to match on and the sticky-routing assertion
+//   is deterministic.
+//
 // Validation approach:
 //   - Determine which backend pod served a request by scraping per-pod
 //     vllm:request_success_total deltas from shadow pods.
@@ -75,7 +92,16 @@ var _ = Describe("Prefix Cache Aware Routing", Ordered, utils.GinkgoLabelPrefixC
 
 	Context("Same prompt repeated requests", func() {
 		const numRequests = 5
-		const prompt = "Explain quantum computing in simple terms for a beginner audience"
+		// ~700 chars ≈ ~175 tokens ≈ ~11 full 16-token blocks. Well above
+		// the single-block floor required for the prefix-cache-scorer to
+		// produce stable hashes; see the file-level comment.
+		const prompt = "Explain in considerable depth the foundations of quantum computing for a curious beginner. " +
+			"Start with the difference between a classical bit and a quantum bit, then introduce the principles " +
+			"of superposition and entanglement using small concrete examples. Walk through the operation of a " +
+			"single-qubit Hadamard gate, a two-qubit CNOT gate, and explain how these gates compose into circuits " +
+			"that solve problems faster than any classical algorithm. Conclude by surveying real hardware platforms, " +
+			"including superconducting qubits, trapped ions, and photonic systems, and the engineering challenges " +
+			"of decoherence and error correction in current noisy intermediate-scale quantum devices."
 
 		It("should route identical requests to the same backend pod", func() {
 			clientset, err := utils.GetK8sClientset()
@@ -114,7 +140,7 @@ var _ = Describe("Prefix Cache Aware Routing", Ordered, utils.GinkgoLabelPrefixC
 			for pod, delta := range diff {
 				if delta > 0 {
 					Expect(delta).To(BeNumerically("==", float64(numRequests)),
-						"pod %s received %.0f requests, expected all %d (prefix cache should make EPP sticky)", pod, delta, numRequests)
+						"pod %s received %.0f requests, expected all %d (prefix cache should make EPP sticky); full distribution: %v", pod, delta, numRequests, diff)
 					stickyPod = pod
 				}
 			}
@@ -141,8 +167,21 @@ var _ = Describe("Prefix Cache Aware Routing", Ordered, utils.GinkgoLabelPrefixC
 
 	Context("Different prompt categories sticky routing", func() {
 		const numPerCategory = 3
-		const promptA = "Explain quantum computing and the principles of superposition and entanglement in detail"
-		const promptB = "Write a Python function to sort a list using the merge sort algorithm with detailed comments"
+		// promptA and promptB share NO common prefix, so the EPP
+		// prefix-cache-scorer must steer each category to a different pod.
+		// Each is sized to span ~9 full 16-token blocks (~570+ chars).
+		const promptA = "Write a comprehensive Python implementation of the merge sort algorithm with detailed inline " +
+			"commentary. The function must accept a list of integers, recursively split it in halves until " +
+			"singleton sublists remain, then merge the halves back together while preserving sort order. " +
+			"Include explicit handling for empty and single-element inputs, a suite of unit tests covering " +
+			"already sorted, reverse sorted, and uniformly random inputs, and a short paragraph at the end " +
+			"that analyses the time and space complexity using big-O notation."
+		const promptB = "Describe the historical development of the special theory of relativity, starting with the " +
+			"Michelson and Morley aether-drift experiment of 1887 and ending with Albert Einstein's foundational " +
+			"1905 paper. Explain how the postulate that the vacuum speed of light is the same in every inertial " +
+			"frame forces a re-examination of simultaneity, gives rise to the phenomena of time dilation and " +
+			"length contraction, and unifies three-dimensional space with one-dimensional time into a single " +
+			"four-dimensional spacetime manifold."
 
 		It("should route each category to a consistent pod", func() {
 			clientset, err := utils.GetK8sClientset()
@@ -176,7 +215,7 @@ var _ = Describe("Prefix Cache Aware Routing", Ordered, utils.GinkgoLabelPrefixC
 				}
 			}
 			Expect(podA).NotTo(BeEmpty(),
-				"category A should be sticky — one pod should have received all %d requests", numPerCategory)
+				"category A should be sticky — one pod should have received all %d requests; full distribution: %v", numPerCategory, diffA)
 
 			By(fmt.Sprintf("sending category B prompt %d times", numPerCategory))
 			beforeB, err := utils.ScrapeRequestSuccessTotal(ctx, clientset, caseNamespace, model)
@@ -202,7 +241,7 @@ var _ = Describe("Prefix Cache Aware Routing", Ordered, utils.GinkgoLabelPrefixC
 				}
 			}
 			Expect(podB).NotTo(BeEmpty(),
-				"category B should be sticky — one pod should have received all %d requests", numPerCategory)
+				"category B should be sticky — one pod should have received all %d requests; full distribution: %v", numPerCategory, diffB)
 
 			By("checking prefix cache hits on each sticky pod")
 			afterCacheHits, err := utils.ScrapeModelMetric(ctx, clientset, caseNamespace, model, "vllm:prefix_cache_hits")
@@ -218,7 +257,14 @@ var _ = Describe("Prefix Cache Aware Routing", Ordered, utils.GinkgoLabelPrefixC
 	})
 
 	Context("Pod deletion fallback", utils.GinkgoLabelNightly, func() {
-		const prompt = "Explain the theory of relativity and its implications for modern physics"
+		// ~590 chars ≈ ~9 full 16-token blocks; see file-level comment for
+		// the prompt-length rationale.
+		const prompt = "Outline the major scientific revolutions of the twentieth century in chronological order. " +
+			"Begin with the introduction of relativity, then the development of quantum mechanics, the discovery " +
+			"of the double-helix structure of DNA, the formulation of the standard model of particle physics, " +
+			"the experimental confirmation of plate tectonics, and conclude with the sequencing of the human " +
+			"genome. For each revolution, summarise the key experiments that drove the paradigm shift and " +
+			"identify the principal scientists involved."
 
 		It("should re-route to another pod when the sticky pod is deleted", func() {
 			clientset, err := utils.GetK8sClientset()

--- a/test/e2e/utils/ginkgo.go
+++ b/test/e2e/utils/ginkgo.go
@@ -57,4 +57,10 @@ var (
 	// GinkgoLabelAntiFlapping marks anti-flapping tests that verify KEDA
 	// does not oscillate replicas near the threshold or during cooldown.
 	GinkgoLabelAntiFlapping = g.Label("AntiFlapping")
+
+	// GinkgoLabelFilterOrder marks tests that verify the Envoy HTTP
+	// filter chain execution order on the per-namespace Gateway:
+	//   ext_authz → ext_proc.bbr → ext_proc (InferencePool/EPP) → router
+	// See test/e2e/filter_order_test.go for the test matrix.
+	GinkgoLabelFilterOrder = g.Label("FilterOrder")
 )


### PR DESCRIPTION
    Chart packaging:
    - Add charts/productionstack umbrella chart bundling body-based-routing
      and keda-kaito-scaler as in-tree subcharts.
    - charts/productionstack/charts/body-based-routing: anchor BBR's
      EnvoyFilter on `envoy.filters.http.ext_proc` (the InferencePool
      ext_proc Istio injects per Gateway) with INSERT_BEFORE, so the final
      HCM chain is `… → bbr → ext_proc(EPP) → … → router`. The previous
      router-anchored placement let the InferencePool ext_proc run before
      BBR, which silently fell back to `cluster: dummy` (a no-op) on every
      request and bypassed EPP entirely — breaking prefix-cache /
      KV-cache / queue-aware routing. Rationale + regression test pointer
      inlined in the chart values.
    - charts/modeldeployment HTTPRoute: also match X-Gateway-Base-Model-Name
      (OR'd with X-Gateway-Model-Name) so adapter/LoRA requests route to
      the same InferencePool.
    - charts/modeldeployment defaults: replicas 2→1, maxReplicas 5→3.

    Install scripts:
    - hack/e2e/scripts/install-components.sh: replace install_bbr +
      install_keda_kaito_scaler with a single install_productionstack
      helm release using per-subchart namespaceOverride. Drop the
      now-redundant install_gateway_api_crds and install_keda functions.
    - hack/e2e/scripts/setup-cluster.sh: install KEDA (helm/upstream or
      managed/azure) and the base Gateway API CRDs so both providers
      converge on the same prerequisite state before install-components.sh
      runs. GAIE CRDs stay in install-components.sh's phase1-base.
    - Makefile: thread E2E_CLUSTER_NAME / E2E_RESOURCE_GROUP into
      `make e2e-teardown` so teardown targets the same cluster the rest of
      the e2e-* targets created (previously teardown silently fell back to
      defaults).

    E2E coverage:
    - test/e2e/filter_order_test.go (new): regression suite that pins the
      Gateway HCM filter chain order
      `ext_authz → bbr → ext_proc(EPP) → router` via three independent
      signals — HTTP status code (unauth + unknown-model returns 401, not
      catch-all 404), BBR/EPP pod-log snapshots (unauth requests never
      reach BBR or EPP), and a direct Envoy `/config_dump` parse on the
      Gateway pod (static xDS proof). Covers P0/P1/P2 of the agreed
      matrix and adds the new CaseFilterOrder + GinkgoLabelFilterOrder.
    - test/e2e/prefix_cache_routing_test.go: lengthen every prompt to span
      ≥ 8 full BlockSizeTokens=16 token blocks (vLLM / GAIE default) so
      the EPP prefix-cache-scorer has multiple block hashes to match on
      and sticky-routing assertions become deterministic. File-level
      comment documents the prompt-length / block-size relationship.

    README:
    - Document the umbrella chart in the cluster-addons table.
   
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
