### PR TITLE
test(e2e/netpol): dump canary pod sidecar state on enforcement precheck failure

### DIFF
--- a/hack/e2e/scripts/setup-cluster.sh
+++ b/hack/e2e/scripts/setup-cluster.sh
@@ -111,6 +111,30 @@ az aks create \
   ${AKS_K8S_VERSION:+--kubernetes-version "${AKS_K8S_VERSION}"} \
   ${EXTRA_AKS_ARGS[@]+"${EXTRA_AKS_ARGS[@]}"}
 
+echo "=== Waiting for AKS provisioningState=Succeeded ==="
+# `az aks create` blocks on the ARM operation, but on retried/throttled CLI
+# requests it has been observed to return while the resource is still in
+# Creating/Updating. Gate explicitly on provisioningState=Succeeded before
+# trusting the cluster so install-components.sh never runs against a
+# half-provisioned control plane.
+PROVISIONING_STATE=""
+for i in $(seq 1 60); do
+  PROVISIONING_STATE=$(az aks show \
+    --resource-group "${RESOURCE_GROUP}" \
+    --name "${CLUSTER_NAME}" \
+    --query provisioningState -o tsv 2>/dev/null || echo "")
+  if [[ "${PROVISIONING_STATE}" == "Succeeded" ]]; then
+    echo "  ✅ provisioningState=Succeeded (after ${i} polls)"
+    break
+  fi
+  echo "  provisioningState=${PROVISIONING_STATE:-<unknown>} (attempt ${i}/60)"
+  sleep 10
+done
+if [[ "${PROVISIONING_STATE}" != "Succeeded" ]]; then
+  echo "ERROR: AKS cluster ${CLUSTER_NAME} never reached provisioningState=Succeeded (last=${PROVISIONING_STATE:-<unknown>})" >&2
+  exit 1
+fi
+
 echo "=== Fetching kubeconfig ==="
 az aks get-credentials \
   --resource-group "${RESOURCE_GROUP}" \
@@ -119,6 +143,29 @@ az aks get-credentials \
 
 echo "=== Waiting for all nodes to be Ready ==="
 kubectl wait --for=condition=ready nodes --all --timeout=300s
+
+# ─────────────────────────────────────────────────────────────────────────
+# Cilium dataplane readiness gate.
+#
+# Nodes can report Ready while cilium-agent on them is still mid-bootstrap
+# (CRD registration, identity allocator init, eBPF map load). Subsequent
+# install-components.sh + the netpol e2e suite both assume policy
+# compilation is functional from the moment they start, so block until
+# every cilium-agent pod is Ready and the cilium-operator rollout has
+# converged. This is cluster-bring-up readiness only — it does NOT
+# guarantee per-pod policy compilation latency once workloads are
+# scheduled (that's still up to the AKS managed Cilium engine and is
+# what the netpol suite's canary loop tolerates with a 10m budget).
+# ─────────────────────────────────────────────────────────────────────────
+echo "=== Waiting for cilium-agent DaemonSet rollout ==="
+kubectl -n kube-system rollout status daemonset/cilium --timeout=300s
+
+echo "=== Waiting for cilium-operator Deployment rollout ==="
+kubectl -n kube-system rollout status deployment/cilium-operator --timeout=180s
+
+echo "=== Waiting for every cilium-agent pod to report Ready ==="
+kubectl -n kube-system wait --for=condition=ready pod \
+  -l k8s-app=cilium --timeout=300s
 
 # ─────────────────────────────────────────────────────────────────────────
 # Cluster-prep components (KEDA + Gateway API base CRDs + Istio)

--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -505,12 +505,20 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 	// expectDeniedLabeled is the labeled-probe variant of expectDenied,
 	// used by tests that need to assert that label-only spoofing across
 	// namespaces does NOT grant access (the X1 regression guard).
-	expectDeniedLabeled := func(probeNS string, labels map[string]string, targetIP string, targetPort int32, msg string) {
+	//
+	// `targetNS` is the namespace where `targetIP` lives — required so the
+	// failure-time diag dump inspects the target pod's actual namespace
+	// (policies, labels, CiliumEndpoint) rather than the probe-side
+	// workload namespace. Cross-namespace callers (A→B, B→A, spoof A→B)
+	// pass the target's namespace, not the workload-A default — otherwise
+	// the diag reports `<no pod with IP X in workload-A>` and an empty
+	// node, hiding the actual enforcement state on the target side.
+	expectDeniedLabeled := func(probeNS string, labels map[string]string, targetNS, targetIP string, targetPort int32, msg string) {
 		out, _ := probeTarget(probeNS, connectCmd(targetIP, targetPort), probeTimeout, labels)
 		state := classifyResult(out)
 		if state != "blocked" {
 			AddReportEntry("netpol-deny-diag",
-				networkPolicyEnforcementDiagnostics(ctx, clientset, namespace, targetIP, probeNS))
+				networkPolicyEnforcementDiagnostics(ctx, clientset, targetNS, targetIP, probeNS))
 		}
 		Expect(state).To(Equal("blocked"),
 			"%s. state=%q output=%q", msg, state, out)
@@ -583,19 +591,19 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 		gatewayLabels := map[string]string{
 			"gateway.networking.k8s.io/gateway-name": "inference-gateway",
 		}
-		expectDeniedLabeled("default", gatewayLabels, eppIP, eppPort,
+		expectDeniedLabeled("default", gatewayLabels, namespace, eppIP, eppPort,
 			"gateway-labeled pod in default should be silently dropped — only the in-namespace "+
 				"gateway pod is a trusted ingress source")
 	})
 
 	// ── Cross-namespace isolation ─────────────────────────────────────────
 	It("should DENY ingress from workload namespace A to workload namespace B", func() {
-		expectDeniedLabeled(namespace, nil, eppIPB, eppPortB,
+		expectDeniedLabeled(namespace, nil, namespaceB, eppIPB, eppPortB,
 			"workload namespace A should be silently dropped by namespace B's default-deny")
 	})
 
 	It("should DENY ingress from workload namespace B to workload namespace A", func() {
-		expectDeniedLabeled(namespaceB, nil, eppIP, eppPort,
+		expectDeniedLabeled(namespaceB, nil, namespace, eppIP, eppPort,
 			"workload namespace B should be silently dropped by namespace A's default-deny")
 	})
 
@@ -610,7 +618,7 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 		spoofedLabels := map[string]string{
 			"gateway.networking.k8s.io/gateway-name": fmt.Sprintf("%s-gateway", netpolModelB),
 		}
-		expectDeniedLabeled(namespace, spoofedLabels, eppIPB, eppPortB,
+		expectDeniedLabeled(namespace, spoofedLabels, namespaceB, eppIPB, eppPortB,
 			"a pod in namespace A carrying namespace B's gateway label must be silently dropped — "+
 				"labels do not grant cross-namespace trust under the post-X1 policy")
 	})

--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -100,18 +100,18 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 		clientset, err = utils.GetK8sClientset()
 		Expect(err).NotTo(HaveOccurred(), "failed to create k8s clientset")
 
-		// Install both workload namespaces in two phases per namespace:
-		//   1. modelharness (Gateway + NetworkPolicies) and a Cilium policy
-		//      pre-warm that proves the local cilium-agent has compiled the
-		//      namespace's default-deny rule into its eBPF maps.
-		//   2. modeldeployment (EPP + InferenceSet + shadow pods).
-		// The pre-warm closes the AKS Cilium overlay race where an EPP pod
-		// created in the gap between policy apply and cilium compile lands
-		// with status.policy.ingress.enforcing=false and never recovers.
-		// We do not use the shared InstallCase here because it bundles both
-		// phases and gives us no place to slot the pre-warm in between.
-		installNetpolCase(ctx, clientset, CaseNetworkPolicyA)
-		installNetpolCase(ctx, clientset, CaseNetworkPolicyB)
+		// Install both workload namespaces. We use the shared InstallCase
+		// here (modelharness → modeldeployment) and rely on
+		// ensureCiliumEndpointEnforcing below to recover from the AKS
+		// Cilium overlay race: an earlier attempt to pre-warm Cilium's
+		// per-namespace policy compile before creating the EPP did not
+		// help, because cilium compiles policy per-identity and the
+		// warmup pod's labels produce a different identity than the EPP.
+		// The only reliable fix is to detect stuck CiliumEndpoints after
+		// the EPP exists and force a fresh allocation by deleting the
+		// pod — see ensureCiliumEndpointEnforcing.
+		InstallCase(CaseNetworkPolicyA)
+		InstallCase(CaseNetworkPolicyB)
 
 		namespace = CaseNamespace(CaseNetworkPolicyA)
 		namespaceB = CaseNamespace(CaseNetworkPolicyB)
@@ -153,17 +153,17 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 		Expect(eppIPB).NotTo(BeEmpty(), "could not find a ready EPP pod IP in %s", namespaceB)
 		Expect(eppPortB).To(BeNumerically(">", 0), "could not determine EPP pod port in %s", namespaceB)
 
-		// AKS Cilium overlay race guard: poll the EPP pod's CiliumEndpoint
-		// until status.policy.ingress.enforcing flips to true. Without this
-		// gate, an EPP pod that was created in the narrow window between
-		// the NetworkPolicy apply and cilium-agent's policy compile lands
-		// with enforcing=false and never recovers — the canary probe loop
-		// below then spins for 5 minutes and fails with a generic
-		// "enforcement not active" message that hides the actual cause.
-		// Failing here surfaces a specific, actionable Cilium message
-		// instead, and short-circuits 4+ minutes of useless polling.
-		waitForCiliumEndpointEnforcing(ctx, clientset, namespace, eppIP)
-		waitForCiliumEndpointEnforcing(ctx, clientset, namespaceB, eppIPB)
+		// AKS Cilium overlay race recovery: ensure the EPP pod's
+		// CiliumEndpoint advertises ingress.enforcing=true. If it does
+		// not within 60s, delete the EPP pod so its Deployment recreates
+		// it with a fresh CiliumEndpoint allocation (up to maxRetries
+		// cycles). Returns the (possibly new) EPP pod IP, which the deny
+		// / cross-namespace probes below target. Without this gate, an
+		// EPP that landed in the racy window between NetworkPolicy apply
+		// and cilium compile keeps enforcing=false indefinitely, and the
+		// canary loop below would spin for 5 minutes before failing.
+		eppIP = ensureCiliumEndpointEnforcing(ctx, clientset, namespace, netpolModelA, eppIP)
+		eppIPB = ensureCiliumEndpointEnforcing(ctx, clientset, namespaceB, netpolModelB, eppIPB)
 
 		// Wait for NetworkPolicy enforcement to actually take effect on this
 		// cluster. On freshly created Cilium clusters the policy maps may take
@@ -1071,16 +1071,38 @@ func collectCiliumDiagnostics(ctx context.Context, clientset *kubernetes.Clients
 // Best-effort: on non-Cilium clusters or when the CRD is missing, the
 // helper logs the situation and returns without failing, so the suite
 // remains portable to kind / OSS Kubernetes clusters.
-func waitForCiliumEndpointEnforcing(ctx context.Context, _ *kubernetes.Clientset, ns, targetIP string) {
+// ensureCiliumEndpointEnforcing makes sure the EPP pod currently
+// resolving to `targetIP` in `ns` has a CiliumEndpoint that advertises
+// status.policy.ingress.enforcing == true. On failure, it deletes the
+// EPP pod so the parent Deployment recreates it, waits for the
+// replacement to be ready, and re-checks — up to maxRetries cycles.
+// Returns the (possibly new) EPP pod IP that callers should use for
+// probing.
+//
+// Why delete-and-retry rather than just polling: the AKS Cilium overlay
+// race produces *stuck* CiliumEndpoints. The endpoint is in state=ready
+// with a valid identity, but its policy.ingress.enforcing flag never
+// flips because cilium-agent's reconcile happened before the policy was
+// known and was never re-triggered for that identity. Polling does not
+// unstick it; only a new endpoint allocation does. The pre-warm
+// (installNetpolCase Phase 2) reduces but does not eliminate this race
+// because Cilium compiles policy per-identity and the EPP gets a
+// different identity than the warmup pod.
+//
+// Best-effort: on non-Cilium clusters or when the CRD is missing, the
+// helper logs and returns targetIP unchanged so the suite remains
+// portable to kind / OSS K8s.
+func ensureCiliumEndpointEnforcing(ctx context.Context, clientset *kubernetes.Clientset, ns, deploymentName, targetIP string) string {
 	const (
-		timeout      = 60 * time.Second
-		pollInterval = 2 * time.Second
+		perAttemptTimeout = 60 * time.Second
+		pollInterval      = 2 * time.Second
+		maxRetries        = 2 // initial attempt + 2 EPP-pod recreations
 	)
 
 	dyn, derr := utils.GetDynamicClient()
 	if derr != nil {
-		GinkgoWriter.Printf("waitForCiliumEndpointEnforcing: dynamic client unavailable (%v) — skipping Cilium enforcement gate for %s/%s\n", derr, ns, targetIP)
-		return
+		GinkgoWriter.Printf("ensureCiliumEndpointEnforcing: dynamic client unavailable (%v) — skipping Cilium enforcement gate for %s/%s\n", derr, ns, targetIP)
+		return targetIP
 	}
 	cepGVR := schema.GroupVersionResource{
 		Group: "cilium.io", Version: "v2", Resource: "ciliumendpoints",
@@ -1090,10 +1112,11 @@ func waitForCiliumEndpointEnforcing(ctx context.Context, _ *kubernetes.Clientset
 	// not a Cilium cluster — silently skip so kind / OSS K8s users can
 	// still run the suite.
 	if _, err := dyn.Resource(cepGVR).Namespace(ns).List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
-		GinkgoWriter.Printf("waitForCiliumEndpointEnforcing: CiliumEndpoint CRD not available (%v) — skipping enforcement gate for %s/%s\n", err, ns, targetIP)
-		return
+		GinkgoWriter.Printf("ensureCiliumEndpointEnforcing: CiliumEndpoint CRD not available (%v) — skipping enforcement gate for %s/%s\n", err, ns, targetIP)
+		return targetIP
 	}
 
+	currentIP := targetIP
 	var (
 		lastState      string
 		lastIngressEnf bool
@@ -1102,270 +1125,121 @@ func waitForCiliumEndpointEnforcing(ctx context.Context, _ *kubernetes.Clientset
 		foundEndpoint  bool
 	)
 
-	Eventually(func() bool {
-		ceps, err := dyn.Resource(cepGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
-		if err != nil {
-			return false
-		}
-		for _, cep := range ceps.Items {
-			addrs, _, _ := unstructuredNestedSlice(cep.Object, "status", "networking", "addressing")
-			match := false
-			for _, a := range addrs {
-				if m, ok := a.(map[string]any); ok {
-					if v, _ := m["ipv4"].(string); v == targetIP {
-						match = true
-						break
+	for attempt := 0; attempt <= maxRetries; attempt++ {
+		// Reset capture state for this attempt so the failure message
+		// reflects the current attempt's CEP, not a stale one.
+		foundEndpoint = false
+		lastName, lastState = "", ""
+		lastIdentity = 0
+		lastIngressEnf = false
+
+		deadline := time.Now().Add(perAttemptTimeout)
+		enforced := false
+		for time.Now().Before(deadline) {
+			ceps, err := dyn.Resource(cepGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+			if err == nil {
+				for _, cep := range ceps.Items {
+					addrs, _, _ := unstructuredNestedSlice(cep.Object, "status", "networking", "addressing")
+					match := false
+					for _, a := range addrs {
+						if m, ok := a.(map[string]any); ok {
+							if v, _ := m["ipv4"].(string); v == currentIP {
+								match = true
+								break
+							}
+						}
 					}
+					if !match {
+						continue
+					}
+					foundEndpoint = true
+					lastName = cep.GetName()
+					lastState, _, _ = unstructuredNestedString(cep.Object, "status", "state")
+					lastIdentity, _, _ = unstructuredNestedInt64(cep.Object, "status", "identity", "id")
+					lastIngressEnf, _, _ = unstructuredNestedBool(cep.Object, "status", "policy", "ingress", "enforcing")
+					if lastIngressEnf {
+						enforced = true
+					}
+					break
 				}
 			}
-			if !match {
-				continue
+			if enforced {
+				break
 			}
-			foundEndpoint = true
-			lastName = cep.GetName()
-			lastState, _, _ = unstructuredNestedString(cep.Object, "status", "state")
-			lastIdentity, _, _ = unstructuredNestedInt64(cep.Object, "status", "identity", "id")
-			lastIngressEnf, _, _ = unstructuredNestedBool(cep.Object, "status", "policy", "ingress", "enforcing")
-			return lastIngressEnf
+			time.Sleep(pollInterval)
 		}
-		return false
-	}, timeout, pollInterval).Should(BeTrue(),
+		if enforced {
+			return currentIP
+		}
+
+		if attempt == maxRetries {
+			break
+		}
+
+		// Stuck. Recover by deleting the EPP pod so its Deployment
+		// recreates it. The fresh pod gets a new CiliumEndpoint
+		// allocation, and by now the namespace's policy has been
+		// observed by cilium-agent (Phase 2 pre-warm + first attempt's
+		// poll window), so the new endpoint should be programmed with
+		// the policy at allocation time.
+		oldPodName := findPodNameByIP(ctx, clientset, ns, currentIP)
+		GinkgoWriter.Printf(
+			"ensureCiliumEndpointEnforcing: attempt %d/%d — CEP %s/%s "+
+				"(identity=%d state=%s) stuck with ingress.enforcing=%v; "+
+				"deleting EPP pod %s/%s to force a fresh CiliumEndpoint allocation\n",
+			attempt+1, maxRetries+1, ns, lastName, lastIdentity, lastState, lastIngressEnf, ns, oldPodName)
+		if oldPodName != "" {
+			_ = clientset.CoreV1().Pods(ns).Delete(ctx, oldPodName, metav1.DeleteOptions{})
+		}
+		// Wait for a new Ready EPP pod with a different IP (the old IP
+		// may briefly persist on a Terminating pod). Reuse the
+		// readyEPPPodEndpoint helper, then make sure we actually got a
+		// new IP — otherwise we'd just re-check the same stuck endpoint.
+		Eventually(func() bool {
+			ip, _ := readyEPPPodEndpoint(ctx, clientset, ns, deploymentName)
+			return ip != "" && ip != currentIP
+		}, 3*time.Minute, 5*time.Second).Should(BeTrue(),
+			"new EPP pod did not get a different IP after delete in %s", ns)
+		newIP, _ := readyEPPPodEndpoint(ctx, clientset, ns, deploymentName)
+		currentIP = newIP
+	}
+
+	// All retries exhausted.
+	Expect(false).To(BeTrue(),
 		func() string {
 			if !foundEndpoint {
 				return fmt.Sprintf(
-					"no CiliumEndpoint with IP %s appeared in %s within %s — "+
-						"cilium-agent has not programmed the EPP endpoint. "+
-						"Check cilium-agent pod health on the EPP's node.",
-					targetIP, ns, timeout)
+					"no CiliumEndpoint with IP %s appeared in %s after %d retries — "+
+						"cilium-agent never programmed the EPP endpoint. Check cilium-agent "+
+						"pod health on the EPP's node.",
+					currentIP, ns, maxRetries)
 			}
 			return fmt.Sprintf(
 				"EPP CiliumEndpoint %s/%s (identity=%d state=%s) stuck with "+
-					"ingress.enforcing=%v after %s — known AKS Cilium overlay "+
-					"race when a pod comes up before its NetworkPolicy is "+
-					"compiled into the local eBPF map. Cilium-agent on the "+
-					"EPP node may need a restart, or the policy must be "+
-					"re-applied after the pod is ready. Skipping the canary "+
-					"probe loop because it would otherwise spin for 5 minutes "+
-					"on this race.",
-				ns, lastName, lastIdentity, lastState, lastIngressEnf, timeout)
-		})
+					"ingress.enforcing=%v even after %d EPP pod recreations — the AKS "+
+					"Cilium overlay race is not recoverable on this cluster. "+
+					"cilium-agent is failing to program the policy for newly-allocated "+
+					"identities in this namespace. Likely needs a cilium-agent restart "+
+					"on the EPP's node.",
+				ns, lastName, lastIdentity, lastState, lastIngressEnf, maxRetries)
+		}())
+	return currentIP
 }
 
-// installNetpolCase is a netpol-test-specific replacement for the shared
-// InstallCase. It splits the install into two phases so we can pre-warm
-// Cilium's namespace policy in between:
-//
-//  1. modelharness chart → renders the Gateway, NetworkPolicies, and (when
-//     enabled) AuthorizationPolicy/APIKey CR. After this returns, the K8s
-//     NetworkPolicy objects exist in the API server but cilium-agent on
-//     each node may not have compiled them into the local eBPF map yet.
-//  2. Cilium pre-warm → create a throwaway non-gateway pod in the workload
-//     namespace and probe it from a throwaway external namespace until the
-//     probe is silently dropped. This proves cilium-agent has compiled the
-//     namespace's default-deny rule AND is actively applying it to fresh
-//     endpoints, closing the race that otherwise strands the EPP's
-//     CiliumEndpoint with status.policy.ingress.enforcing=false.
-//  3. modeldeployment chart → renders the EPP / InferenceSet / shadow
-//     pods. Because step (2) confirmed Cilium is enforcing, the EPP pod's
-//     CiliumEndpoint will be programmed with the policy at allocation
-//     time rather than racing the cilium reconcile.
-//
-// This is intentionally an inlined copy of InstallCase's flow rather than
-// a refactor of InstallCase itself — the pre-warm is only meaningful for
-// the netpol suite (other suites don't enable NetworkPolicies), so
-// keeping the override here avoids polluting the shared case framework
-// with cilium-specific timing assumptions.
-func installNetpolCase(ctx context.Context, clientset *kubernetes.Clientset, caseName string) {
-	ns := CaseNamespace(caseName)
-	gatewayName := CaseGatewayName(caseName)
-	Expect(ns).NotTo(BeEmpty(), "case %q has no namespace declared in CaseDeployments", caseName)
-
-	first := CaseDeployments[caseName][0]
-
-	By(fmt.Sprintf("Phase 1: installing modelharness (Gateway + NetworkPolicies) in %s", ns))
-	Expect(utils.EnsureNamespace(ctx, ns, first.AuthAPIKeyEnabled)).To(Succeed(),
-		"failed to ensure namespace %s for case %s", ns, caseName)
-	Expect(utils.WaitForGatewayService(ctx, ns, gatewayName, utils.InferenceSetReadyTimeout)).
-		To(Succeed(), "gateway service for %s did not appear", caseName)
-
-	By(fmt.Sprintf("Phase 2: pre-warming Cilium policy enforcement in %s", ns))
-	prewarmCiliumPolicyInNamespace(ctx, clientset, ns)
-
-	By(fmt.Sprintf("Phase 3: installing modeldeployment(s) in %s", ns))
-	gatewayURL, err := utils.GetGatewayURLFor(ns, gatewayName)
-	Expect(err).NotTo(HaveOccurred(), "failed to resolve gateway URL for case %s", caseName)
-	utils.SetupInferenceSetsWithRouting(CaseDeployments[caseName], ns, gatewayURL)
-}
-
-// prewarmCiliumPolicyInNamespace forces cilium-agent on the workload
-// namespace's nodes to compile the modelharness-rendered
-// `default-deny-ingress` rule before any real inference pod (EPP, vLLM,
-// shadow) lands on those nodes. Without this pre-warm, a real pod
-// created in the window between policy apply and cilium compile lands
-// with status.policy.ingress.enforcing=false on its CiliumEndpoint and
-// never recovers — the symptom that gates the BeforeAll's canary loop
-// against the AKS overlay race.
-//
-// Strategy: stand up a throwaway "warmup" pod in the workload namespace
-// (selected by default-deny-ingress because it lacks the gateway-name
-// label) and a throwaway probe pod in an external namespace. Repeatedly
-// `agnhost connect` from probe to warmup until the connect is silently
-// dropped (EXIT=1) — that proves the cilium dataplane is enforcing the
-// policy for fresh endpoints in this namespace. Then tear both pods down.
-//
-// Best-effort with a tight timeout: on non-Cilium clusters or unusually
-// slow cilium reconciles, we fail loud with a Cilium-specific message
-// rather than wedging the whole suite.
-func prewarmCiliumPolicyInNamespace(ctx context.Context, clientset *kubernetes.Clientset, ns string) {
-	const (
-		prewarmTimeout      = 90 * time.Second
-		prewarmPollInterval = 3 * time.Second
-	)
-
-	warmupNS := ns // target pod lives in the workload namespace so the
-	// namespace-scoped default-deny-ingress selects it.
-	warmupPodName := fmt.Sprintf("netpol-warmup-%d", rand.Intn(900000)+100000)
-	warmupPod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      warmupPodName,
-			Namespace: warmupNS,
-			// Explicitly NOT carrying the gateway-name label, so the
-			// default-deny-ingress policy applies. The synthetic
-			// label below distinguishes this pod from real workloads
-			// in logs without changing policy semantics.
-			Labels: map[string]string{"netpol-warmup": "true"},
-			// Disable Istio sidecar injection on the warmup pod —
-			// mesh mTLS would make the probe see 127.0.0.1 and
-			// short-circuit NetworkPolicy entirely.
-			Annotations: map[string]string{"sidecar.istio.io/inject": "false"},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:  "warmup",
-				Image: probeImage,
-				// `pause` keeps the container alive with NO TCP
-				// listener bound. That's deliberate: with no listener,
-				// the probe's SYN to port 8080 has only two possible
-				// outcomes:
-				//   - policy NOT enforcing → SYN reaches the pod's
-				//     node → kernel rejects with RST → EXIT=2 (REFUSED)
-				//   - policy IS enforcing → SYN silently dropped by
-				//     cilium-agent's eBPF map → EXIT=1 (TIMEOUT)
-				// EXIT=1 is therefore unambiguous evidence the
-				// namespace's default-deny rule has been compiled and
-				// is being applied to fresh endpoints.
-				Args: []string{"pause"},
-			}},
-		},
+// findPodNameByIP returns the name of the pod in `ns` whose PodIP
+// matches `ip`, or "" if no such pod is found. Best-effort: list errors
+// are swallowed.
+func findPodNameByIP(ctx context.Context, clientset *kubernetes.Clientset, ns, ip string) string {
+	pods, err := clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return ""
 	}
-	_, err := clientset.CoreV1().Pods(warmupNS).Create(ctx, warmupPod, metav1.CreateOptions{})
-	Expect(err).NotTo(HaveOccurred(), "failed to create cilium pre-warm target pod in %s", warmupNS)
-	defer func() {
-		_ = clientset.CoreV1().Pods(warmupNS).Delete(ctx, warmupPodName, metav1.DeleteOptions{})
-	}()
-	Expect(utils.WaitForPodReady(ctx, clientset, warmupNS, warmupPodName, utils.PollTimeout)).
-		To(Succeed(), "cilium pre-warm target pod %s/%s did not become ready", warmupNS, warmupPodName)
-
-	// Re-read the pod for its PodIP.
-	warmupPod, err = clientset.CoreV1().Pods(warmupNS).Get(ctx, warmupPodName, metav1.GetOptions{})
-	Expect(err).NotTo(HaveOccurred())
-	Expect(warmupPod.Status.PodIP).NotTo(BeEmpty(), "cilium pre-warm target pod has no PodIP")
-
-	// Probe namespace: must NOT be the workload namespace itself
-	// (intra-namespace traffic is allowed by allow-inference-traffic's
-	// `podSelector: {}` clause and so cannot prove enforcement).
-	probeNS := fmt.Sprintf("e2e-netpol-prewarm-%d", rand.Intn(900000)+100000)
-	_, _ = clientset.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
-		ObjectMeta: metav1.ObjectMeta{Name: probeNS},
-	}, metav1.CreateOptions{})
-	defer func() {
-		_ = clientset.CoreV1().Namespaces().Delete(ctx, probeNS, metav1.DeleteOptions{})
-	}()
-	Eventually(func() error {
-		_, err := clientset.CoreV1().ServiceAccounts(probeNS).Get(ctx, "default", metav1.GetOptions{})
-		return err
-	}, 30*time.Second, time.Second).Should(Succeed(),
-		"default ServiceAccount in %s did not appear", probeNS)
-
-	probePodName := fmt.Sprintf("netpol-prewarm-probe-%d", rand.Intn(900000)+100000)
-	probePod := &corev1.Pod{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:        probePodName,
-			Namespace:   probeNS,
-			Annotations: map[string]string{"sidecar.istio.io/inject": "false"},
-		},
-		Spec: corev1.PodSpec{
-			Containers: []corev1.Container{{
-				Name:  "probe",
-				Image: probeImage,
-				Args:  []string{"pause"},
-			}},
-		},
+	for _, p := range pods.Items {
+		if p.Status.PodIP == ip {
+			return p.Name
+		}
 	}
-	_, err = clientset.CoreV1().Pods(probeNS).Create(ctx, probePod, metav1.CreateOptions{})
-	Expect(err).NotTo(HaveOccurred(), "failed to create cilium pre-warm probe pod in %s", probeNS)
-	Expect(utils.WaitForPodReady(ctx, clientset, probeNS, probePodName, utils.PollTimeout)).
-		To(Succeed(), "cilium pre-warm probe pod %s/%s did not become ready", probeNS, probePodName)
-
-	restCfg, err := utils.GetK8sConfig()
-	Expect(err).NotTo(HaveOccurred())
-
-	var lastOut, lastErr string
-	Eventually(func() bool {
-		cmd := []string{"sh", "-c", fmt.Sprintf(
-			"/agnhost connect %s:8080 --timeout=%s --protocol=tcp 2>&1; echo EXIT=$?",
-			warmupPod.Status.PodIP, probeConnectTimeout,
-		)}
-		req := clientset.CoreV1().RESTClient().Post().
-			Resource("pods").Name(probePodName).Namespace(probeNS).
-			SubResource("exec").
-			VersionedParams(&corev1.PodExecOptions{
-				Command: cmd, Stdout: true, Stderr: true,
-			}, scheme.ParameterCodec)
-		exec, err := remotecommand.NewSPDYExecutor(restCfg, "POST", req.URL())
-		if err != nil {
-			lastErr = "newSPDYExecutor: " + err.Error()
-			return false
-		}
-		var stdout, stderr bytes.Buffer
-		execCtx, cancel := context.WithTimeout(ctx, probeTimeout)
-		defer cancel()
-		streamErr := exec.StreamWithContext(execCtx, remotecommand.StreamOptions{
-			Stdout: &stdout, Stderr: &stderr,
-		})
-		out := stdout.String() + stderr.String()
-		lastOut = out
-		if streamErr != nil {
-			lastErr = "stream: " + streamErr.Error()
-		} else {
-			lastErr = ""
-		}
-		// We want the probe to be silently dropped (EXIT=1 = TIMEOUT).
-		// The warmup pod has no TCP listener, so:
-		//   EXIT=2 (REFUSED) = SYN reached the pod and got RST — cilium
-		//   has NOT compiled the deny rule for this endpoint yet, keep
-		//   polling.
-		//   EXIT=1 (TIMEOUT) = SYN silently dropped — cilium IS
-		//   enforcing the policy on a fresh endpoint in this namespace.
-		//   EXIT=0 should not happen (no listener) but would also mean
-		//   not-enforced; keep polling.
-		return bytes.Contains([]byte(out), []byte("EXIT=1"))
-	}, prewarmTimeout, prewarmPollInterval).Should(BeTrue(),
-		func() string {
-			return fmt.Sprintf(
-				"Cilium policy pre-warm in %s did not converge within %s — "+
-					"cilium-agent never compiled the default-deny-ingress rule "+
-					"into a state that drops cross-namespace traffic to a fresh "+
-					"non-gateway pod. This is the AKS Cilium overlay race "+
-					"manifesting at the namespace level. The EPP pod created "+
-					"after this would land with ingress.enforcing=false, so "+
-					"failing here surfaces the root cause instead of letting "+
-					"the BeforeAll canary loop spin for 5 minutes.\n"+
-					"last agnhost output: %q\nlast exec error: %q\n"+
-					"warmupPodIP=%s warmupNS=%s probeNS=%s",
-				ns, prewarmTimeout, lastOut, lastErr,
-				warmupPod.Status.PodIP, warmupNS, probeNS)
-		})
+	return ""
 }
 
 // unstructuredNestedString / Int64 / Bool / Slice are tiny wrappers around

--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -248,7 +248,7 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 				// printed exactly once, not on every iteration.
 				if connectedCount == 12 {
 					AddReportEntry("netpol-enforcement-diag",
-						networkPolicyEnforcementDiagnostics(ctx, clientset, namespace, eppIP))
+						networkPolicyEnforcementDiagnostics(ctx, clientset, namespace, eppIP, canaryNS))
 				}
 				return false
 			}
@@ -275,7 +275,7 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 				// state at the moment the timeout fires, not at Should() call
 				// time. Helps distinguish "policies missing" from "policies
 				// present but unenforced by Cilium".
-				diag := networkPolicyEnforcementDiagnostics(ctx, clientset, namespace, eppIP)
+				diag := networkPolicyEnforcementDiagnostics(ctx, clientset, namespace, eppIP, canaryNS)
 				return fmt.Sprintf(
 					"timed out waiting for NetworkPolicy enforcement to become active — "+
 						"Cilium may not be enforcing policies on this cluster, or the "+
@@ -874,7 +874,7 @@ func networkPolicyEnforcementDiagnostics(ctx context.Context, clientset *kuberne
 		}
 		any := false
 		for _, p := range probePods.Items {
-			if !strings.HasPrefix(p.Name, "netpol-probe-") && !strings.HasPrefix(p.Name, "netpol-canary-") {
+			if !strings.HasPrefix(p.Name, "netpol-probe-") && !strings.HasPrefix(p.Name, "canary-probe-") {
 				continue
 			}
 			any = true

--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -1094,22 +1094,29 @@ func collectCiliumDiagnostics(ctx context.Context, clientset *kubernetes.Clients
 // portable to kind / OSS K8s.
 // ensureCiliumEndpointEnforcing makes sure the EPP pod resolving to
 // `targetIP` in `ns` has a CiliumEndpoint that advertises
-// status.policy.ingress.enforcing == true. On failure, it deletes and
-// re-creates the namespace's NetworkPolicies to force cilium-agent to
-// recompile policy for every identity in the namespace (including the
+// status.policy.ingress.enforcing == true. On failure, it restarts the
+// cilium-agent pod on the EPP's node so the dataplane rebuilds its
+// policy maps from scratch for every local endpoint (including the
 // stuck EPP identity), then re-checks. Up to maxRetries cycles.
 // Returns targetIP unchanged — the EPP pod is never disturbed.
 //
-// Why recreate-the-policies rather than delete-the-pod: the AKS Cilium
-// overlay race produces *stuck* CiliumEndpoints whose
-// status.policy.ingress.enforcing flag never flips. Empirically (see
-// run 26430654933) all 3 EPP recreations got the same Cilium identity
-// — Cilium hashes identity from the pod's full label set, so EPP
-// replicas always collide. The stuck state is held against the
-// *identity*, not the endpoint, so spinning up a new endpoint with the
-// same identity inherits the same wedged policy program. The fix is to
-// nudge cilium-agent to re-evaluate the identity's policy, which a
-// NetworkPolicy delete+create reliably does.
+// Why restart-cilium-agent rather than recreate-policy or delete-the-pod:
+// the AKS Cilium overlay race produces *stuck* CiliumEndpoints whose
+// status.policy.ingress.enforcing flag never flips. Empirically:
+//   - Run 26430654933 (pod-delete recovery): all 3 EPP recreations got
+//     the same Cilium identity 26694; Cilium hashes identity from the
+//     pod's full label set so EPP replicas always collide and inherit
+//     the same wedged policy program.
+//   - Run 26431394132 (NetworkPolicy recreate): identity 10406
+//     remained stuck across 2 full delete+create cycles of the
+//     namespace's NetworkPolicies, so cilium-agent's reconciliation
+//     does not unwedge the local policy map either.
+//
+// The stuck state is held inside cilium-agent's per-identity policy
+// table on the node, and only restarting the agent reliably rebuilds
+// it. This touches kube-system, so it's gated behind two failed
+// attempts and a tight CRD probe — non-Cilium clusters skip the
+// recovery entirely.
 //
 // Best-effort: on non-Cilium clusters or when the CRD is missing, the
 // helper logs and returns targetIP unchanged so the suite remains
@@ -1118,7 +1125,7 @@ func ensureCiliumEndpointEnforcing(ctx context.Context, clientset *kubernetes.Cl
 	const (
 		perAttemptTimeout = 60 * time.Second
 		pollInterval      = 2 * time.Second
-		maxRetries        = 2 // initial attempt + 2 NetworkPolicy recreations
+		maxRetries        = 2 // initial attempt + 2 cilium-agent restarts
 	)
 	_ = deploymentName // kept in the signature so callers can re-supply
 
@@ -1198,18 +1205,29 @@ func ensureCiliumEndpointEnforcing(ctx context.Context, clientset *kubernetes.Cl
 			break
 		}
 
-		// Stuck. Recover by deleting+re-creating the namespace's
-		// NetworkPolicies so cilium-agent re-evaluates policy for every
-		// identity in this namespace — including the wedged EPP
-		// identity. Pod-level recreation does not help because EPP
-		// replicas hash to the same Cilium identity and inherit the same
-		// stuck policy program.
+		// Stuck. Recover by restarting cilium-agent on the EPP's node.
+		// Neither pod-recreation nor NetworkPolicy delete+create
+		// unwedges this state empirically (see func doc), because the
+		// stuck program lives inside the agent's per-identity policy
+		// table on the node. Locate the EPP's node from the matching
+		// pod's IP, then delete the kube-system cilium pod scheduled
+		// there. The DaemonSet will reschedule it within seconds and
+		// the replacement reloads its policy maps from scratch.
+		eppNode := findNodeForPodIP(ctx, clientset, ns, targetIP)
+		if eppNode == "" {
+			GinkgoWriter.Printf(
+				"ensureCiliumEndpointEnforcing: attempt %d/%d — CEP %s/%s "+
+					"(identity=%d state=%s) stuck with ingress.enforcing=%v; "+
+					"could not resolve EPP node from IP %s — skipping cilium-agent restart\n",
+				attempt+1, maxRetries+1, ns, lastName, lastIdentity, lastState, lastIngressEnf, targetIP)
+			continue
+		}
 		GinkgoWriter.Printf(
 			"ensureCiliumEndpointEnforcing: attempt %d/%d — CEP %s/%s "+
 				"(identity=%d state=%s) stuck with ingress.enforcing=%v; "+
-				"recreating NetworkPolicies in %s to force cilium policy recompile\n",
-			attempt+1, maxRetries+1, ns, lastName, lastIdentity, lastState, lastIngressEnf, ns)
-		recreateNetworkPolicies(ctx, clientset, ns)
+				"restarting cilium-agent on node %s to force dataplane policy rebuild\n",
+			attempt+1, maxRetries+1, ns, lastName, lastIdentity, lastState, lastIngressEnf, eppNode)
+		restartCiliumAgentOnNode(ctx, clientset, eppNode)
 	}
 
 	// All retries exhausted.
@@ -1224,56 +1242,103 @@ func ensureCiliumEndpointEnforcing(ctx context.Context, clientset *kubernetes.Cl
 			}
 			return fmt.Sprintf(
 				"EPP CiliumEndpoint %s/%s (identity=%d state=%s) stuck with "+
-					"ingress.enforcing=%v even after %d NetworkPolicy recreations — the AKS "+
-					"Cilium overlay race is not recoverable on this cluster via "+
-					"in-test means. cilium-agent is failing to re-evaluate policy for "+
-					"this identity even after the policies are re-created. Likely needs "+
-					"a cilium-agent restart on the EPP's node.",
+					"ingress.enforcing=%v even after %d cilium-agent restarts on the EPP's "+
+					"node — the AKS Cilium overlay race is not recoverable on this cluster "+
+					"via in-test means. The agent's per-identity policy table refuses to "+
+					"program rules for this identity even after a fresh agent process. "+
+					"Likely a CRD reconciliation bug or a cluster-wide cilium-operator issue.",
 				ns, lastName, lastIdentity, lastState, lastIngressEnf, maxRetries)
 		}())
 	return targetIP
 }
 
-// recreateNetworkPolicies deletes and immediately re-creates every
-// NetworkPolicy in `ns`. Cilium-agent reconciles the delete (drops the
-// policy program for every identity selected by the policy) and then
-// the create (re-derives and re-installs the program from scratch),
-// which is empirically the cheapest way to nudge cilium out of a state
-// where a specific identity is stuck with ingress.enforcing=false.
+// findNodeForPodIP returns the spec.nodeName of the pod in `ns` whose
+// status.podIP equals `targetIP`, or "" if no such pod exists / on
+// list error. Best-effort lookup used by the cilium-agent restart
+// recovery path.
+func findNodeForPodIP(ctx context.Context, clientset *kubernetes.Clientset, ns, targetIP string) string {
+	pods, err := clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		GinkgoWriter.Printf("findNodeForPodIP: list pods in %s failed: %v\n", ns, err)
+		return ""
+	}
+	for _, p := range pods.Items {
+		if p.Status.PodIP == targetIP {
+			return p.Spec.NodeName
+		}
+	}
+	return ""
+}
+
+// restartCiliumAgentOnNode deletes the kube-system cilium-agent pod
+// scheduled on `nodeName` and waits up to 90 seconds for the
+// DaemonSet's replacement to become Ready. cilium-agent rebuilds its
+// per-identity policy maps from scratch on startup, which is the
+// only mechanism that reliably unwedges a CiliumEndpoint whose
+// status.policy.ingress.enforcing flag is stuck false (see
+// ensureCiliumEndpointEnforcing for the empirical evidence).
 //
 // Best-effort: failures are logged and swallowed so the surrounding
 // ensureCiliumEndpointEnforcing retry loop gets to make the final
 // pass/fail determination based on whether enforcement actually came
-// back up — not on transient list/delete errors.
-func recreateNetworkPolicies(ctx context.Context, clientset *kubernetes.Clientset, ns string) {
-	nps, err := clientset.NetworkingV1().NetworkPolicies(ns).List(ctx, metav1.ListOptions{})
+// back up — not on transient delete / list errors.
+func restartCiliumAgentOnNode(ctx context.Context, clientset *kubernetes.Clientset, nodeName string) {
+	const (
+		readyTimeout = 90 * time.Second
+		pollInterval = 2 * time.Second
+	)
+	pods, err := clientset.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
+		LabelSelector: "k8s-app=cilium",
+		FieldSelector: "spec.nodeName=" + nodeName,
+	})
 	if err != nil {
-		GinkgoWriter.Printf("recreateNetworkPolicies: list in %s failed: %v\n", ns, err)
+		GinkgoWriter.Printf("restartCiliumAgentOnNode: list cilium pods on %s failed: %v\n", nodeName, err)
 		return
 	}
-	for _, np := range nps.Items {
-		// Strip ResourceVersion and other server-managed fields so
-		// the Create below is accepted as a fresh object.
-		fresh := np.DeepCopy()
-		fresh.ObjectMeta = metav1.ObjectMeta{
-			Name:        np.Name,
-			Namespace:   np.Namespace,
-			Labels:      np.Labels,
-			Annotations: np.Annotations,
-		}
-		if err := clientset.NetworkingV1().NetworkPolicies(ns).Delete(ctx, np.Name, metav1.DeleteOptions{}); err != nil {
-			GinkgoWriter.Printf("recreateNetworkPolicies: delete %s/%s failed: %v\n", ns, np.Name, err)
-			continue
-		}
-		// Give the apiserver a tick to finalize the delete; cilium
-		// reconciles on the watch stream so we don't strictly need
-		// to wait, but immediate create-after-delete can occasionally
-		// race the finalizer queue.
-		time.Sleep(500 * time.Millisecond)
-		if _, err := clientset.NetworkingV1().NetworkPolicies(ns).Create(ctx, fresh, metav1.CreateOptions{}); err != nil {
-			GinkgoWriter.Printf("recreateNetworkPolicies: recreate %s/%s failed: %v\n", ns, np.Name, err)
-		}
+	if len(pods.Items) == 0 {
+		GinkgoWriter.Printf("restartCiliumAgentOnNode: no cilium-agent pod found on node %s (cluster may not be Cilium-backed)\n", nodeName)
+		return
 	}
+	victim := pods.Items[0]
+	oldUID := victim.UID
+	GinkgoWriter.Printf("restartCiliumAgentOnNode: deleting kube-system/%s (uid=%s) on node %s\n", victim.Name, oldUID, nodeName)
+	if err := clientset.CoreV1().Pods("kube-system").Delete(ctx, victim.Name, metav1.DeleteOptions{}); err != nil {
+		GinkgoWriter.Printf("restartCiliumAgentOnNode: delete kube-system/%s failed: %v\n", victim.Name, err)
+		return
+	}
+
+	deadline := time.Now().Add(readyTimeout)
+	for time.Now().Before(deadline) {
+		pods, err := clientset.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
+			LabelSelector: "k8s-app=cilium",
+			FieldSelector: "spec.nodeName=" + nodeName,
+		})
+		if err == nil {
+			for _, p := range pods.Items {
+				// Skip the terminating victim.
+				if p.UID == oldUID {
+					continue
+				}
+				if p.Status.Phase != corev1.PodRunning {
+					continue
+				}
+				for _, cs := range p.Status.ContainerStatuses {
+					if cs.Name == "cilium-agent" && cs.Ready {
+						GinkgoWriter.Printf("restartCiliumAgentOnNode: replacement kube-system/%s on %s is Ready\n", p.Name, nodeName)
+						// Give the freshly-started agent a few seconds
+						// to finish its initial endpoint regeneration
+						// pass before the caller re-checks CiliumEndpoint
+						// status. The Ready gate only proves the gRPC
+						// API is up.
+						time.Sleep(5 * time.Second)
+						return
+					}
+				}
+			}
+		}
+		time.Sleep(pollInterval)
+	}
+	GinkgoWriter.Printf("restartCiliumAgentOnNode: replacement cilium-agent on %s did not become Ready within %s\n", nodeName, readyTimeout)
 }
 
 // unstructuredNestedString / Int64 / Bool / Slice are tiny wrappers around

--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -100,16 +100,21 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 		clientset, err = utils.GetK8sClientset()
 		Expect(err).NotTo(HaveOccurred(), "failed to create k8s clientset")
 
-		// Install both workload namespaces. We use the shared InstallCase
-		// here (modelharness → modeldeployment) and rely on
-		// ensureCiliumEndpointEnforcing below to recover from the AKS
-		// Cilium overlay race: an earlier attempt to pre-warm Cilium's
-		// per-namespace policy compile before creating the EPP did not
-		// help, because cilium compiles policy per-identity and the
-		// warmup pod's labels produce a different identity than the EPP.
-		// The only reliable fix is to detect stuck CiliumEndpoints after
-		// the EPP exists and force a fresh allocation by deleting the
-		// pod — see ensureCiliumEndpointEnforcing.
+		// Install both workload namespaces. The canary loop below is
+		// the source of truth for "is enforcement on?" — it probes the
+		// dataplane directly via `agnhost connect`. Earlier branches
+		// of this file tried to gate on the CiliumEndpoint
+		// `status.policy.ingress.enforcing` field as a faster signal,
+		// but three rounds of CI evidence (runs 26430654933 /
+		// 26431394132 / 26432081380) showed that field stays false
+		// indefinitely on AKS Cilium overlay even after pod
+		// recreation, NetworkPolicy delete+create, AND cilium-agent
+		// restart on the EPP's node. The wedge survived every recovery
+		// we threw at the supposed root cause, which means either the
+		// field is lying (enforcement actually IS on, the metadata just
+		// never settles) or the canary will still hang for 5 minutes.
+		// Either way, the canary loop is the only honest test — delete
+		// the gate and let it run.
 		InstallCase(CaseNetworkPolicyA)
 		InstallCase(CaseNetworkPolicyB)
 
@@ -152,18 +157,6 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 		eppIPB, eppPortB = readyEPPPodEndpoint(ctx, clientset, namespaceB, netpolModelB)
 		Expect(eppIPB).NotTo(BeEmpty(), "could not find a ready EPP pod IP in %s", namespaceB)
 		Expect(eppPortB).To(BeNumerically(">", 0), "could not determine EPP pod port in %s", namespaceB)
-
-		// AKS Cilium overlay race recovery: ensure the EPP pod's
-		// CiliumEndpoint advertises ingress.enforcing=true. If it does
-		// not within 60s, delete the EPP pod so its Deployment recreates
-		// it with a fresh CiliumEndpoint allocation (up to maxRetries
-		// cycles). Returns the (possibly new) EPP pod IP, which the deny
-		// / cross-namespace probes below target. Without this gate, an
-		// EPP that landed in the racy window between NetworkPolicy apply
-		// and cilium compile keeps enforcing=false indefinitely, and the
-		// canary loop below would spin for 5 minutes before failing.
-		eppIP = ensureCiliumEndpointEnforcing(ctx, clientset, namespace, netpolModelA, eppIP)
-		eppIPB = ensureCiliumEndpointEnforcing(ctx, clientset, namespaceB, netpolModelB, eppIPB)
 
 		// Wait for NetworkPolicy enforcement to actually take effect on this
 		// cluster. On freshly created Cilium clusters the policy maps may take
@@ -1048,298 +1041,6 @@ func collectCiliumDiagnostics(ctx context.Context, clientset *kubernetes.Clients
 	}
 }
 
-// waitForCiliumEndpointEnforcing polls the CiliumEndpoint backing the pod
-// at `targetIP` in `ns` and fails the current Ginkgo spec if its
-// status.policy.ingress.enforcing does not flip to true within the
-// timeout.
-//
-// Background: AKS clusters running with `--network-dataplane cilium
-// --network-policy cilium` exhibit a race where a pod created in the
-// narrow window between a NetworkPolicy apply and cilium-agent's policy
-// compile lands with enforcing=false on its CiliumEndpoint and stays
-// that way indefinitely. The K8s NetworkPolicies look correct, cilium-
-// agent is healthy, but traffic to the affected endpoint is silently
-// admitted because the eBPF map for that identity has no rules
-// programmed. Symptom: the canary probe loop sees EXIT=0 forever.
-//
-// The fix is to wait for the CiliumEndpoint to advertise enforcing=true
-// before starting probes. If it never flips (the race triggered and is
-// stuck), this helper fails the BeforeAll with a Cilium-specific
-// message — turning a 5-minute generic timeout into a 60-second
-// actionable one.
-//
-// Best-effort: on non-Cilium clusters or when the CRD is missing, the
-// helper logs the situation and returns without failing, so the suite
-// remains portable to kind / OSS Kubernetes clusters.
-// ensureCiliumEndpointEnforcing makes sure the EPP pod currently
-// resolving to `targetIP` in `ns` has a CiliumEndpoint that advertises
-// status.policy.ingress.enforcing == true. On failure, it deletes the
-// EPP pod so the parent Deployment recreates it, waits for the
-// replacement to be ready, and re-checks — up to maxRetries cycles.
-// Returns the (possibly new) EPP pod IP that callers should use for
-// probing.
-//
-// Why delete-and-retry rather than just polling: the AKS Cilium overlay
-// race produces *stuck* CiliumEndpoints. The endpoint is in state=ready
-// with a valid identity, but its policy.ingress.enforcing flag never
-// flips because cilium-agent's reconcile happened before the policy was
-// known and was never re-triggered for that identity. Polling does not
-// unstick it; only a new endpoint allocation does. The pre-warm
-// (installNetpolCase Phase 2) reduces but does not eliminate this race
-// because Cilium compiles policy per-identity and the EPP gets a
-// different identity than the warmup pod.
-//
-// Best-effort: on non-Cilium clusters or when the CRD is missing, the
-// helper logs and returns targetIP unchanged so the suite remains
-// portable to kind / OSS K8s.
-// ensureCiliumEndpointEnforcing makes sure the EPP pod resolving to
-// `targetIP` in `ns` has a CiliumEndpoint that advertises
-// status.policy.ingress.enforcing == true. On failure, it restarts the
-// cilium-agent pod on the EPP's node so the dataplane rebuilds its
-// policy maps from scratch for every local endpoint (including the
-// stuck EPP identity), then re-checks. Up to maxRetries cycles.
-// Returns targetIP unchanged — the EPP pod is never disturbed.
-//
-// Why restart-cilium-agent rather than recreate-policy or delete-the-pod:
-// the AKS Cilium overlay race produces *stuck* CiliumEndpoints whose
-// status.policy.ingress.enforcing flag never flips. Empirically:
-//   - Run 26430654933 (pod-delete recovery): all 3 EPP recreations got
-//     the same Cilium identity 26694; Cilium hashes identity from the
-//     pod's full label set so EPP replicas always collide and inherit
-//     the same wedged policy program.
-//   - Run 26431394132 (NetworkPolicy recreate): identity 10406
-//     remained stuck across 2 full delete+create cycles of the
-//     namespace's NetworkPolicies, so cilium-agent's reconciliation
-//     does not unwedge the local policy map either.
-//
-// The stuck state is held inside cilium-agent's per-identity policy
-// table on the node, and only restarting the agent reliably rebuilds
-// it. This touches kube-system, so it's gated behind two failed
-// attempts and a tight CRD probe — non-Cilium clusters skip the
-// recovery entirely.
-//
-// Best-effort: on non-Cilium clusters or when the CRD is missing, the
-// helper logs and returns targetIP unchanged so the suite remains
-// portable to kind / OSS K8s.
-func ensureCiliumEndpointEnforcing(ctx context.Context, clientset *kubernetes.Clientset, ns, deploymentName, targetIP string) string {
-	const (
-		perAttemptTimeout = 60 * time.Second
-		pollInterval      = 2 * time.Second
-		maxRetries        = 2 // initial attempt + 2 cilium-agent restarts
-	)
-	_ = deploymentName // kept in the signature so callers can re-supply
-
-	dyn, derr := utils.GetDynamicClient()
-	if derr != nil {
-		GinkgoWriter.Printf("ensureCiliumEndpointEnforcing: dynamic client unavailable (%v) — skipping Cilium enforcement gate for %s/%s\n", derr, ns, targetIP)
-		return targetIP
-	}
-	cepGVR := schema.GroupVersionResource{
-		Group: "cilium.io", Version: "v2", Resource: "ciliumendpoints",
-	}
-
-	// Probe once to see if the CRD is registered at all. If not, this is
-	// not a Cilium cluster — silently skip so kind / OSS K8s users can
-	// still run the suite.
-	if _, err := dyn.Resource(cepGVR).Namespace(ns).List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
-		GinkgoWriter.Printf("ensureCiliumEndpointEnforcing: CiliumEndpoint CRD not available (%v) — skipping enforcement gate for %s/%s\n", err, ns, targetIP)
-		return targetIP
-	}
-
-	var (
-		lastState      string
-		lastIngressEnf bool
-		lastIdentity   int64
-		lastName       string
-		foundEndpoint  bool
-	)
-
-	for attempt := 0; attempt <= maxRetries; attempt++ {
-		// Reset capture state for this attempt so the failure message
-		// reflects the current attempt's CEP, not a stale one.
-		foundEndpoint = false
-		lastName, lastState = "", ""
-		lastIdentity = 0
-		lastIngressEnf = false
-
-		deadline := time.Now().Add(perAttemptTimeout)
-		enforced := false
-		for time.Now().Before(deadline) {
-			ceps, err := dyn.Resource(cepGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
-			if err == nil {
-				for _, cep := range ceps.Items {
-					addrs, _, _ := unstructuredNestedSlice(cep.Object, "status", "networking", "addressing")
-					match := false
-					for _, a := range addrs {
-						if m, ok := a.(map[string]any); ok {
-							if v, _ := m["ipv4"].(string); v == targetIP {
-								match = true
-								break
-							}
-						}
-					}
-					if !match {
-						continue
-					}
-					foundEndpoint = true
-					lastName = cep.GetName()
-					lastState, _, _ = unstructuredNestedString(cep.Object, "status", "state")
-					lastIdentity, _, _ = unstructuredNestedInt64(cep.Object, "status", "identity", "id")
-					lastIngressEnf, _, _ = unstructuredNestedBool(cep.Object, "status", "policy", "ingress", "enforcing")
-					if lastIngressEnf {
-						enforced = true
-					}
-					break
-				}
-			}
-			if enforced {
-				break
-			}
-			time.Sleep(pollInterval)
-		}
-		if enforced {
-			return targetIP
-		}
-
-		if attempt == maxRetries {
-			break
-		}
-
-		// Stuck. Recover by restarting cilium-agent on the EPP's node.
-		// Neither pod-recreation nor NetworkPolicy delete+create
-		// unwedges this state empirically (see func doc), because the
-		// stuck program lives inside the agent's per-identity policy
-		// table on the node. Locate the EPP's node from the matching
-		// pod's IP, then delete the kube-system cilium pod scheduled
-		// there. The DaemonSet will reschedule it within seconds and
-		// the replacement reloads its policy maps from scratch.
-		eppNode := findNodeForPodIP(ctx, clientset, ns, targetIP)
-		if eppNode == "" {
-			GinkgoWriter.Printf(
-				"ensureCiliumEndpointEnforcing: attempt %d/%d — CEP %s/%s "+
-					"(identity=%d state=%s) stuck with ingress.enforcing=%v; "+
-					"could not resolve EPP node from IP %s — skipping cilium-agent restart\n",
-				attempt+1, maxRetries+1, ns, lastName, lastIdentity, lastState, lastIngressEnf, targetIP)
-			continue
-		}
-		GinkgoWriter.Printf(
-			"ensureCiliumEndpointEnforcing: attempt %d/%d — CEP %s/%s "+
-				"(identity=%d state=%s) stuck with ingress.enforcing=%v; "+
-				"restarting cilium-agent on node %s to force dataplane policy rebuild\n",
-			attempt+1, maxRetries+1, ns, lastName, lastIdentity, lastState, lastIngressEnf, eppNode)
-		restartCiliumAgentOnNode(ctx, clientset, eppNode)
-	}
-
-	// All retries exhausted.
-	Expect(false).To(BeTrue(),
-		func() string {
-			if !foundEndpoint {
-				return fmt.Sprintf(
-					"no CiliumEndpoint with IP %s appeared in %s after %d retries — "+
-						"cilium-agent never programmed the EPP endpoint. Check cilium-agent "+
-						"pod health on the EPP's node.",
-					targetIP, ns, maxRetries)
-			}
-			return fmt.Sprintf(
-				"EPP CiliumEndpoint %s/%s (identity=%d state=%s) stuck with "+
-					"ingress.enforcing=%v even after %d cilium-agent restarts on the EPP's "+
-					"node — the AKS Cilium overlay race is not recoverable on this cluster "+
-					"via in-test means. The agent's per-identity policy table refuses to "+
-					"program rules for this identity even after a fresh agent process. "+
-					"Likely a CRD reconciliation bug or a cluster-wide cilium-operator issue.",
-				ns, lastName, lastIdentity, lastState, lastIngressEnf, maxRetries)
-		}())
-	return targetIP
-}
-
-// findNodeForPodIP returns the spec.nodeName of the pod in `ns` whose
-// status.podIP equals `targetIP`, or "" if no such pod exists / on
-// list error. Best-effort lookup used by the cilium-agent restart
-// recovery path.
-func findNodeForPodIP(ctx context.Context, clientset *kubernetes.Clientset, ns, targetIP string) string {
-	pods, err := clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
-	if err != nil {
-		GinkgoWriter.Printf("findNodeForPodIP: list pods in %s failed: %v\n", ns, err)
-		return ""
-	}
-	for _, p := range pods.Items {
-		if p.Status.PodIP == targetIP {
-			return p.Spec.NodeName
-		}
-	}
-	return ""
-}
-
-// restartCiliumAgentOnNode deletes the kube-system cilium-agent pod
-// scheduled on `nodeName` and waits up to 90 seconds for the
-// DaemonSet's replacement to become Ready. cilium-agent rebuilds its
-// per-identity policy maps from scratch on startup, which is the
-// only mechanism that reliably unwedges a CiliumEndpoint whose
-// status.policy.ingress.enforcing flag is stuck false (see
-// ensureCiliumEndpointEnforcing for the empirical evidence).
-//
-// Best-effort: failures are logged and swallowed so the surrounding
-// ensureCiliumEndpointEnforcing retry loop gets to make the final
-// pass/fail determination based on whether enforcement actually came
-// back up — not on transient delete / list errors.
-func restartCiliumAgentOnNode(ctx context.Context, clientset *kubernetes.Clientset, nodeName string) {
-	const (
-		readyTimeout = 90 * time.Second
-		pollInterval = 2 * time.Second
-	)
-	pods, err := clientset.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
-		LabelSelector: "k8s-app=cilium",
-		FieldSelector: "spec.nodeName=" + nodeName,
-	})
-	if err != nil {
-		GinkgoWriter.Printf("restartCiliumAgentOnNode: list cilium pods on %s failed: %v\n", nodeName, err)
-		return
-	}
-	if len(pods.Items) == 0 {
-		GinkgoWriter.Printf("restartCiliumAgentOnNode: no cilium-agent pod found on node %s (cluster may not be Cilium-backed)\n", nodeName)
-		return
-	}
-	victim := pods.Items[0]
-	oldUID := victim.UID
-	GinkgoWriter.Printf("restartCiliumAgentOnNode: deleting kube-system/%s (uid=%s) on node %s\n", victim.Name, oldUID, nodeName)
-	if err := clientset.CoreV1().Pods("kube-system").Delete(ctx, victim.Name, metav1.DeleteOptions{}); err != nil {
-		GinkgoWriter.Printf("restartCiliumAgentOnNode: delete kube-system/%s failed: %v\n", victim.Name, err)
-		return
-	}
-
-	deadline := time.Now().Add(readyTimeout)
-	for time.Now().Before(deadline) {
-		pods, err := clientset.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
-			LabelSelector: "k8s-app=cilium",
-			FieldSelector: "spec.nodeName=" + nodeName,
-		})
-		if err == nil {
-			for _, p := range pods.Items {
-				// Skip the terminating victim.
-				if p.UID == oldUID {
-					continue
-				}
-				if p.Status.Phase != corev1.PodRunning {
-					continue
-				}
-				for _, cs := range p.Status.ContainerStatuses {
-					if cs.Name == "cilium-agent" && cs.Ready {
-						GinkgoWriter.Printf("restartCiliumAgentOnNode: replacement kube-system/%s on %s is Ready\n", p.Name, nodeName)
-						// Give the freshly-started agent a few seconds
-						// to finish its initial endpoint regeneration
-						// pass before the caller re-checks CiliumEndpoint
-						// status. The Ready gate only proves the gRPC
-						// API is up.
-						time.Sleep(5 * time.Second)
-						return
-					}
-				}
-			}
-		}
-		time.Sleep(pollInterval)
-	}
-	GinkgoWriter.Printf("restartCiliumAgentOnNode: replacement cilium-agent on %s did not become Ready within %s\n", nodeName, readyTimeout)
-}
 
 // unstructuredNestedString / Int64 / Bool / Slice are tiny wrappers around
 // the apimachinery helpers. We re-export here to keep the diag function

--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -100,12 +100,18 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 		clientset, err = utils.GetK8sClientset()
 		Expect(err).NotTo(HaveOccurred(), "failed to create k8s clientset")
 
-		// Install both workload namespaces (each with default-deny + allow-inference
-		// NetworkPolicy pair) via the shared case framework. InstallCase handles
-		// the per-namespace Gateway, modeldeployment Helm release, EPP / shadow
-		// pod readiness, and gateway routing warmup.
-		InstallCase(CaseNetworkPolicyA)
-		InstallCase(CaseNetworkPolicyB)
+		// Install both workload namespaces in two phases per namespace:
+		//   1. modelharness (Gateway + NetworkPolicies) and a Cilium policy
+		//      pre-warm that proves the local cilium-agent has compiled the
+		//      namespace's default-deny rule into its eBPF maps.
+		//   2. modeldeployment (EPP + InferenceSet + shadow pods).
+		// The pre-warm closes the AKS Cilium overlay race where an EPP pod
+		// created in the gap between policy apply and cilium compile lands
+		// with status.policy.ingress.enforcing=false and never recovers.
+		// We do not use the shared InstallCase here because it bundles both
+		// phases and gives us no place to slot the pre-warm in between.
+		installNetpolCase(ctx, clientset, CaseNetworkPolicyA)
+		installNetpolCase(ctx, clientset, CaseNetworkPolicyB)
 
 		namespace = CaseNamespace(CaseNetworkPolicyA)
 		namespaceB = CaseNamespace(CaseNetworkPolicyB)
@@ -1142,6 +1148,223 @@ func waitForCiliumEndpointEnforcing(ctx context.Context, _ *kubernetes.Clientset
 					"probe loop because it would otherwise spin for 5 minutes "+
 					"on this race.",
 				ns, lastName, lastIdentity, lastState, lastIngressEnf, timeout)
+		})
+}
+
+// installNetpolCase is a netpol-test-specific replacement for the shared
+// InstallCase. It splits the install into two phases so we can pre-warm
+// Cilium's namespace policy in between:
+//
+//  1. modelharness chart → renders the Gateway, NetworkPolicies, and (when
+//     enabled) AuthorizationPolicy/APIKey CR. After this returns, the K8s
+//     NetworkPolicy objects exist in the API server but cilium-agent on
+//     each node may not have compiled them into the local eBPF map yet.
+//  2. Cilium pre-warm → create a throwaway non-gateway pod in the workload
+//     namespace and probe it from a throwaway external namespace until the
+//     probe is silently dropped. This proves cilium-agent has compiled the
+//     namespace's default-deny rule AND is actively applying it to fresh
+//     endpoints, closing the race that otherwise strands the EPP's
+//     CiliumEndpoint with status.policy.ingress.enforcing=false.
+//  3. modeldeployment chart → renders the EPP / InferenceSet / shadow
+//     pods. Because step (2) confirmed Cilium is enforcing, the EPP pod's
+//     CiliumEndpoint will be programmed with the policy at allocation
+//     time rather than racing the cilium reconcile.
+//
+// This is intentionally an inlined copy of InstallCase's flow rather than
+// a refactor of InstallCase itself — the pre-warm is only meaningful for
+// the netpol suite (other suites don't enable NetworkPolicies), so
+// keeping the override here avoids polluting the shared case framework
+// with cilium-specific timing assumptions.
+func installNetpolCase(ctx context.Context, clientset *kubernetes.Clientset, caseName string) {
+	ns := CaseNamespace(caseName)
+	gatewayName := CaseGatewayName(caseName)
+	Expect(ns).NotTo(BeEmpty(), "case %q has no namespace declared in CaseDeployments", caseName)
+
+	first := CaseDeployments[caseName][0]
+
+	By(fmt.Sprintf("Phase 1: installing modelharness (Gateway + NetworkPolicies) in %s", ns))
+	Expect(utils.EnsureNamespace(ctx, ns, first.AuthAPIKeyEnabled)).To(Succeed(),
+		"failed to ensure namespace %s for case %s", ns, caseName)
+	Expect(utils.WaitForGatewayService(ctx, ns, gatewayName, utils.InferenceSetReadyTimeout)).
+		To(Succeed(), "gateway service for %s did not appear", caseName)
+
+	By(fmt.Sprintf("Phase 2: pre-warming Cilium policy enforcement in %s", ns))
+	prewarmCiliumPolicyInNamespace(ctx, clientset, ns)
+
+	By(fmt.Sprintf("Phase 3: installing modeldeployment(s) in %s", ns))
+	gatewayURL, err := utils.GetGatewayURLFor(ns, gatewayName)
+	Expect(err).NotTo(HaveOccurred(), "failed to resolve gateway URL for case %s", caseName)
+	utils.SetupInferenceSetsWithRouting(CaseDeployments[caseName], ns, gatewayURL)
+}
+
+// prewarmCiliumPolicyInNamespace forces cilium-agent on the workload
+// namespace's nodes to compile the modelharness-rendered
+// `default-deny-ingress` rule before any real inference pod (EPP, vLLM,
+// shadow) lands on those nodes. Without this pre-warm, a real pod
+// created in the window between policy apply and cilium compile lands
+// with status.policy.ingress.enforcing=false on its CiliumEndpoint and
+// never recovers — the symptom that gates the BeforeAll's canary loop
+// against the AKS overlay race.
+//
+// Strategy: stand up a throwaway "warmup" pod in the workload namespace
+// (selected by default-deny-ingress because it lacks the gateway-name
+// label) and a throwaway probe pod in an external namespace. Repeatedly
+// `agnhost connect` from probe to warmup until the connect is silently
+// dropped (EXIT=1) — that proves the cilium dataplane is enforcing the
+// policy for fresh endpoints in this namespace. Then tear both pods down.
+//
+// Best-effort with a tight timeout: on non-Cilium clusters or unusually
+// slow cilium reconciles, we fail loud with a Cilium-specific message
+// rather than wedging the whole suite.
+func prewarmCiliumPolicyInNamespace(ctx context.Context, clientset *kubernetes.Clientset, ns string) {
+	const (
+		prewarmTimeout      = 90 * time.Second
+		prewarmPollInterval = 3 * time.Second
+	)
+
+	warmupNS := ns // target pod lives in the workload namespace so the
+	// namespace-scoped default-deny-ingress selects it.
+	warmupPodName := fmt.Sprintf("netpol-warmup-%d", rand.Intn(900000)+100000)
+	warmupPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      warmupPodName,
+			Namespace: warmupNS,
+			// Explicitly NOT carrying the gateway-name label, so the
+			// default-deny-ingress policy applies. The synthetic
+			// label below distinguishes this pod from real workloads
+			// in logs without changing policy semantics.
+			Labels: map[string]string{"netpol-warmup": "true"},
+			// Disable Istio sidecar injection on the warmup pod —
+			// mesh mTLS would make the probe see 127.0.0.1 and
+			// short-circuit NetworkPolicy entirely.
+			Annotations: map[string]string{"sidecar.istio.io/inject": "false"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "warmup",
+				Image: probeImage,
+				// `pause` keeps the container alive with NO TCP
+				// listener bound. That's deliberate: with no listener,
+				// the probe's SYN to port 8080 has only two possible
+				// outcomes:
+				//   - policy NOT enforcing → SYN reaches the pod's
+				//     node → kernel rejects with RST → EXIT=2 (REFUSED)
+				//   - policy IS enforcing → SYN silently dropped by
+				//     cilium-agent's eBPF map → EXIT=1 (TIMEOUT)
+				// EXIT=1 is therefore unambiguous evidence the
+				// namespace's default-deny rule has been compiled and
+				// is being applied to fresh endpoints.
+				Args: []string{"pause"},
+			}},
+		},
+	}
+	_, err := clientset.CoreV1().Pods(warmupNS).Create(ctx, warmupPod, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to create cilium pre-warm target pod in %s", warmupNS)
+	defer func() {
+		_ = clientset.CoreV1().Pods(warmupNS).Delete(ctx, warmupPodName, metav1.DeleteOptions{})
+	}()
+	Expect(utils.WaitForPodReady(ctx, clientset, warmupNS, warmupPodName, utils.PollTimeout)).
+		To(Succeed(), "cilium pre-warm target pod %s/%s did not become ready", warmupNS, warmupPodName)
+
+	// Re-read the pod for its PodIP.
+	warmupPod, err = clientset.CoreV1().Pods(warmupNS).Get(ctx, warmupPodName, metav1.GetOptions{})
+	Expect(err).NotTo(HaveOccurred())
+	Expect(warmupPod.Status.PodIP).NotTo(BeEmpty(), "cilium pre-warm target pod has no PodIP")
+
+	// Probe namespace: must NOT be the workload namespace itself
+	// (intra-namespace traffic is allowed by allow-inference-traffic's
+	// `podSelector: {}` clause and so cannot prove enforcement).
+	probeNS := fmt.Sprintf("e2e-netpol-prewarm-%d", rand.Intn(900000)+100000)
+	_, _ = clientset.CoreV1().Namespaces().Create(ctx, &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{Name: probeNS},
+	}, metav1.CreateOptions{})
+	defer func() {
+		_ = clientset.CoreV1().Namespaces().Delete(ctx, probeNS, metav1.DeleteOptions{})
+	}()
+	Eventually(func() error {
+		_, err := clientset.CoreV1().ServiceAccounts(probeNS).Get(ctx, "default", metav1.GetOptions{})
+		return err
+	}, 30*time.Second, time.Second).Should(Succeed(),
+		"default ServiceAccount in %s did not appear", probeNS)
+
+	probePodName := fmt.Sprintf("netpol-prewarm-probe-%d", rand.Intn(900000)+100000)
+	probePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        probePodName,
+			Namespace:   probeNS,
+			Annotations: map[string]string{"sidecar.istio.io/inject": "false"},
+		},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{
+				Name:  "probe",
+				Image: probeImage,
+				Args:  []string{"pause"},
+			}},
+		},
+	}
+	_, err = clientset.CoreV1().Pods(probeNS).Create(ctx, probePod, metav1.CreateOptions{})
+	Expect(err).NotTo(HaveOccurred(), "failed to create cilium pre-warm probe pod in %s", probeNS)
+	Expect(utils.WaitForPodReady(ctx, clientset, probeNS, probePodName, utils.PollTimeout)).
+		To(Succeed(), "cilium pre-warm probe pod %s/%s did not become ready", probeNS, probePodName)
+
+	restCfg, err := utils.GetK8sConfig()
+	Expect(err).NotTo(HaveOccurred())
+
+	var lastOut, lastErr string
+	Eventually(func() bool {
+		cmd := []string{"sh", "-c", fmt.Sprintf(
+			"/agnhost connect %s:8080 --timeout=%s --protocol=tcp 2>&1; echo EXIT=$?",
+			warmupPod.Status.PodIP, probeConnectTimeout,
+		)}
+		req := clientset.CoreV1().RESTClient().Post().
+			Resource("pods").Name(probePodName).Namespace(probeNS).
+			SubResource("exec").
+			VersionedParams(&corev1.PodExecOptions{
+				Command: cmd, Stdout: true, Stderr: true,
+			}, scheme.ParameterCodec)
+		exec, err := remotecommand.NewSPDYExecutor(restCfg, "POST", req.URL())
+		if err != nil {
+			lastErr = "newSPDYExecutor: " + err.Error()
+			return false
+		}
+		var stdout, stderr bytes.Buffer
+		execCtx, cancel := context.WithTimeout(ctx, probeTimeout)
+		defer cancel()
+		streamErr := exec.StreamWithContext(execCtx, remotecommand.StreamOptions{
+			Stdout: &stdout, Stderr: &stderr,
+		})
+		out := stdout.String() + stderr.String()
+		lastOut = out
+		if streamErr != nil {
+			lastErr = "stream: " + streamErr.Error()
+		} else {
+			lastErr = ""
+		}
+		// We want the probe to be silently dropped (EXIT=1 = TIMEOUT).
+		// The warmup pod has no TCP listener, so:
+		//   EXIT=2 (REFUSED) = SYN reached the pod and got RST — cilium
+		//   has NOT compiled the deny rule for this endpoint yet, keep
+		//   polling.
+		//   EXIT=1 (TIMEOUT) = SYN silently dropped — cilium IS
+		//   enforcing the policy on a fresh endpoint in this namespace.
+		//   EXIT=0 should not happen (no listener) but would also mean
+		//   not-enforced; keep polling.
+		return bytes.Contains([]byte(out), []byte("EXIT=1"))
+	}, prewarmTimeout, prewarmPollInterval).Should(BeTrue(),
+		func() string {
+			return fmt.Sprintf(
+				"Cilium policy pre-warm in %s did not converge within %s — "+
+					"cilium-agent never compiled the default-deny-ingress rule "+
+					"into a state that drops cross-namespace traffic to a fresh "+
+					"non-gateway pod. This is the AKS Cilium overlay race "+
+					"manifesting at the namespace level. The EPP pod created "+
+					"after this would land with ingress.enforcing=false, so "+
+					"failing here surfaces the root cause instead of letting "+
+					"the BeforeAll canary loop spin for 5 minutes.\n"+
+					"last agnhost output: %q\nlast exec error: %q\n"+
+					"warmupPodIP=%s warmupNS=%s probeNS=%s",
+				ns, prewarmTimeout, lastOut, lastErr,
+				warmupPod.Status.PodIP, warmupNS, probeNS)
 		})
 }
 

--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -113,7 +113,7 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 		// we threw at the supposed root cause, which means either the
 		// field is lying (enforcement actually IS on, the metadata just
 		// never settles) or the canary will still hang for its full
-		// 10-minute deadline. Either way, the canary loop is the only
+		// 2-minute deadline. Either way, the canary loop is the only
 		// honest test — delete the gate and let it run.
 		InstallCase(CaseNetworkPolicyA)
 		InstallCase(CaseNetworkPolicyB)
@@ -274,7 +274,7 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 			// EXIT=N (N != 0): nc could not establish the TCP handshake from
 			// the external canary namespace. Enforcement is active.
 			return true
-		}, 10*time.Minute, 5*time.Second).Should(BeTrue(),
+		}, 2*time.Minute, 5*time.Second).Should(BeTrue(),
 			// Use a func() string so Gomega evaluates the diagnostic message
 			// lazily, after the polling loop has updated the captured
 			// variables. Passing `lastCanaryOut`/`lastCanaryExecErr` as
@@ -1132,7 +1132,7 @@ var _ = networkingv1.SchemeGroupVersion
 // in `ns` has rendered both `default-deny-ingress` and
 // `allow-inference-traffic` NetworkPolicies. Failing here turns a silent
 // chart regression into an immediate, clearly-attributable BeforeAll
-// failure rather than a 10-minute canary timeout that — by the time CI's
+// failure rather than a 2-minute canary timeout that — by the time CI's
 // post-failure dump runs — has been masked by AfterAll teardown.
 func expectNetworkPoliciesPresent(ctx context.Context, clientset *kubernetes.Clientset, ns string) {
 	required := map[string]bool{

--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -1092,12 +1092,35 @@ func collectCiliumDiagnostics(ctx context.Context, clientset *kubernetes.Clients
 // Best-effort: on non-Cilium clusters or when the CRD is missing, the
 // helper logs and returns targetIP unchanged so the suite remains
 // portable to kind / OSS K8s.
+// ensureCiliumEndpointEnforcing makes sure the EPP pod resolving to
+// `targetIP` in `ns` has a CiliumEndpoint that advertises
+// status.policy.ingress.enforcing == true. On failure, it deletes and
+// re-creates the namespace's NetworkPolicies to force cilium-agent to
+// recompile policy for every identity in the namespace (including the
+// stuck EPP identity), then re-checks. Up to maxRetries cycles.
+// Returns targetIP unchanged — the EPP pod is never disturbed.
+//
+// Why recreate-the-policies rather than delete-the-pod: the AKS Cilium
+// overlay race produces *stuck* CiliumEndpoints whose
+// status.policy.ingress.enforcing flag never flips. Empirically (see
+// run 26430654933) all 3 EPP recreations got the same Cilium identity
+// — Cilium hashes identity from the pod's full label set, so EPP
+// replicas always collide. The stuck state is held against the
+// *identity*, not the endpoint, so spinning up a new endpoint with the
+// same identity inherits the same wedged policy program. The fix is to
+// nudge cilium-agent to re-evaluate the identity's policy, which a
+// NetworkPolicy delete+create reliably does.
+//
+// Best-effort: on non-Cilium clusters or when the CRD is missing, the
+// helper logs and returns targetIP unchanged so the suite remains
+// portable to kind / OSS K8s.
 func ensureCiliumEndpointEnforcing(ctx context.Context, clientset *kubernetes.Clientset, ns, deploymentName, targetIP string) string {
 	const (
 		perAttemptTimeout = 60 * time.Second
 		pollInterval      = 2 * time.Second
-		maxRetries        = 2 // initial attempt + 2 EPP-pod recreations
+		maxRetries        = 2 // initial attempt + 2 NetworkPolicy recreations
 	)
+	_ = deploymentName // kept in the signature so callers can re-supply
 
 	dyn, derr := utils.GetDynamicClient()
 	if derr != nil {
@@ -1116,7 +1139,6 @@ func ensureCiliumEndpointEnforcing(ctx context.Context, clientset *kubernetes.Cl
 		return targetIP
 	}
 
-	currentIP := targetIP
 	var (
 		lastState      string
 		lastIngressEnf bool
@@ -1143,7 +1165,7 @@ func ensureCiliumEndpointEnforcing(ctx context.Context, clientset *kubernetes.Cl
 					match := false
 					for _, a := range addrs {
 						if m, ok := a.(map[string]any); ok {
-							if v, _ := m["ipv4"].(string); v == currentIP {
+							if v, _ := m["ipv4"].(string); v == targetIP {
 								match = true
 								break
 							}
@@ -1169,39 +1191,25 @@ func ensureCiliumEndpointEnforcing(ctx context.Context, clientset *kubernetes.Cl
 			time.Sleep(pollInterval)
 		}
 		if enforced {
-			return currentIP
+			return targetIP
 		}
 
 		if attempt == maxRetries {
 			break
 		}
 
-		// Stuck. Recover by deleting the EPP pod so its Deployment
-		// recreates it. The fresh pod gets a new CiliumEndpoint
-		// allocation, and by now the namespace's policy has been
-		// observed by cilium-agent (Phase 2 pre-warm + first attempt's
-		// poll window), so the new endpoint should be programmed with
-		// the policy at allocation time.
-		oldPodName := findPodNameByIP(ctx, clientset, ns, currentIP)
+		// Stuck. Recover by deleting+re-creating the namespace's
+		// NetworkPolicies so cilium-agent re-evaluates policy for every
+		// identity in this namespace — including the wedged EPP
+		// identity. Pod-level recreation does not help because EPP
+		// replicas hash to the same Cilium identity and inherit the same
+		// stuck policy program.
 		GinkgoWriter.Printf(
 			"ensureCiliumEndpointEnforcing: attempt %d/%d — CEP %s/%s "+
 				"(identity=%d state=%s) stuck with ingress.enforcing=%v; "+
-				"deleting EPP pod %s/%s to force a fresh CiliumEndpoint allocation\n",
-			attempt+1, maxRetries+1, ns, lastName, lastIdentity, lastState, lastIngressEnf, ns, oldPodName)
-		if oldPodName != "" {
-			_ = clientset.CoreV1().Pods(ns).Delete(ctx, oldPodName, metav1.DeleteOptions{})
-		}
-		// Wait for a new Ready EPP pod with a different IP (the old IP
-		// may briefly persist on a Terminating pod). Reuse the
-		// readyEPPPodEndpoint helper, then make sure we actually got a
-		// new IP — otherwise we'd just re-check the same stuck endpoint.
-		Eventually(func() bool {
-			ip, _ := readyEPPPodEndpoint(ctx, clientset, ns, deploymentName)
-			return ip != "" && ip != currentIP
-		}, 3*time.Minute, 5*time.Second).Should(BeTrue(),
-			"new EPP pod did not get a different IP after delete in %s", ns)
-		newIP, _ := readyEPPPodEndpoint(ctx, clientset, ns, deploymentName)
-		currentIP = newIP
+				"recreating NetworkPolicies in %s to force cilium policy recompile\n",
+			attempt+1, maxRetries+1, ns, lastName, lastIdentity, lastState, lastIngressEnf, ns)
+		recreateNetworkPolicies(ctx, clientset, ns)
 	}
 
 	// All retries exhausted.
@@ -1212,34 +1220,60 @@ func ensureCiliumEndpointEnforcing(ctx context.Context, clientset *kubernetes.Cl
 					"no CiliumEndpoint with IP %s appeared in %s after %d retries — "+
 						"cilium-agent never programmed the EPP endpoint. Check cilium-agent "+
 						"pod health on the EPP's node.",
-					currentIP, ns, maxRetries)
+					targetIP, ns, maxRetries)
 			}
 			return fmt.Sprintf(
 				"EPP CiliumEndpoint %s/%s (identity=%d state=%s) stuck with "+
-					"ingress.enforcing=%v even after %d EPP pod recreations — the AKS "+
-					"Cilium overlay race is not recoverable on this cluster. "+
-					"cilium-agent is failing to program the policy for newly-allocated "+
-					"identities in this namespace. Likely needs a cilium-agent restart "+
-					"on the EPP's node.",
+					"ingress.enforcing=%v even after %d NetworkPolicy recreations — the AKS "+
+					"Cilium overlay race is not recoverable on this cluster via "+
+					"in-test means. cilium-agent is failing to re-evaluate policy for "+
+					"this identity even after the policies are re-created. Likely needs "+
+					"a cilium-agent restart on the EPP's node.",
 				ns, lastName, lastIdentity, lastState, lastIngressEnf, maxRetries)
 		}())
-	return currentIP
+	return targetIP
 }
 
-// findPodNameByIP returns the name of the pod in `ns` whose PodIP
-// matches `ip`, or "" if no such pod is found. Best-effort: list errors
-// are swallowed.
-func findPodNameByIP(ctx context.Context, clientset *kubernetes.Clientset, ns, ip string) string {
-	pods, err := clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{})
+// recreateNetworkPolicies deletes and immediately re-creates every
+// NetworkPolicy in `ns`. Cilium-agent reconciles the delete (drops the
+// policy program for every identity selected by the policy) and then
+// the create (re-derives and re-installs the program from scratch),
+// which is empirically the cheapest way to nudge cilium out of a state
+// where a specific identity is stuck with ingress.enforcing=false.
+//
+// Best-effort: failures are logged and swallowed so the surrounding
+// ensureCiliumEndpointEnforcing retry loop gets to make the final
+// pass/fail determination based on whether enforcement actually came
+// back up — not on transient list/delete errors.
+func recreateNetworkPolicies(ctx context.Context, clientset *kubernetes.Clientset, ns string) {
+	nps, err := clientset.NetworkingV1().NetworkPolicies(ns).List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return ""
+		GinkgoWriter.Printf("recreateNetworkPolicies: list in %s failed: %v\n", ns, err)
+		return
 	}
-	for _, p := range pods.Items {
-		if p.Status.PodIP == ip {
-			return p.Name
+	for _, np := range nps.Items {
+		// Strip ResourceVersion and other server-managed fields so
+		// the Create below is accepted as a fresh object.
+		fresh := np.DeepCopy()
+		fresh.ObjectMeta = metav1.ObjectMeta{
+			Name:        np.Name,
+			Namespace:   np.Namespace,
+			Labels:      np.Labels,
+			Annotations: np.Annotations,
+		}
+		if err := clientset.NetworkingV1().NetworkPolicies(ns).Delete(ctx, np.Name, metav1.DeleteOptions{}); err != nil {
+			GinkgoWriter.Printf("recreateNetworkPolicies: delete %s/%s failed: %v\n", ns, np.Name, err)
+			continue
+		}
+		// Give the apiserver a tick to finalize the delete; cilium
+		// reconciles on the watch stream so we don't strictly need
+		// to wait, but immediate create-after-delete can occasionally
+		// race the finalizer queue.
+		time.Sleep(500 * time.Millisecond)
+		if _, err := clientset.NetworkingV1().NetworkPolicies(ns).Create(ctx, fresh, metav1.CreateOptions{}); err != nil {
+			GinkgoWriter.Printf("recreateNetworkPolicies: recreate %s/%s failed: %v\n", ns, np.Name, err)
 		}
 	}
-	return ""
 }
 
 // unstructuredNestedString / Int64 / Bool / Slice are tiny wrappers around

--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -29,6 +29,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/tools/remotecommand"
@@ -894,7 +895,171 @@ func networkPolicyEnforcementDiagnostics(ctx context.Context, clientset *kuberne
 			fmt.Fprintf(&b, "  <no netpol-* probe pods found — probe was already torn down>\n")
 		}
 	}
+
+	// 5. Cilium dataplane state. The AKS e2e cluster runs Azure CNI
+	//    overlay with `--network-dataplane cilium --network-policy cilium`,
+	//    so K8s NetworkPolicies are enforced by cilium-agent on each
+	//    node. When the K8s policies are present on the API server but
+	//    canary traffic is still admitted, the candidates are:
+	//      a) cilium-agent on the EPP's node isn't Ready (or missing),
+	//         so the policy never got compiled into the local eBPF map;
+	//      b) the EPP pod's CiliumEndpoint exists but its
+	//         status.policy.ingress.enforcing is false — common when an
+	//         endpoint was created before its identity was allocated;
+	//      c) the K8s NetworkPolicies were never translated into Cilium's
+	//         internal representation (would show as 0 CiliumNetworkPolicy
+	//         resources AND no inline status on CiliumEndpoint).
+	//    Dump the minimum that distinguishes (a)/(b)/(c). All calls are
+	//    best-effort — on non-Cilium clusters the CRDs / pods are absent
+	//    and we just skip the section.
+	collectCiliumDiagnostics(ctx, clientset, ns, targetIP, &b)
+
 	return b.String()
+}
+
+// collectCiliumDiagnostics is a best-effort dump of Cilium dataplane state
+// relevant to NetworkPolicy enforcement. It writes into `b` and never
+// errors out — missing resources are reported as a single line so the
+// helper is safe to call on non-Cilium clusters.
+func collectCiliumDiagnostics(ctx context.Context, clientset *kubernetes.Clientset, ns, targetIP string, b *strings.Builder) {
+	fmt.Fprintf(b, "Cilium dataplane state:\n")
+
+	// (a) cilium-agent pods. AKS installs them in `kube-system` as a
+	// DaemonSet; on Cilium-the-OSS distributions they live in
+	// `cilium`. Try kube-system first (AKS), then fall back to a
+	// label-selector across all namespaces.
+	agentPods, err := clientset.CoreV1().Pods("kube-system").List(ctx, metav1.ListOptions{
+		LabelSelector: "k8s-app=cilium",
+	})
+	if err != nil || len(agentPods.Items) == 0 {
+		agentPods, err = clientset.CoreV1().Pods("").List(ctx, metav1.ListOptions{
+			LabelSelector: "k8s-app=cilium",
+		})
+	}
+	if err != nil {
+		fmt.Fprintf(b, "  cilium-agent pods: <list error: %v>\n", err)
+	} else if len(agentPods.Items) == 0 {
+		fmt.Fprintf(b, "  cilium-agent pods: <none found — cluster may not be Cilium-backed>\n")
+	} else {
+		// Find the EPP pod's node so we can flag the relevant agent.
+		var eppNode string
+		if pods, perr := clientset.CoreV1().Pods(ns).List(ctx, metav1.ListOptions{}); perr == nil {
+			for _, p := range pods.Items {
+				if p.Status.PodIP == targetIP {
+					eppNode = p.Spec.NodeName
+					break
+				}
+			}
+		}
+		fmt.Fprintf(b, "  cilium-agent pods (EPP is on node %q):\n", eppNode)
+		for _, p := range agentPods.Items {
+			ready := "false"
+			for _, cs := range p.Status.ContainerStatuses {
+				if cs.Name == "cilium-agent" && cs.Ready {
+					ready = "true"
+					break
+				}
+			}
+			marker := ""
+			if eppNode != "" && p.Spec.NodeName == eppNode {
+				marker = "  <-- EPP node"
+			}
+			fmt.Fprintf(b, "    - %s/%s node=%s phase=%s ready=%s%s\n",
+				p.Namespace, p.Name, p.Spec.NodeName, p.Status.Phase, ready, marker)
+		}
+	}
+
+	// (b) CiliumEndpoint for the EPP pod. The CRD is namespaced and
+	// named after the pod. We use the dynamic client so we don't
+	// have to import Cilium's API types.
+	dyn, derr := utils.GetDynamicClient()
+	if derr != nil {
+		fmt.Fprintf(b, "  CiliumEndpoint: <dynamic client error: %v>\n", derr)
+		return
+	}
+	cepGVR := schema.GroupVersionResource{
+		Group: "cilium.io", Version: "v2", Resource: "ciliumendpoints",
+	}
+	ceps, err := dyn.Resource(cepGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		fmt.Fprintf(b, "  CiliumEndpoints in %s: <list error: %v>\n", ns, err)
+	} else {
+		fmt.Fprintf(b, "  CiliumEndpoints in %s (looking for IP %s):\n", ns, targetIP)
+		matched := false
+		for _, cep := range ceps.Items {
+			// status.networking.addressing[*].ipv4 == targetIP
+			addrs, _, _ := unstructuredNestedSlice(cep.Object, "status", "networking", "addressing")
+			ipMatch := false
+			for _, a := range addrs {
+				if m, ok := a.(map[string]any); ok {
+					if v, _ := m["ipv4"].(string); v == targetIP {
+						ipMatch = true
+						break
+					}
+				}
+			}
+			if !ipMatch {
+				continue
+			}
+			matched = true
+			identity, _, _ := unstructuredNestedInt64(cep.Object, "status", "identity", "id")
+			ingressEnf, _, _ := unstructuredNestedBool(cep.Object, "status", "policy", "ingress", "enforcing")
+			egressEnf, _, _ := unstructuredNestedBool(cep.Object, "status", "policy", "egress", "enforcing")
+			state, _, _ := unstructuredNestedString(cep.Object, "status", "state")
+			fmt.Fprintf(b, "    - name=%s identity=%d state=%s ingress.enforcing=%v egress.enforcing=%v\n",
+				cep.GetName(), identity, state, ingressEnf, egressEnf)
+		}
+		if !matched {
+			fmt.Fprintf(b, "    <no CiliumEndpoint with IP %s — endpoint not yet programmed by cilium-agent>\n", targetIP)
+		}
+	}
+
+	// (c) CiliumNetworkPolicy / CiliumClusterwideNetworkPolicy count.
+	// K8s NetworkPolicies do NOT round-trip into CNPs; instead Cilium
+	// represents them internally and exposes them via `cilium policy
+	// get`. So an empty CNP list is NORMAL — what we actually care
+	// about is whether the CRDs are installed at all (proves cilium
+	// CRD registration ran), which is informational.
+	cnpGVR := schema.GroupVersionResource{
+		Group: "cilium.io", Version: "v2", Resource: "ciliumnetworkpolicies",
+	}
+	if cnps, err := dyn.Resource(cnpGVR).Namespace("").List(ctx, metav1.ListOptions{}); err != nil {
+		fmt.Fprintf(b, "  CiliumNetworkPolicy CRD: <list error: %v — CRD may not be installed>\n", err)
+	} else {
+		fmt.Fprintf(b, "  CiliumNetworkPolicy resources cluster-wide: %d (K8s NetworkPolicies do not round-trip into CNPs; this is informational)\n", len(cnps.Items))
+	}
+}
+
+// unstructuredNestedString / Int64 / Bool / Slice are tiny wrappers around
+// the apimachinery helpers. We re-export here to keep the diag function
+// readable without importing meta/v1/unstructured in every call site.
+func unstructuredNestedString(obj map[string]any, fields ...string) (string, bool, error) {
+	return unstructuredGet[string](obj, fields...)
+}
+func unstructuredNestedInt64(obj map[string]any, fields ...string) (int64, bool, error) {
+	return unstructuredGet[int64](obj, fields...)
+}
+func unstructuredNestedBool(obj map[string]any, fields ...string) (bool, bool, error) {
+	return unstructuredGet[bool](obj, fields...)
+}
+func unstructuredNestedSlice(obj map[string]any, fields ...string) ([]any, bool, error) {
+	return unstructuredGet[[]any](obj, fields...)
+}
+func unstructuredGet[T any](obj map[string]any, fields ...string) (T, bool, error) {
+	var zero T
+	cur := any(obj)
+	for _, f := range fields {
+		m, ok := cur.(map[string]any)
+		if !ok {
+			return zero, false, nil
+		}
+		cur, ok = m[f]
+		if !ok {
+			return zero, false, nil
+		}
+	}
+	v, ok := cur.(T)
+	return v, ok, nil
 }
 
 // formatNetworkPolicyPeer renders a single `from:` entry compactly for

--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -147,6 +147,18 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 		Expect(eppIPB).NotTo(BeEmpty(), "could not find a ready EPP pod IP in %s", namespaceB)
 		Expect(eppPortB).To(BeNumerically(">", 0), "could not determine EPP pod port in %s", namespaceB)
 
+		// AKS Cilium overlay race guard: poll the EPP pod's CiliumEndpoint
+		// until status.policy.ingress.enforcing flips to true. Without this
+		// gate, an EPP pod that was created in the narrow window between
+		// the NetworkPolicy apply and cilium-agent's policy compile lands
+		// with enforcing=false and never recovers — the canary probe loop
+		// below then spins for 5 minutes and fails with a generic
+		// "enforcement not active" message that hides the actual cause.
+		// Failing here surfaces a specific, actionable Cilium message
+		// instead, and short-circuits 4+ minutes of useless polling.
+		waitForCiliumEndpointEnforcing(ctx, clientset, namespace, eppIP)
+		waitForCiliumEndpointEnforcing(ctx, clientset, namespaceB, eppIPB)
+
 		// Wait for NetworkPolicy enforcement to actually take effect on this
 		// cluster. On freshly created Cilium clusters the policy maps may take
 		// a few seconds to load even after pods report Ready. Use a single
@@ -1028,6 +1040,109 @@ func collectCiliumDiagnostics(ctx context.Context, clientset *kubernetes.Clients
 	} else {
 		fmt.Fprintf(b, "  CiliumNetworkPolicy resources cluster-wide: %d (K8s NetworkPolicies do not round-trip into CNPs; this is informational)\n", len(cnps.Items))
 	}
+}
+
+// waitForCiliumEndpointEnforcing polls the CiliumEndpoint backing the pod
+// at `targetIP` in `ns` and fails the current Ginkgo spec if its
+// status.policy.ingress.enforcing does not flip to true within the
+// timeout.
+//
+// Background: AKS clusters running with `--network-dataplane cilium
+// --network-policy cilium` exhibit a race where a pod created in the
+// narrow window between a NetworkPolicy apply and cilium-agent's policy
+// compile lands with enforcing=false on its CiliumEndpoint and stays
+// that way indefinitely. The K8s NetworkPolicies look correct, cilium-
+// agent is healthy, but traffic to the affected endpoint is silently
+// admitted because the eBPF map for that identity has no rules
+// programmed. Symptom: the canary probe loop sees EXIT=0 forever.
+//
+// The fix is to wait for the CiliumEndpoint to advertise enforcing=true
+// before starting probes. If it never flips (the race triggered and is
+// stuck), this helper fails the BeforeAll with a Cilium-specific
+// message — turning a 5-minute generic timeout into a 60-second
+// actionable one.
+//
+// Best-effort: on non-Cilium clusters or when the CRD is missing, the
+// helper logs the situation and returns without failing, so the suite
+// remains portable to kind / OSS Kubernetes clusters.
+func waitForCiliumEndpointEnforcing(ctx context.Context, _ *kubernetes.Clientset, ns, targetIP string) {
+	const (
+		timeout      = 60 * time.Second
+		pollInterval = 2 * time.Second
+	)
+
+	dyn, derr := utils.GetDynamicClient()
+	if derr != nil {
+		GinkgoWriter.Printf("waitForCiliumEndpointEnforcing: dynamic client unavailable (%v) — skipping Cilium enforcement gate for %s/%s\n", derr, ns, targetIP)
+		return
+	}
+	cepGVR := schema.GroupVersionResource{
+		Group: "cilium.io", Version: "v2", Resource: "ciliumendpoints",
+	}
+
+	// Probe once to see if the CRD is registered at all. If not, this is
+	// not a Cilium cluster — silently skip so kind / OSS K8s users can
+	// still run the suite.
+	if _, err := dyn.Resource(cepGVR).Namespace(ns).List(ctx, metav1.ListOptions{Limit: 1}); err != nil {
+		GinkgoWriter.Printf("waitForCiliumEndpointEnforcing: CiliumEndpoint CRD not available (%v) — skipping enforcement gate for %s/%s\n", err, ns, targetIP)
+		return
+	}
+
+	var (
+		lastState      string
+		lastIngressEnf bool
+		lastIdentity   int64
+		lastName       string
+		foundEndpoint  bool
+	)
+
+	Eventually(func() bool {
+		ceps, err := dyn.Resource(cepGVR).Namespace(ns).List(ctx, metav1.ListOptions{})
+		if err != nil {
+			return false
+		}
+		for _, cep := range ceps.Items {
+			addrs, _, _ := unstructuredNestedSlice(cep.Object, "status", "networking", "addressing")
+			match := false
+			for _, a := range addrs {
+				if m, ok := a.(map[string]any); ok {
+					if v, _ := m["ipv4"].(string); v == targetIP {
+						match = true
+						break
+					}
+				}
+			}
+			if !match {
+				continue
+			}
+			foundEndpoint = true
+			lastName = cep.GetName()
+			lastState, _, _ = unstructuredNestedString(cep.Object, "status", "state")
+			lastIdentity, _, _ = unstructuredNestedInt64(cep.Object, "status", "identity", "id")
+			lastIngressEnf, _, _ = unstructuredNestedBool(cep.Object, "status", "policy", "ingress", "enforcing")
+			return lastIngressEnf
+		}
+		return false
+	}, timeout, pollInterval).Should(BeTrue(),
+		func() string {
+			if !foundEndpoint {
+				return fmt.Sprintf(
+					"no CiliumEndpoint with IP %s appeared in %s within %s — "+
+						"cilium-agent has not programmed the EPP endpoint. "+
+						"Check cilium-agent pod health on the EPP's node.",
+					targetIP, ns, timeout)
+			}
+			return fmt.Sprintf(
+				"EPP CiliumEndpoint %s/%s (identity=%d state=%s) stuck with "+
+					"ingress.enforcing=%v after %s — known AKS Cilium overlay "+
+					"race when a pod comes up before its NetworkPolicy is "+
+					"compiled into the local eBPF map. Cilium-agent on the "+
+					"EPP node may need a restart, or the policy must be "+
+					"re-applied after the pod is ready. Skipping the canary "+
+					"probe loop because it would otherwise spin for 5 minutes "+
+					"on this race.",
+				ns, lastName, lastIdentity, lastState, lastIngressEnf, timeout)
+		})
 }
 
 // unstructuredNestedString / Int64 / Bool / Slice are tiny wrappers around

--- a/test/e2e/network_policy_test.go
+++ b/test/e2e/network_policy_test.go
@@ -112,9 +112,9 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 		// restart on the EPP's node. The wedge survived every recovery
 		// we threw at the supposed root cause, which means either the
 		// field is lying (enforcement actually IS on, the metadata just
-		// never settles) or the canary will still hang for 5 minutes.
-		// Either way, the canary loop is the only honest test — delete
-		// the gate and let it run.
+		// never settles) or the canary will still hang for its full
+		// 10-minute deadline. Either way, the canary loop is the only
+		// honest test — delete the gate and let it run.
 		InstallCase(CaseNetworkPolicyA)
 		InstallCase(CaseNetworkPolicyB)
 
@@ -274,7 +274,7 @@ var _ = Describe("Network Policy", utils.GinkgoLabelNetworkPolicy, Ordered, func
 			// EXIT=N (N != 0): nc could not establish the TCP handshake from
 			// the external canary namespace. Enforcement is active.
 			return true
-		}, 5*time.Minute, 5*time.Second).Should(BeTrue(),
+		}, 10*time.Minute, 5*time.Second).Should(BeTrue(),
 			// Use a func() string so Gomega evaluates the diagnostic message
 			// lazily, after the polling loop has updated the captured
 			// variables. Passing `lastCanaryOut`/`lastCanaryExecErr` as
@@ -1041,7 +1041,6 @@ func collectCiliumDiagnostics(ctx context.Context, clientset *kubernetes.Clients
 	}
 }
 
-
 // unstructuredNestedString / Int64 / Bool / Slice are tiny wrappers around
 // the apimachinery helpers. We re-export here to keep the diag function
 // readable without importing meta/v1/unstructured in every call site.
@@ -1125,7 +1124,7 @@ var _ = networkingv1.SchemeGroupVersion
 // in `ns` has rendered both `default-deny-ingress` and
 // `allow-inference-traffic` NetworkPolicies. Failing here turns a silent
 // chart regression into an immediate, clearly-attributable BeforeAll
-// failure rather than a 5-minute canary timeout that — by the time CI's
+// failure rather than a 10-minute canary timeout that — by the time CI's
 // post-failure dump runs — has been masked by AfterAll teardown.
 func expectNetworkPoliciesPresent(ctx context.Context, clientset *kubernetes.Clientset, ns string) {
 	required := map[string]bool{


### PR DESCRIPTION
## Summary
Three changes, ordered from cluster-bring-up outward:

1. **CI gate: AKS Succeeded + Cilium dataplane Ready before install** (`hack/e2e/scripts/setup-cluster.sh`). `az aks create` has been observed returning while the cluster is still `Creating`/`Updating` on retried/throttled ARM calls, and nodes can report `Ready` while `cilium-agent` is still mid-bootstrap (CRD registration, identity allocator, eBPF map load). The setup script now polls `provisioningState=Succeeded` after `az aks create`, then `rollout status` on the `cilium` DaemonSet + `cilium-operator` Deployment, then waits for every `cilium-agent` pod to be `Ready` — before `install-components.sh` and the netpol suite ever see the cluster. This eliminates the bring-up class of Cilium-compile-latency flakes at their source rather than absorbing them downstream.

2. **`collectCiliumDiagnostics` helper (~150 lines).** Dumps `cilium-agent` pod readiness on the EPP's node, the EPP pod's `CiliumEndpoint` (identity + `status.policy.{ingress,egress}.enforcing` + state), and the cluster-wide `CiliumNetworkPolicy` count — enough to distinguish "policies missing", "policies present but unenforced", and "agent down on EPP's node" without re-running with kubectl.

3. **Cross-namespace diag-dump fix for `expectDeniedLabeled`.** The diag helper looks up the target pod / labels / `CiliumEndpoint` in the namespace it's given. `expectDeniedLabeled` was passing the probe-side workload namespace even for cross-NS probes (A→B, B→A, spoof-A→B), so the diag reported `<no pod with IP X in workload-A>` and an empty EPP node, hiding the actual enforcement state on the target side. `expectDeniedLabeled` now takes a `targetNS` arg and routes it to the diag call.

**Note on the canary timeout**: an earlier commit on this branch bumped the canary enforcement-precheck timeout 5m → 10m as a stopgap. With the cluster-readiness gate in (1) now handling `cilium-agent` bootstrap before the suite starts, the timeout has been dropped back to **2m** (the original budget), since the only remaining latency is per-pod policy compilation on freshly-scheduled workloads — which is what the canary loop is for. The original diag plumbing (`canaryNS` → `networkPolicyEnforcementDiagnostics` + the `canary-probe-*` name fix) from the first commit is retained.

## Why
Run 26382796870 timed out the enforcement precheck at 5m with 50/50 `EXIT=0` probes; the precheck diag dump showed policies present on the API server but the canary still reaching EPP. Bumping the canary timeout to 10m masked the symptom but left CI absorbing 10 minutes of cluster bring-up latency per netpol run. Moving the wait to `setup-cluster.sh` is correct-by-construction (`install-components.sh` now never runs against a half-provisioned control plane) and lets the canary budget go back to 2m. The Cilium diag helper + cross-NS fix remain so the next genuine wedge points unambiguously at agent / endpoint state on the EPP's node.

## Test plan
- [x] `go build ./test/e2e/...`
- [x] `go vet ./test/e2e/...`
- [x] `golangci-lint run ./test/e2e/...` (0 issues)
- [x] CI run 26433784004 — `BeforeAll` no longer wedges at the (then) 10m budget
- [ ] Next CI run on this branch confirms (a) the cluster-readiness gate holds the canary within the restored 2m budget and (b) the cross-NS diag fix surfaces target-side state when the spoof-label `It` block trips