### PR TITLE
Generate E2E coverage report

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -178,6 +178,25 @@ jobs:
         env:
           E2E_LABEL: "Nightly && !NetworkPolicy"
 
+      - name: Generate E2E coverage report
+        if: always()
+        run: |
+          go run ./hack/e2e/report \
+            --label-filter 'Nightly && !NetworkPolicy' \
+            --workflow 'E2E tests (nightly, full suite)' \
+            --output-md e2e-coverage-report.md \
+            --output-html e2e-coverage-report.html
+          cat e2e-coverage-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload E2E coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-coverage-report
+          path: |
+            e2e-coverage-report.md
+            e2e-coverage-report.html
+
       - name: Dump cluster state
         if: failure()
         run: make e2e-dump

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -95,6 +95,25 @@ jobs:
         env:
           E2E_LABEL: "!Nightly && !NetworkPolicy"
 
+      - name: Generate E2E coverage report
+        if: always()
+        run: |
+          go run ./hack/e2e/report \
+            --label-filter '!Nightly && !NetworkPolicy' \
+            --workflow 'E2E tests' \
+            --output-md e2e-coverage-report.md \
+            --output-html e2e-coverage-report.html
+          cat e2e-coverage-report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload E2E coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-coverage-report
+          path: |
+            e2e-coverage-report.md
+            e2e-coverage-report.html
+
       - name: Dump cluster state
         if: failure()
         run: make e2e-dump

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ config/
 # Coverage reports
 coverage.out
 coverage.html
+e2e-coverage-report.html
+e2e-report-preview.html
+e2e-summary-preview.md
 
 # Local development
 .env

--- a/hack/e2e/report/main.go
+++ b/hack/e2e/report/main.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 The KAITO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// generate-e2e-report parses Ginkgo E2E test source files and produces
+// Markdown + HTML coverage reports for GitHub Actions.
+//
+// Usage:
+//
+//	go run ./hack/e2e/report [flags]
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Block represents a single Ginkgo Describe, Context, or It block.
+type Block struct {
+	Type   string // "Describe", "Context", or "It"
+	Title  string
+	Labels []string
+}
+
+// TestFile collects all parsed blocks from a single *_test.go file.
+type TestFile struct {
+	Name         string
+	Blocks       []Block
+	TestCount    int // number of It blocks
+	SuiteCount   int // number of Describe blocks
+	ContextCount int // number of Context blocks
+}
+
+func main() {
+	labelFilter := flag.String("label-filter", "(all)", "Ginkgo label filter shown in report header")
+	outputMD := flag.String("output-md", "e2e-coverage-report.md", "path for Markdown output")
+	outputHTML := flag.String("output-html", "e2e-coverage-report.html", "path for HTML output")
+	workflow := flag.String("workflow", "", "GitHub Actions workflow name")
+	flag.Parse()
+
+	repoRoot, err := findRepoRoot()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	e2eDir := filepath.Join(repoRoot, "test", "e2e")
+
+	labelMap := parseLabelConstants(filepath.Join(e2eDir, "utils", "ginkgo.go"))
+	files := parseTestFiles(e2eDir, labelMap)
+
+	data := buildReportData(files, *workflow, *labelFilter)
+
+	if err := writeMarkdown(data, *outputMD); err != nil {
+		fmt.Fprintf(os.Stderr, "markdown: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("✅ Markdown report → %s\n", *outputMD)
+
+	if err := writeHTML(data, *outputHTML); err != nil {
+		fmt.Fprintf(os.Stderr, "html: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("✅ HTML report  → %s\n", *outputHTML)
+}
+
+// findRepoRoot walks up from the working directory until it finds go.mod.
+func findRepoRoot() (string, error) {
+	dir, err := os.Getwd()
+	if err != nil {
+		return "", err
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir, nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", fmt.Errorf("could not find go.mod in any parent directory")
+		}
+		dir = parent
+	}
+}

--- a/hack/e2e/report/parser.go
+++ b/hack/e2e/report/parser.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The KAITO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"bufio"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+var (
+	// Matches: GinkgoLabelFoo = g.Label("Foo")
+	labelConstRe = regexp.MustCompile(`(\w+)\s*=\s*\w+\.Label\("([^"]+)"\)`)
+	// Matches: Describe("title" | Context("title" | It("title"
+	blockRe = regexp.MustCompile(`(Describe|Context|It)\("([^"]+)"`)
+	// Matches: utils.GinkgoLabelFoo
+	utilsLabelRe = regexp.MustCompile(`utils\.(GinkgoLabel\w+)`)
+	// Matches: Label("Foo")
+	inlineLabelRe = regexp.MustCompile(`Label\("([^"]+)"\)`)
+)
+
+// parseLabelConstants reads utils/ginkgo.go and returns a map from
+// Go constant name (e.g. "GinkgoLabelSmoke") to label string (e.g. "Smoke").
+func parseLabelConstants(path string) map[string]string {
+	m := make(map[string]string)
+	f, err := os.Open(path)
+	if err != nil {
+		return m
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		if matches := labelConstRe.FindStringSubmatch(sc.Text()); matches != nil {
+			m[matches[1]] = matches[2]
+		}
+	}
+	return m
+}
+
+// extractLabels pulls all Ginkgo labels from a single source line.
+// It handles both utils.GinkgoLabelFoo references and inline Label("Foo") calls.
+func extractLabels(line string, labelMap map[string]string) []string {
+	var labels []string
+	seen := make(map[string]bool)
+
+	for _, m := range utilsLabelRe.FindAllStringSubmatch(line, -1) {
+		varName := m[1]
+		display := labelMap[varName]
+		if display == "" {
+			display = strings.TrimPrefix(varName, "GinkgoLabel")
+		}
+		if !seen[display] {
+			labels = append(labels, display)
+			seen[display] = true
+		}
+	}
+
+	for _, m := range inlineLabelRe.FindAllStringSubmatch(line, -1) {
+		lbl := m[1]
+		if !seen[lbl] {
+			labels = append(labels, lbl)
+			seen[lbl] = true
+		}
+	}
+
+	return labels
+}
+
+// parseTestFiles scans every *_test.go file in e2eDir (skipping e2e_test.go)
+// and returns the parsed blocks grouped by file.
+func parseTestFiles(e2eDir string, labelMap map[string]string) []TestFile {
+	matches, _ := filepath.Glob(filepath.Join(e2eDir, "*_test.go"))
+	sort.Strings(matches)
+
+	var files []TestFile
+	for _, path := range matches {
+		name := filepath.Base(path)
+		if name == "e2e_test.go" {
+			continue
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+
+		var blocks []Block
+		tests, suites, contexts := 0, 0, 0
+		sc := bufio.NewScanner(f)
+		for sc.Scan() {
+			line := sc.Text()
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			m := blockRe.FindStringSubmatch(line)
+			if m == nil {
+				continue
+			}
+			// When the block call spans multiple lines (e.g. labels on the
+			// next line), concatenate continuation lines until we see func()
+			// or hit a reasonable limit.
+			full := line
+			for i := 0; i < 5 && !strings.Contains(full, "func()"); i++ {
+				if !sc.Scan() {
+					break
+				}
+				full += " " + strings.TrimSpace(sc.Text())
+			}
+			b := Block{
+				Type:   m[1],
+				Title:  m[2],
+				Labels: extractLabels(full, labelMap),
+			}
+			blocks = append(blocks, b)
+			switch b.Type {
+			case "It":
+				tests++
+			case "Describe":
+				suites++
+			case "Context":
+				contexts++
+			}
+		}
+		f.Close()
+
+		files = append(files, TestFile{
+			Name:         name,
+			Blocks:       blocks,
+			TestCount:    tests,
+			SuiteCount:   suites,
+			ContextCount: contexts,
+		})
+	}
+	return files
+}

--- a/hack/e2e/report/parser_test.go
+++ b/hack/e2e/report/parser_test.go
@@ -1,0 +1,261 @@
+/*
+Copyright 2026 The KAITO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseLabelConstants(t *testing.T) {
+	content := `package utils
+
+import g "github.com/onsi/ginkgo/v2"
+
+var (
+	GinkgoLabelSmoke = g.Label("Smoke")
+	GinkgoLabelAuth  = g.Label("Auth")
+	GinkgoLabelNightly = g.Label("Nightly")
+)
+`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ginkgo.go")
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := parseLabelConstants(path)
+
+	if len(m) != 3 {
+		t.Fatalf("expected 3 labels, got %d: %v", len(m), m)
+	}
+	for k, v := range map[string]string{
+		"GinkgoLabelSmoke":   "Smoke",
+		"GinkgoLabelAuth":    "Auth",
+		"GinkgoLabelNightly": "Nightly",
+	} {
+		if m[k] != v {
+			t.Errorf("expected %s=%q, got %q", k, v, m[k])
+		}
+	}
+}
+
+func TestParseLabelConstants_MissingFile(t *testing.T) {
+	m := parseLabelConstants("/nonexistent/file.go")
+	if len(m) != 0 {
+		t.Fatalf("expected empty map for missing file, got %v", m)
+	}
+}
+
+func TestExtractLabels_UtilsReferences(t *testing.T) {
+	labelMap := map[string]string{
+		"GinkgoLabelSmoke": "Smoke",
+		"GinkgoLabelAuth":  "Auth",
+	}
+
+	labels := extractLabels(
+		`var _ = Describe("Test", Ordered, utils.GinkgoLabelSmoke, utils.GinkgoLabelAuth, func() {`,
+		labelMap,
+	)
+
+	if len(labels) != 2 {
+		t.Fatalf("expected 2 labels, got %d: %v", len(labels), labels)
+	}
+	if labels[0] != "Smoke" || labels[1] != "Auth" {
+		t.Errorf("expected [Smoke Auth], got %v", labels)
+	}
+}
+
+func TestExtractLabels_InlineLabel(t *testing.T) {
+	labels := extractLabels(
+		`It("does stuff", Label("Fast"), func() {`,
+		nil,
+	)
+
+	if len(labels) != 1 || labels[0] != "Fast" {
+		t.Fatalf("expected [Fast], got %v", labels)
+	}
+}
+
+func TestExtractLabels_MixedRefsAndInline(t *testing.T) {
+	labelMap := map[string]string{
+		"GinkgoLabelSmoke": "Smoke",
+	}
+
+	labels := extractLabels(
+		`It("test", utils.GinkgoLabelSmoke, Label("Custom"), func() {`,
+		labelMap,
+	)
+
+	if len(labels) != 2 {
+		t.Fatalf("expected 2 labels, got %d: %v", len(labels), labels)
+	}
+	if labels[0] != "Smoke" || labels[1] != "Custom" {
+		t.Errorf("expected [Smoke Custom], got %v", labels)
+	}
+}
+
+func TestExtractLabels_NoLabels(t *testing.T) {
+	labels := extractLabels(`It("plain test", func() {`, nil)
+	if len(labels) != 0 {
+		t.Fatalf("expected 0 labels, got %d: %v", len(labels), labels)
+	}
+}
+
+func TestExtractLabels_UnknownUtilsRef(t *testing.T) {
+	// When a utils.GinkgoLabelXyz isn't in the map, it should fall back
+	// to stripping the "GinkgoLabel" prefix.
+	labels := extractLabels(
+		`It("test", utils.GinkgoLabelUnknown, func() {`,
+		map[string]string{},
+	)
+
+	if len(labels) != 1 || labels[0] != "Unknown" {
+		t.Fatalf("expected [Unknown], got %v", labels)
+	}
+}
+
+func TestExtractLabels_Dedup(t *testing.T) {
+	labelMap := map[string]string{"GinkgoLabelSmoke": "Smoke"}
+	labels := extractLabels(
+		`It("test", utils.GinkgoLabelSmoke, Label("Smoke"), func() {`,
+		labelMap,
+	)
+
+	if len(labels) != 1 {
+		t.Fatalf("expected 1 label (deduped), got %d: %v", len(labels), labels)
+	}
+}
+
+func TestParseTestFiles_SingleLine(t *testing.T) {
+	dir := t.TempDir()
+	content := `package e2e
+
+import . "github.com/onsi/ginkgo/v2"
+
+var _ = Describe("Suite A", utils.GinkgoLabelSmoke, func() {
+	Context("when ready", func() {
+		It("does thing 1", func() {})
+		It("does thing 2", func() {})
+	})
+})
+`
+	if err := os.WriteFile(filepath.Join(dir, "alpha_test.go"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	labelMap := map[string]string{"GinkgoLabelSmoke": "Smoke"}
+	files := parseTestFiles(dir, labelMap)
+
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	f := files[0]
+	if f.Name != "alpha_test.go" {
+		t.Errorf("expected alpha_test.go, got %s", f.Name)
+	}
+	if f.SuiteCount != 1 {
+		t.Errorf("expected 1 suite, got %d", f.SuiteCount)
+	}
+	if f.ContextCount != 1 {
+		t.Errorf("expected 1 context, got %d", f.ContextCount)
+	}
+	if f.TestCount != 2 {
+		t.Errorf("expected 2 tests, got %d", f.TestCount)
+	}
+	if len(f.Blocks) != 4 {
+		t.Errorf("expected 4 blocks, got %d", len(f.Blocks))
+	}
+	// First block should be the Describe with Smoke label.
+	if len(f.Blocks[0].Labels) != 1 || f.Blocks[0].Labels[0] != "Smoke" {
+		t.Errorf("expected Describe to have [Smoke], got %v", f.Blocks[0].Labels)
+	}
+}
+
+func TestParseTestFiles_MultiLine(t *testing.T) {
+	dir := t.TempDir()
+	content := `package e2e
+
+import . "github.com/onsi/ginkgo/v2"
+
+var _ = Describe("Multi-line Suite",
+	Ordered, utils.GinkgoLabelAuth, utils.GinkgoLabelSmoke, func() {
+	It("test one", func() {})
+})
+`
+	if err := os.WriteFile(filepath.Join(dir, "multi_test.go"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	labelMap := map[string]string{
+		"GinkgoLabelSmoke": "Smoke",
+		"GinkgoLabelAuth":  "Auth",
+	}
+	files := parseTestFiles(dir, labelMap)
+
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	f := files[0]
+	if f.SuiteCount != 1 || f.TestCount != 1 {
+		t.Fatalf("expected 1 suite + 1 test, got %d suites + %d tests", f.SuiteCount, f.TestCount)
+	}
+	// The Describe block should have both labels from the continuation line.
+	desc := f.Blocks[0]
+	if desc.Type != "Describe" {
+		t.Fatalf("expected Describe, got %s", desc.Type)
+	}
+	if len(desc.Labels) != 2 {
+		t.Fatalf("expected 2 labels on multi-line Describe, got %d: %v", len(desc.Labels), desc.Labels)
+	}
+	if desc.Labels[0] != "Auth" || desc.Labels[1] != "Smoke" {
+		t.Errorf("expected [Auth Smoke], got %v", desc.Labels)
+	}
+}
+
+func TestParseTestFiles_SkipsE2ETest(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"e2e_test.go", "real_test.go"} {
+		content := `package e2e
+import . "github.com/onsi/ginkgo/v2"
+var _ = Describe("Suite", func() {
+	It("test", func() {})
+})
+`
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files := parseTestFiles(dir, nil)
+
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file (e2e_test.go skipped), got %d", len(files))
+	}
+	if files[0].Name != "real_test.go" {
+		t.Errorf("expected real_test.go, got %s", files[0].Name)
+	}
+}
+
+func TestParseTestFiles_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	files := parseTestFiles(dir, nil)
+	if len(files) != 0 {
+		t.Fatalf("expected 0 files, got %d", len(files))
+	}
+}

--- a/hack/e2e/report/report.go
+++ b/hack/e2e/report/report.go
@@ -233,8 +233,6 @@ func writeMarkdown(data *ReportData, path string) error {
 	p("| Metric | Count |")
 	p("|--------|------:|")
 	p("| 📄 Test Files | **%d** |", data.TotalFiles)
-	p("| 📋 Suites | **%d** |", data.TotalDescribes)
-	p("| 📂 Contexts | **%d** |", data.TotalContexts)
 	p("| 🧪 Test Cases | **%d** |", data.TotalIts)
 	p("")
 	p("---")
@@ -282,7 +280,7 @@ func writeMarkdown(data *ReportData, path string) error {
 
 	for _, tf := range data.Files {
 		p("<details>")
-		p("<summary><strong>📄 %s</strong> &mdash; %d tests, %d suite(s)</summary>", tf.Name, tf.TestCount, tf.SuiteCount)
+		p("<summary><strong>📄 %s</strong> &mdash; %d tests</summary>", tf.Name, tf.TestCount)
 		p("")
 		for _, b := range tf.Blocks {
 			badges := ""

--- a/hack/e2e/report/report.go
+++ b/hack/e2e/report/report.go
@@ -1,0 +1,336 @@
+/*
+Copyright 2026 The KAITO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	_ "embed"
+	"fmt"
+	"os"
+	"strings"
+	"text/template"
+	"time"
+)
+
+//go:embed template.html
+var htmlTemplateStr string
+
+// ---------------------------------------------------------------------------
+// Data structures for report rendering
+// ---------------------------------------------------------------------------
+
+// ReportData holds all data needed to render both Markdown and HTML reports.
+type ReportData struct {
+	Workflow       string
+	LabelFilter    string
+	Timestamp      string
+	TotalFiles     int
+	TotalDescribes int
+	TotalContexts  int
+	TotalIts       int
+
+	Files         []TestFile
+	BarChart      []BarEntry
+	ConicGradient string
+	DonutLegend   []LegendEntry
+	LabelCards    []LabelCard
+	AllLabels     []string
+}
+
+// BarEntry is one row in the horizontal bar chart.
+type BarEntry struct {
+	Label   string
+	Value   int
+	Percent int
+	Color   string
+}
+
+// LegendEntry is one swatch in the donut chart legend.
+type LegendEntry struct {
+	Label string
+	Color string
+}
+
+// LabelCard is one card in the "Coverage by Label" section.
+type LabelCard struct {
+	Name  string
+	Count int
+	Color string
+}
+
+// ---------------------------------------------------------------------------
+// Label configuration — edit here when adding new Ginkgo labels
+// ---------------------------------------------------------------------------
+
+var orderedLabels = []string{
+	"Smoke", "Infra", "Routing", "Auth",
+	"Scaling", "ScaleUp", "ScaleDown", "AntiFlapping",
+	"FilterOrder", "Nightly", "NetworkPolicy",
+	"PrefixCache", "InferenceSet",
+}
+
+var labelDescriptions = map[string]string{
+	"Smoke":         "Basic sanity checks — every PR",
+	"Infra":         "Infrastructure lifecycle (nodes, pods, GC)",
+	"Routing":       "Gateway / model routing correctness",
+	"Auth":          "API key authentication",
+	"Scaling":       "KEDA-driven scale-up / scale-down",
+	"ScaleUp":       "Scale-up specific assertions",
+	"ScaleDown":     "Scale-down specific assertions",
+	"AntiFlapping":  "Prevents premature re-scaling",
+	"FilterOrder":   "Envoy HTTP filter chain execution order",
+	"Nightly":       "Long-running tests (nightly only)",
+	"NetworkPolicy": "Kubernetes NetworkPolicy enforcement",
+	"PrefixCache":   "Prefix / KV-cache aware routing",
+	"InferenceSet":  "InferenceSet chart lifecycle",
+}
+
+var labelColors = map[string]string{
+	"Smoke":         "#3fb950",
+	"Infra":         "#bc8cff",
+	"Routing":       "#f0883e",
+	"Auth":          "#f85149",
+	"Scaling":       "#39d353",
+	"ScaleUp":       "#39d353",
+	"ScaleDown":     "#39d353",
+	"AntiFlapping":  "#39d353",
+	"FilterOrder":   "#58a6ff",
+	"Nightly":       "#d29922",
+	"NetworkPolicy": "#bc8cff",
+	"PrefixCache":   "#f0883e",
+	"InferenceSet":  "#bc8cff",
+}
+
+var chartColors = []string{
+	"#58a6ff", "#3fb950", "#f85149", "#bc8cff",
+	"#f0883e", "#d29922", "#39d353", "#8b949e",
+	"#79c0ff", "#56d364",
+}
+
+// ---------------------------------------------------------------------------
+// Report data construction
+// ---------------------------------------------------------------------------
+
+func buildReportData(files []TestFile, workflow, labelFilter string) *ReportData {
+	data := &ReportData{
+		Workflow:    workflow,
+		LabelFilter: labelFilter,
+		Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05 UTC"),
+		Files:       files,
+		TotalFiles:  len(files),
+		AllLabels:   orderedLabels,
+	}
+
+	for _, f := range files {
+		data.TotalIts += f.TestCount
+		data.TotalDescribes += f.SuiteCount
+		data.TotalContexts += f.ContextCount
+	}
+
+	// Bar chart data.
+	maxTests := 0
+	for _, f := range files {
+		if f.TestCount > maxTests {
+			maxTests = f.TestCount
+		}
+	}
+
+	cumulative := 0
+	var gradientParts []string
+	for i, f := range files {
+		color := chartColors[i%len(chartColors)]
+		pct := 0
+		if maxTests > 0 {
+			pct = f.TestCount * 100 / maxTests
+		}
+		shortName := strings.TrimSuffix(f.Name, "_test.go")
+
+		data.BarChart = append(data.BarChart, BarEntry{
+			Label:   shortName,
+			Value:   f.TestCount,
+			Percent: pct,
+			Color:   color,
+		})
+
+		// Donut segment.
+		startDeg := 0
+		if data.TotalIts > 0 {
+			startDeg = cumulative * 360 / data.TotalIts
+		}
+		cumulative += f.TestCount
+		endDeg := 0
+		if data.TotalIts > 0 {
+			endDeg = cumulative * 360 / data.TotalIts
+		}
+		gradientParts = append(gradientParts, fmt.Sprintf("%s %ddeg %ddeg", color, startDeg, endDeg))
+		data.DonutLegend = append(data.DonutLegend, LegendEntry{Label: shortName, Color: color})
+	}
+	if len(gradientParts) > 0 {
+		data.ConicGradient = strings.Join(gradientParts, ", ")
+	} else {
+		data.ConicGradient = "var(--bd) 0deg 360deg"
+	}
+
+	// Label card counts.
+	labelCounts := make(map[string]int)
+	for _, lbl := range orderedLabels {
+		labelCounts[lbl] = 0
+	}
+	for _, f := range files {
+		for _, b := range f.Blocks {
+			for _, lbl := range b.Labels {
+				labelCounts[lbl]++
+			}
+		}
+	}
+	for _, lbl := range orderedLabels {
+		data.LabelCards = append(data.LabelCards, LabelCard{
+			Name:  lbl,
+			Count: labelCounts[lbl],
+			Color: labelColors[lbl],
+		})
+	}
+
+	return data
+}
+
+// ---------------------------------------------------------------------------
+// Markdown generation
+// ---------------------------------------------------------------------------
+
+func writeMarkdown(data *ReportData, path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	p := func(format string, a ...interface{}) { fmt.Fprintf(f, format+"\n", a...) }
+
+	p("# ✅ E2E Test Coverage Report")
+	p("")
+	if data.Workflow != "" {
+		p("**Workflow:** %s  ", data.Workflow)
+	}
+	p("**Label filter:** `%s`  ", data.LabelFilter)
+	p("**Generated:** %s", data.Timestamp)
+	p("")
+	p("---")
+	p("")
+	p("| Metric | Count |")
+	p("|--------|------:|")
+	p("| 📄 Test Files | **%d** |", data.TotalFiles)
+	p("| 📋 Suites | **%d** |", data.TotalDescribes)
+	p("| 📂 Contexts | **%d** |", data.TotalContexts)
+	p("| 🧪 Test Cases | **%d** |", data.TotalIts)
+	p("")
+	p("---")
+	p("")
+
+	// Mermaid pie chart — tests per file.
+	p("### 📈 Test Distribution")
+	p("")
+	p("```mermaid")
+	p("pie title Tests by File")
+	for _, entry := range data.BarChart {
+		p("    %q : %d", entry.Label, entry.Value)
+	}
+	p("```")
+	p("")
+
+	// Mermaid bar chart — tests per file.
+	p("### 📊 Tests per File")
+	p("")
+	p("```mermaid")
+	p("xychart-beta horizontal")
+	p("    title \"Tests per File\"")
+	barLabels := make([]string, len(data.BarChart))
+	barValues := make([]string, len(data.BarChart))
+	for i, entry := range data.BarChart {
+		barLabels[i] = fmt.Sprintf("%q", entry.Label)
+		barValues[i] = fmt.Sprintf("%d", entry.Value)
+	}
+	p("    x-axis [%s]", strings.Join(barLabels, ", "))
+	p("    bar [%s]", strings.Join(barValues, ", "))
+	p("```")
+	p("")
+
+	// Label coverage table with counts.
+	p("### 🏷️ Coverage by Label")
+	p("")
+	p("| Label | Blocks | Description |")
+	p("|-------|-------:|-------------|")
+	for _, card := range data.LabelCards {
+		p("| `%s` | **%d** | %s |", card.Name, card.Count, labelDescriptions[card.Name])
+	}
+	p("")
+	p("---")
+	p("")
+
+	for _, tf := range data.Files {
+		p("<details>")
+		p("<summary><strong>📄 %s</strong> &mdash; %d tests, %d suite(s)</summary>", tf.Name, tf.TestCount, tf.SuiteCount)
+		p("")
+		for _, b := range tf.Blocks {
+			badges := ""
+			for _, lbl := range b.Labels {
+				badges += " `" + lbl + "`"
+			}
+			switch b.Type {
+			case "Describe":
+				p("")
+				p("#### ▸ %s%s", b.Title, badges)
+				p("")
+			case "Context":
+				p("**◦ %s**%s", b.Title, badges)
+				p("")
+			case "It":
+				p("- 🟢 %s%s", b.Title, badges)
+			}
+		}
+		p("")
+		p("</details>")
+		p("")
+	}
+
+	p("---")
+	p("")
+	p("_Generated by `go run ./hack/e2e/report` · KAITO Production Stack_")
+
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// HTML generation
+// ---------------------------------------------------------------------------
+
+func writeHTML(data *ReportData, path string) error {
+	funcMap := template.FuncMap{
+		"lower": strings.ToLower,
+	}
+	tmpl, err := template.New("report").Funcs(funcMap).Parse(htmlTemplateStr)
+	if err != nil {
+		return fmt.Errorf("parse template: %w", err)
+	}
+
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return tmpl.Execute(f, data)
+}

--- a/hack/e2e/report/report_test.go
+++ b/hack/e2e/report/report_test.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2026 The KAITO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func sampleFiles() []TestFile {
+	return []TestFile{
+		{
+			Name: "alpha_test.go",
+			Blocks: []Block{
+				{Type: "Describe", Title: "Alpha Suite", Labels: []string{"Smoke", "Infra"}},
+				{Type: "Context", Title: "when running", Labels: nil},
+				{Type: "It", Title: "test 1", Labels: []string{"Smoke"}},
+				{Type: "It", Title: "test 2", Labels: nil},
+			},
+			TestCount:    2,
+			SuiteCount:   1,
+			ContextCount: 1,
+		},
+		{
+			Name: "beta_test.go",
+			Blocks: []Block{
+				{Type: "Describe", Title: "Beta Suite", Labels: []string{"Auth"}},
+				{Type: "It", Title: "test A", Labels: []string{"Auth"}},
+			},
+			TestCount:    1,
+			SuiteCount:   1,
+			ContextCount: 0,
+		},
+	}
+}
+
+func TestBuildReportData_Totals(t *testing.T) {
+	data := buildReportData(sampleFiles(), "CI", "!Nightly")
+
+	if data.Workflow != "CI" {
+		t.Errorf("expected Workflow=CI, got %q", data.Workflow)
+	}
+	if data.LabelFilter != "!Nightly" {
+		t.Errorf("expected LabelFilter=!Nightly, got %q", data.LabelFilter)
+	}
+	if data.TotalFiles != 2 {
+		t.Errorf("expected 2 files, got %d", data.TotalFiles)
+	}
+	if data.TotalDescribes != 2 {
+		t.Errorf("expected 2 describes, got %d", data.TotalDescribes)
+	}
+	if data.TotalContexts != 1 {
+		t.Errorf("expected 1 context, got %d", data.TotalContexts)
+	}
+	if data.TotalIts != 3 {
+		t.Errorf("expected 3 Its, got %d", data.TotalIts)
+	}
+}
+
+func TestBuildReportData_BarChart(t *testing.T) {
+	data := buildReportData(sampleFiles(), "", "")
+
+	if len(data.BarChart) != 2 {
+		t.Fatalf("expected 2 bar entries, got %d", len(data.BarChart))
+	}
+
+	// alpha_test.go has 2 tests (max), so its percent should be 100.
+	if data.BarChart[0].Label != "alpha" {
+		t.Errorf("expected bar[0].Label=alpha, got %q", data.BarChart[0].Label)
+	}
+	if data.BarChart[0].Value != 2 {
+		t.Errorf("expected bar[0].Value=2, got %d", data.BarChart[0].Value)
+	}
+	if data.BarChart[0].Percent != 100 {
+		t.Errorf("expected bar[0].Percent=100, got %d", data.BarChart[0].Percent)
+	}
+
+	// beta_test.go has 1 test → 50%.
+	if data.BarChart[1].Label != "beta" {
+		t.Errorf("expected bar[1].Label=beta, got %q", data.BarChart[1].Label)
+	}
+	if data.BarChart[1].Percent != 50 {
+		t.Errorf("expected bar[1].Percent=50, got %d", data.BarChart[1].Percent)
+	}
+}
+
+func TestBuildReportData_DonutGradient(t *testing.T) {
+	data := buildReportData(sampleFiles(), "", "")
+
+	if data.ConicGradient == "" {
+		t.Fatal("expected non-empty ConicGradient")
+	}
+	if !strings.Contains(data.ConicGradient, "deg") {
+		t.Errorf("expected degree values in gradient, got %q", data.ConicGradient)
+	}
+	if len(data.DonutLegend) != 2 {
+		t.Errorf("expected 2 legend entries, got %d", len(data.DonutLegend))
+	}
+}
+
+func TestBuildReportData_DonutGradient_NoFiles(t *testing.T) {
+	data := buildReportData(nil, "", "")
+
+	if data.ConicGradient != "var(--bd) 0deg 360deg" {
+		t.Errorf("expected fallback gradient, got %q", data.ConicGradient)
+	}
+}
+
+func TestBuildReportData_LabelCards(t *testing.T) {
+	data := buildReportData(sampleFiles(), "", "")
+
+	cardMap := make(map[string]int)
+	for _, c := range data.LabelCards {
+		cardMap[c.Name] = c.Count
+	}
+
+	// Smoke appears on Describe + It = 2 blocks.
+	if cardMap["Smoke"] != 2 {
+		t.Errorf("expected Smoke count=2, got %d", cardMap["Smoke"])
+	}
+	// Auth appears on Describe + It = 2 blocks.
+	if cardMap["Auth"] != 2 {
+		t.Errorf("expected Auth count=2, got %d", cardMap["Auth"])
+	}
+	// Infra appears only on 1 Describe.
+	if cardMap["Infra"] != 1 {
+		t.Errorf("expected Infra count=1, got %d", cardMap["Infra"])
+	}
+	// Routing should be 0.
+	if cardMap["Routing"] != 0 {
+		t.Errorf("expected Routing count=0, got %d", cardMap["Routing"])
+	}
+}
+
+func TestBuildReportData_Timestamp(t *testing.T) {
+	data := buildReportData(nil, "", "")
+
+	if !strings.HasSuffix(data.Timestamp, "UTC") {
+		t.Errorf("expected timestamp ending in UTC, got %q", data.Timestamp)
+	}
+}
+
+func TestWriteMarkdown(t *testing.T) {
+	data := buildReportData(sampleFiles(), "E2E tests", "!Nightly")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.md")
+
+	if err := writeMarkdown(data, path); err != nil {
+		t.Fatalf("writeMarkdown: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	md := string(content)
+
+	checks := []string{
+		"# ✅ E2E Test Coverage Report",
+		"**Workflow:** E2E tests",
+		"**Label filter:** `!Nightly`",
+		"📄 Test Files | **2**",
+		"🧪 Test Cases | **3**",
+		"alpha_test.go",
+		"beta_test.go",
+		"🟢 test 1",
+		"🟢 test A",
+		// Mermaid pie chart.
+		"```mermaid",
+		"pie title Tests by File",
+		`"alpha" : 2`,
+		`"beta" : 1`,
+		// Mermaid bar chart.
+		"xychart-beta horizontal",
+		// Label coverage table.
+		"Coverage by Label",
+		"| `Smoke` | **2**",
+		"| `Auth` | **2**",
+	}
+
+	for _, want := range checks {
+		if !strings.Contains(md, want) {
+			t.Errorf("markdown missing %q", want)
+		}
+	}
+}
+
+func TestWriteMarkdown_NoWorkflow(t *testing.T) {
+	data := buildReportData(sampleFiles(), "", "(all)")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.md")
+
+	if err := writeMarkdown(data, path); err != nil {
+		t.Fatalf("writeMarkdown: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if strings.Contains(string(content), "**Workflow:**") {
+		t.Error("expected no Workflow line when workflow is empty")
+	}
+}
+
+func TestWriteHTML(t *testing.T) {
+	data := buildReportData(sampleFiles(), "Nightly", "Nightly")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.html")
+
+	if err := writeHTML(data, path); err != nil {
+		t.Fatalf("writeHTML: %v", err)
+	}
+
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	html := string(content)
+
+	checks := []string{
+		"<!DOCTYPE html>",
+		"Nightly",
+		"Alpha Suite",
+		"Beta Suite",
+		"conic-gradient",
+	}
+	for _, want := range checks {
+		if !strings.Contains(html, want) {
+			t.Errorf("HTML missing %q", want)
+		}
+	}
+}
+
+func TestWriteHTML_EmptyFiles(t *testing.T) {
+	data := buildReportData(nil, "", "(all)")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.html")
+
+	if err := writeHTML(data, path); err != nil {
+		t.Fatalf("writeHTML should not error with empty files: %v", err)
+	}
+}

--- a/hack/e2e/report/template.html
+++ b/hack/e2e/report/template.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en"><head>
+<meta charset="utf-8"><meta name="viewport" content="width=device-width,initial-scale=1">
+<title>E2E Test Coverage Report</title>
+<style>
+:root{--bg:#0d1117;--sf:#161b22;--bd:#30363d;--tx:#e6edf3;--mt:#8b949e;--ac:#58a6ff;--gn:#3fb950;--yl:#d29922;--rd:#f85149;--pp:#bc8cff;--or:#f0883e;--cy:#39d353}
+*{box-sizing:border-box;margin:0;padding:0}
+body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif;background:var(--bg);color:var(--tx);line-height:1.6;padding:24px 24px 40px}
+.w{max-width:1200px;margin:0 auto}
+.hd-bar{height:3px;background:linear-gradient(90deg,var(--ac),var(--gn),var(--pp),var(--or));border-radius:2px;margin-bottom:20px}
+.hd{display:flex;align-items:center;gap:14px;margin-bottom:28px;padding-bottom:16px;border-bottom:1px solid var(--bd)}
+.hd h1{font-size:24px;font-weight:700}.hd .sb{color:var(--mt);font-size:13px;margin-top:2px}
+.cr{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:24px}
+@media(max-width:640px){.cr{grid-template-columns:repeat(2,1fr)}}
+.cd{background:linear-gradient(135deg,var(--sf) 0%,rgba(22,27,34,.7) 100%);border:1px solid var(--bd);border-radius:12px;padding:18px 20px;text-align:center;position:relative;overflow:hidden}
+.cd::before{content:'';position:absolute;top:0;left:0;right:0;height:2px}
+.cd:nth-child(1)::before{background:linear-gradient(90deg,var(--ac),#79c0ff)}
+.cd:nth-child(2)::before{background:linear-gradient(90deg,var(--pp),#d2a8ff)}
+.cd:nth-child(3)::before{background:linear-gradient(90deg,var(--or),var(--yl))}
+.cd:nth-child(4)::before{background:linear-gradient(90deg,var(--gn),var(--cy))}
+.cd .ic{font-size:22px;margin-bottom:6px}
+.cd .v{font-size:36px;font-weight:800;line-height:1}
+.cd:nth-child(1) .v{color:var(--ac)}.cd:nth-child(2) .v{color:var(--pp)}
+.cd:nth-child(3) .v{color:var(--or)}.cd:nth-child(4) .v{color:var(--gn)}
+.cd .l{font-size:11px;color:var(--mt);text-transform:uppercase;letter-spacing:.8px;margin-top:6px;font-weight:600}
+.br{background:var(--sf);border:1px solid var(--bd);border-radius:8px;padding:10px 16px;margin-bottom:28px;font-size:13px;color:var(--mt);display:flex;gap:20px;flex-wrap:wrap}.br b{color:var(--tx)}
+.charts{display:grid;grid-template-columns:1fr 260px;gap:16px;margin-bottom:28px}
+@media(max-width:768px){.charts{grid-template-columns:1fr}}
+.panel{background:var(--sf);border:1px solid var(--bd);border-radius:12px;padding:20px}
+.panel h3{font-size:12px;text-transform:uppercase;letter-spacing:1px;color:var(--mt);margin-bottom:16px;font-weight:700}
+.bar-row{display:flex;align-items:center;gap:10px;margin-bottom:8px;font-size:12px}
+.bar-label{width:190px;text-overflow:ellipsis;overflow:hidden;white-space:nowrap;color:var(--tx);font-weight:500;font-size:12px}
+.bar-track{flex:1;height:20px;background:rgba(48,54,61,.5);border-radius:4px;overflow:hidden}
+.bar-fill{height:100%;border-radius:4px;display:flex;align-items:center;padding-left:8px;font-size:10px;font-weight:700;color:var(--bg);min-width:24px}
+.bar-val{width:28px;text-align:right;font-weight:700;color:var(--ac);font-size:13px;font-variant-numeric:tabular-nums}
+.donut-wrap{display:flex;flex-direction:column;align-items:center;gap:14px}
+.donut{width:150px;height:150px;border-radius:50%;position:relative}
+.donut-hole{position:absolute;top:50%;left:50%;transform:translate(-50%,-50%);width:86px;height:86px;border-radius:50%;background:var(--sf);display:flex;flex-direction:column;align-items:center;justify-content:center}
+.donut-hole .dv{font-size:28px;font-weight:800;color:var(--ac);line-height:1}
+.donut-hole .dl{font-size:9px;color:var(--mt);text-transform:uppercase;letter-spacing:.5px;margin-top:2px}
+.donut-legend{display:flex;flex-wrap:wrap;gap:4px 10px;justify-content:center}
+.donut-legend-item{display:flex;align-items:center;gap:4px;font-size:10px;color:var(--mt)}
+.donut-legend-item .swatch{width:8px;height:8px;border-radius:2px;flex-shrink:0}
+.lbl-section{margin-bottom:28px}
+.lbl-section h3{font-size:12px;text-transform:uppercase;letter-spacing:1px;color:var(--mt);margin-bottom:14px;font-weight:700}
+.lbl-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(120px,1fr));gap:10px}
+.lbl-card{background:var(--sf);border:1px solid var(--bd);border-radius:10px;padding:14px 10px 12px;text-align:center;position:relative;overflow:hidden;transition:border-color .2s}
+.lbl-card:hover{border-color:var(--ac)}
+.lbl-card .lc-n{font-size:24px;font-weight:800;line-height:1}
+.lbl-card .lc-l{font-size:10px;text-transform:uppercase;letter-spacing:.5px;margin-top:4px;font-weight:600}
+.tree-hd{font-size:12px;text-transform:uppercase;letter-spacing:1px;color:var(--mt);margin-bottom:14px;font-weight:700}
+.fs{background:var(--sf);border:1px solid var(--bd);border-radius:8px;margin-bottom:8px;overflow:hidden}
+.fh{padding:10px 14px;background:rgba(56,139,253,.04);border-bottom:1px solid var(--bd);cursor:pointer;display:flex;align-items:center;gap:8px;user-select:none;font-size:14px}
+.fh:hover{background:rgba(56,139,253,.08)}
+.fh .cv{transition:transform .2s;font-size:11px;color:var(--mt)}.fh.cl .cv{transform:rotate(-90deg)}
+.fh .fn{font-weight:600}.fh .st{margin-left:auto;font-size:12px;color:var(--mt)}
+.fb{padding:0}.fb.hd2{display:none}
+.dh{padding:10px 14px 8px 20px;font-weight:600;font-size:14px;color:var(--pp);border-bottom:1px solid rgba(48,54,61,.5)}
+.cx{padding:8px 14px 6px 36px;font-size:13px;font-weight:600;color:var(--or);border-top:1px solid rgba(48,54,61,.4)}
+.ti{padding:5px 14px 5px 52px;font-size:13px;display:flex;align-items:center;gap:8px;border-top:1px solid rgba(48,54,61,.25)}
+.ti:hover{background:rgba(56,139,253,.04)}
+.ti .dt{width:6px;height:6px;border-radius:50%;background:var(--gn);flex-shrink:0}
+.tg{display:inline-block;font-size:10px;font-weight:500;padding:1px 7px;border-radius:10px;margin-left:3px;vertical-align:middle}
+.t-smoke{background:rgba(63,185,80,.15);border:1px solid rgba(63,185,80,.4);color:var(--gn)}
+.t-infra,.t-networkpolicy,.t-inferenceset{background:rgba(188,140,255,.15);border:1px solid rgba(188,140,255,.4);color:var(--pp)}
+.t-routing,.t-prefixcache{background:rgba(240,136,62,.15);border:1px solid rgba(240,136,62,.4);color:var(--or)}
+.t-auth{background:rgba(248,81,73,.15);border:1px solid rgba(248,81,73,.4);color:var(--rd)}
+.t-nightly{background:rgba(210,153,34,.15);border:1px solid rgba(210,153,34,.4);color:var(--yl)}
+.t-scaling,.t-scaleup,.t-scaledown,.t-antiflapping{background:rgba(57,211,83,.15);border:1px solid rgba(57,211,83,.4);color:var(--cy)}
+.t-shadowpod,.t-filterorder{background:rgba(56,139,253,.15);border:1px solid rgba(56,139,253,.4);color:var(--ac)}
+.lg{margin-top:28px;padding:16px;background:var(--sf);border:1px solid var(--bd);border-radius:10px}
+.lg h3{font-size:12px;margin-bottom:10px;text-transform:uppercase;letter-spacing:1px;color:var(--mt);font-weight:700}
+.lg .gd{display:flex;flex-wrap:wrap;gap:6px}
+.ft{margin-top:24px;text-align:center;font-size:11px;color:var(--mt)}
+</style></head><body>
+<div class="w">
+
+<div class="hd-bar"></div>
+<div class="hd">
+  <svg width="32" height="32" viewBox="0 0 32 32" fill="none"><circle cx="16" cy="16" r="16" fill="#58a6ff"/><path d="M10 16l4 4 8-8" stroke="#0d1117" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/></svg>
+  <div>
+    <h1>E2E Test Coverage Report</h1>
+    <div class="sb">{{if .Workflow}}{{.Workflow}} &mdash; {{end}}{{.Timestamp}}</div>
+  </div>
+</div>
+
+<div class="cr">
+  <div class="cd"><div class="ic">📄</div><div class="v">{{.TotalFiles}}</div><div class="l">Test Files</div></div>
+  <div class="cd"><div class="ic">📋</div><div class="v">{{.TotalDescribes}}</div><div class="l">Suites</div></div>
+  <div class="cd"><div class="ic">📂</div><div class="v">{{.TotalContexts}}</div><div class="l">Contexts</div></div>
+  <div class="cd"><div class="ic">🧪</div><div class="v">{{.TotalIts}}</div><div class="l">Test Cases</div></div>
+</div>
+
+<div class="br">
+  <div><b>Label filter:</b> {{.LabelFilter}}</div>
+  <div><b>Generated:</b> {{.Timestamp}}</div>
+</div>
+
+<div class="charts">
+  <div class="panel"><h3>📊 Tests by File</h3>
+    {{- range .BarChart}}
+    <div class="bar-row">
+      <span class="bar-label">{{.Label}}</span>
+      <div class="bar-track"><div class="bar-fill" style="width:{{.Percent}}%;background:{{.Color}}"></div></div>
+      <span class="bar-val">{{.Value}}</span>
+    </div>
+    {{- end}}
+  </div>
+  <div class="panel"><h3>📈 Distribution</h3>
+    <div class="donut-wrap">
+      <div class="donut" style="background:conic-gradient({{.ConicGradient}})">
+        <div class="donut-hole"><span class="dv">{{.TotalIts}}</span><span class="dl">tests</span></div>
+      </div>
+      <div class="donut-legend">
+        {{- range .DonutLegend}}
+        <div class="donut-legend-item"><span class="swatch" style="background:{{.Color}}"></span>{{.Label}}</div>
+        {{- end}}
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="lbl-section"><h3>🏷️ Coverage by Label</h3>
+  <div class="lbl-grid">
+    {{- range .LabelCards}}
+    <div class="lbl-card">
+      <div style="position:absolute;bottom:0;left:0;right:0;height:3px;background:{{.Color}}"></div>
+      <div class="lc-n" style="color:{{.Color}}">{{.Count}}</div>
+      <div class="lc-l" style="color:{{.Color}}">{{.Name}}</div>
+    </div>
+    {{- end}}
+  </div>
+</div>
+
+<h3 class="tree-hd">🔍 Detailed Test Tree</h3>
+{{- range $i, $file := .Files}}
+<div class="fs">
+  <div class="fh cl" onclick="var e=document.getElementById('f{{$i}}');e.classList.toggle('hd2');this.classList.toggle('cl')">
+    <span class="cv">▼</span>
+    <span class="fn">{{$file.Name}}</span>
+    <span class="st">{{$file.TestCount}} tests · {{$file.SuiteCount}} suite(s)</span>
+  </div>
+  <div class="fb hd2" id="f{{$i}}">
+    {{- range $file.Blocks}}
+      {{- if eq .Type "Describe"}}<div class="dh">▸ {{.Title}} {{range .Labels}}<span class="tg t-{{lower .}}">{{.}}</span>{{end}}</div>
+      {{- else if eq .Type "Context"}}<div class="cx">◦ {{.Title}} {{range .Labels}}<span class="tg t-{{lower .}}">{{.}}</span>{{end}}</div>
+      {{- else if eq .Type "It"}}<div class="ti"><span class="dt"></span>{{.Title}} {{range .Labels}}<span class="tg t-{{lower .}}">{{.}}</span>{{end}}</div>
+      {{- end}}
+    {{- end}}
+  </div>
+</div>
+{{- end}}
+
+<div class="lg"><h3>Label Legend</h3>
+  <div class="gd">
+    {{- range .AllLabels}}<span class="tg t-{{lower .}}">{{.}}</span>{{end}}
+  </div>
+</div>
+
+<div class="ft">Generated by go run ./hack/e2e/report · KAITO Production Stack</div>
+
+</div></body></html>

--- a/hack/e2e/report/template.html
+++ b/hack/e2e/report/template.html
@@ -86,8 +86,6 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,san
 
 <div class="cr">
   <div class="cd"><div class="ic">📄</div><div class="v">{{.TotalFiles}}</div><div class="l">Test Files</div></div>
-  <div class="cd"><div class="ic">📋</div><div class="v">{{.TotalDescribes}}</div><div class="l">Suites</div></div>
-  <div class="cd"><div class="ic">📂</div><div class="v">{{.TotalContexts}}</div><div class="l">Contexts</div></div>
   <div class="cd"><div class="ic">🧪</div><div class="v">{{.TotalIts}}</div><div class="l">Test Cases</div></div>
 </div>
 
@@ -138,7 +136,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,san
   <div class="fh cl" onclick="var e=document.getElementById('f{{$i}}');e.classList.toggle('hd2');this.classList.toggle('cl')">
     <span class="cv">▼</span>
     <span class="fn">{{$file.Name}}</span>
-    <span class="st">{{$file.TestCount}} tests · {{$file.SuiteCount}} suite(s)</span>
+    <span class="st">{{$file.TestCount}} tests</span>
   </div>
   <div class="fb hd2" id="f{{$i}}">
     {{- range $file.Blocks}}


### PR DESCRIPTION
**Reason for Change**:
Generate E2E coverage report

Example report from last run: https://github.com/kaito-project/production-stack/actions/runs/26208067842?pr=73

Downloadable artifact report: 
<img width="987" height="1249" alt="image" src="https://github.com/user-attachments/assets/29743f6a-16bd-4d7f-aae8-1f59a455f6d9" />

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
https://github.com/kaito-project/production-stack/issues/65

**Notes for Reviewers**:
