### PR TITLE
add cleanup path in ShadowPodReconciler to delete fake pod

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -8,6 +8,7 @@ name: E2E tests (nightly, full suite)
 # Nightly specs.
 
 on:
+  pull_request: {}
   schedule:
     # 00:00 Sydney time. GitHub cron is UTC; Sydney is UTC+10 (AEST) for
     # most of the year, so 14:00 UTC == 00:00 AEST next day. During AEDT

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
@@ -35,6 +35,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/go-logr/logr"
 )
 
 // ShadowPodReconciler implements Phase 2 of the Shadow Pod lifecycle.
@@ -61,17 +63,27 @@ type ShadowPodReconciler struct {
 	Config Config
 }
 
-// SetupWithManager registers the controller with two watches:
+// SetupWithManager registers the controller with three watches:
 //
-//  1. Primary watch on Pods (all namespaces) filtered to Pending pods on fake
-//     nodes — these are the "original" pods we need to mirror.
+//  1. Primary watch on Pods (all namespaces) filtered to Pending or Terminating
+//     pods on fake nodes — these are the "original" pods we need to mirror or
+//     clean up after.
 //  2. Secondary watch on shadow pods — when a shadow pod transitions to Running
 //     we re-queue the original pod so we can apply the status patch immediately.
+//  3. Tertiary watch on fake Node DELETE events — when a fake node is deleted
+//     (NodeClaim scale-down cleanup) we re-queue every original pod that was
+//     scheduled on that node so their shadow pods are cleaned up immediately,
+//     without waiting for Kubernetes GC (which would be blocked until the
+//     original pod is fully removed from etcd, which never happens without a
+//     real kubelet).
 func (r *ShadowPodReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Predicate: only enqueue pods that are Pending AND assigned to a fake node.
+	// Predicate: enqueue pods that are Pending on a fake node (create/update
+	// path) OR that are terminating on a fake node (cleanup path).
 	pendingOnFakeNode := predicate.Funcs{
-		CreateFunc:  func(e event.CreateEvent) bool { return isPendingOnFakeNode(e.Object) },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return isPendingOnFakeNode(e.ObjectNew) },
+		CreateFunc: func(e event.CreateEvent) bool { return isPendingOnFakeNode(e.Object) },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isPendingOnFakeNode(e.ObjectNew) || isTerminatingOnFakeNode(e.ObjectNew)
+		},
 		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
@@ -87,12 +99,25 @@ func (r *ShadowPodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
 
+	// Predicate: fake Node DELETE events only.
+	fakeNodeDeleted := predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return false },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return isFakeNode(e.Object) },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&corev1.Pod{}, builder.WithPredicates(pendingOnFakeNode)).
 		Watches(
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.shadowPodToOriginalPod),
 			builder.WithPredicates(shadowPodRunning),
+		).
+		Watches(
+			&corev1.Node{},
+			handler.EnqueueRequestsFromMapFunc(r.fakeNodeToOriginalPods),
+			builder.WithPredicates(fakeNodeDeleted),
 		).
 		Complete(r)
 }
@@ -101,15 +126,61 @@ func (r *ShadowPodReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // +kubebuilder:rbac:groups="",resources=pods/status,verbs=get;patch
 // +kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create
 
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
+
 func (r *ShadowPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := log.FromContext(ctx).WithValues("pod", req.NamespacedName)
 
 	original := &corev1.Pod{}
 	if err := r.Get(ctx, req.NamespacedName, original); err != nil {
 		if errors.IsNotFound(err) {
+			// Original pod is gone (force-deleted by pod-GC or KAITO). This reconcile
+			// may have been triggered by the fakeNodeToOriginalPods watch after the
+			// fake node was deleted. Attempt shadow-pod cleanup by name so we don't
+			// leave orphaned shadow pods if GC hasn't cascaded yet.
+			shadowName := shadowPodName(&corev1.Pod{ObjectMeta: metav1.ObjectMeta{
+				Name: req.Name, Namespace: req.Namespace,
+			}})
+			shadow := &corev1.Pod{}
+			if sErr := r.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: shadowName}, shadow); sErr == nil {
+				if shadow.DeletionTimestamp == nil {
+					if delErr := r.Delete(ctx, shadow); delErr != nil && !errors.IsNotFound(delErr) {
+						return ctrl.Result{}, fmt.Errorf("delete orphaned shadow pod: %w", delErr)
+					}
+					log.Info("deleted orphaned shadow pod after original pod was removed", "shadowPod", shadowName)
+				}
+			}
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("get pod: %w", err)
+	}
+
+	// Cleanup path A: the original pod has a deletionTimestamp but is stuck in
+	// Terminating because there is no real kubelet on the fake node to
+	// acknowledge graceful termination. Kubernetes GC will not cascade the
+	// OwnerReference to the shadow pod until the original pod is fully removed
+	// from etcd. Explicitly delete the shadow pod here.
+	if original.DeletionTimestamp != nil && isTerminatingOnFakeNode(original) {
+		return r.deleteShadowPod(ctx, log, original, "terminating original pod")
+	}
+
+	// Cleanup path B: the original pod has been patched to Running on a fake
+	// node that no longer exists. This is triggered by the fakeNodeToOriginalPods
+	// watch when the NodeClaimReconciler deletes the fake node during scale-down.
+	// A Pending pod is excluded because it hasn't been assigned a shadow pod
+	// yet; we let the normal pending-pod path handle it (or it will be GC'd).
+	if original.Status.Phase == corev1.PodRunning {
+		if _, hasLabel := original.Labels[InferenceSetCreatedByLabelKey]; hasLabel {
+			if original.Spec.NodeName != "" && strings.HasPrefix(original.Spec.NodeName, "fake-") {
+				node := &corev1.Node{}
+				if nodeErr := r.Get(ctx, types.NamespacedName{Name: original.Spec.NodeName}, node); nodeErr != nil {
+					if errors.IsNotFound(nodeErr) {
+						return r.deleteShadowPod(ctx, log, original, "fake node deleted")
+					}
+					return ctrl.Result{}, fmt.Errorf("get fake node: %w", nodeErr)
+				}
+			}
+		}
 	}
 
 	if !isPendingOnFakeNode(original) {
@@ -406,6 +477,65 @@ func (r *ShadowPodReconciler) patchOriginalPodStatus(ctx context.Context, origin
 	return nil
 }
 
+// deleteShadowPod is a shared helper for both cleanup paths (Terminating pod
+// and fake-node-gone). It finds the shadow pod by name and issues a Delete.
+func (r *ShadowPodReconciler) deleteShadowPod(ctx context.Context, log logr.Logger, original *corev1.Pod, reason string) (ctrl.Result, error) {
+	shadowName := shadowPodName(original)
+	shadow := &corev1.Pod{}
+	if err := r.Get(ctx, types.NamespacedName{Namespace: original.Namespace, Name: shadowName}, shadow); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get shadow pod for cleanup (%s): %w", reason, err)
+	}
+	if shadow.DeletionTimestamp == nil {
+		if err := r.Delete(ctx, shadow); err != nil && !errors.IsNotFound(err) {
+			return ctrl.Result{}, fmt.Errorf("delete shadow pod (%s): %w", reason, err)
+		}
+		log.Info("deleted shadow pod", "shadowPod", shadowName, "reason", reason)
+	}
+	return ctrl.Result{}, nil
+}
+
+// fakeNodeToOriginalPods maps a deleted fake Node to reconcile requests for
+// every original pod that was scheduled on it. This fires when
+// NodeClaimReconciler.reconcileDelete removes the fake node during scale-down,
+// ensuring shadow pods are cleaned up without waiting for Kubernetes GC (which
+// would be blocked until the original pod — still Running on the now-deleted
+// node — is fully removed from etcd).
+func (r *ShadowPodReconciler) fakeNodeToOriginalPods(ctx context.Context, obj client.Object) []reconcile.Request {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		return nil
+	}
+	nodeName := node.Name
+
+	// List all pods and filter by NodeName. The cache still contains the pods
+	// at this point because only the Node has been deleted; the pods remain in
+	// Running phase on the (now-gone) node.
+	podList := &corev1.PodList{}
+	if err := r.List(ctx, podList); err != nil {
+		return nil
+	}
+
+	var requests []reconcile.Request
+	for _, pod := range podList.Items {
+		if pod.Spec.NodeName != nodeName {
+			continue
+		}
+		if _, hasLabel := pod.Labels[InferenceSetCreatedByLabelKey]; !hasLabel {
+			continue
+		}
+		requests = append(requests, reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Namespace: pod.Namespace,
+				Name:      pod.Name,
+			},
+		})
+	}
+	return requests
+}
+
 // shadowPodToOriginalPod maps a shadow pod back to a reconcile.
 func (r *ShadowPodReconciler) shadowPodToOriginalPod(_ context.Context, obj client.Object) []reconcile.Request {
 	pod, ok := obj.(*corev1.Pod)
@@ -438,6 +568,32 @@ func isPendingOnFakeNode(obj client.Object) bool {
 	return pod.Spec.NodeName != "" &&
 		strings.HasPrefix(pod.Spec.NodeName, "fake-") &&
 		pod.Status.Phase == corev1.PodPending
+}
+
+// isTerminatingOnFakeNode returns true when the pod is assigned to a fake node
+// and has a deletion timestamp. Fake-node pods have no real kubelet to
+// acknowledge graceful termination, so they can remain stuck in Terminating
+// indefinitely. This predicate triggers the explicit shadow-pod cleanup path.
+func isTerminatingOnFakeNode(obj client.Object) bool {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return false
+	}
+	if _, hasLabel := pod.Labels[InferenceSetCreatedByLabelKey]; !hasLabel {
+		return false
+	}
+	return pod.DeletionTimestamp != nil &&
+		pod.Spec.NodeName != "" &&
+		strings.HasPrefix(pod.Spec.NodeName, "fake-")
+}
+
+// isFakeNode returns true when the object is a Node with the fake-node label.
+func isFakeNode(obj client.Object) bool {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		return false
+	}
+	return node.Labels[LabelFakeNode] == "true"
 }
 
 func isShadowPod(pod *corev1.Pod) bool {

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
@@ -861,3 +861,307 @@ func TestEnsureSimConfigMap(t *testing.T) {
 		t.Fatalf("second call should be idempotent: %v", err)
 	}
 }
+
+func TestIsTerminatingOnFakeNode(t *testing.T) {
+	now := metav1.Now()
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{"terminating on fake node", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:            map[string]string{InferenceSetCreatedByLabelKey: "falcon"},
+				DeletionTimestamp: &now,
+			},
+			Spec: corev1.PodSpec{NodeName: "fake-ws1"},
+		}, true},
+		{"no deletion timestamp", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{InferenceSetCreatedByLabelKey: "falcon"}},
+			Spec:       corev1.PodSpec{NodeName: "fake-ws1"},
+		}, false},
+		{"real node", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:            map[string]string{InferenceSetCreatedByLabelKey: "falcon"},
+				DeletionTimestamp: &now,
+			},
+			Spec: corev1.PodSpec{NodeName: "aks-real-node"},
+		}, false},
+		{"no kaito label", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:            map[string]string{"app": "other"},
+				DeletionTimestamp: &now,
+			},
+			Spec: corev1.PodSpec{NodeName: "fake-ws1"},
+		}, false},
+		{"no node assigned", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:            map[string]string{InferenceSetCreatedByLabelKey: "falcon"},
+				DeletionTimestamp: &now,
+			},
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTerminatingOnFakeNode(tt.pod); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestShadowPodReconcile_TerminatingOriginalDeletesShadow verifies that when
+// the original pod on a fake node is being deleted (deletionTimestamp set), the
+// reconciler explicitly deletes the shadow pod rather than waiting for
+// Kubernetes GC — which would be blocked until the original pod is fully
+// removed from etcd (never, without a real kubelet).
+func TestShadowPodReconcile_TerminatingOriginalDeletesShadow(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+	now := metav1.Now()
+
+	original := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "falcon-0",
+			Namespace:         "default",
+			DeletionTimestamp: &now,
+			// fake client requires non-zero Finalizers for DeletionTimestamp to persist
+			Finalizers: []string{"test.io/block"},
+			Labels:     map[string]string{InferenceSetCreatedByLabelKey: "falcon-7b-instruct"},
+		},
+		Spec:   corev1.PodSpec{NodeName: "fake-ws1"},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	shadowPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      shadowPodName(original),
+			Namespace: "default",
+			Labels:    map[string]string{ShadowPodLabelKey: "default.falcon-0"},
+		},
+		Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "i"}}},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(original, shadowPod).Build()
+	r := &ShadowPodReconciler{Client: cl, Config: testConfig()}
+
+	result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "falcon-0", Namespace: "default"}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if result.Requeue || result.RequeueAfter != 0 {
+		t.Error("should not requeue after cleanup")
+	}
+
+	// Shadow pod must have been deleted.
+	got := &corev1.Pod{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: shadowPod.Name, Namespace: "default"}, got); err == nil {
+		t.Error("shadow pod should have been deleted")
+	}
+}
+
+// TestShadowPodReconcile_TerminatingOriginalShadowAlreadyGone verifies that
+// the reconciler handles the case where the shadow pod was already deleted
+// before the reconcile fires.
+func TestShadowPodReconcile_TerminatingOriginalShadowAlreadyGone(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+	now := metav1.Now()
+
+	original := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "falcon-1",
+			Namespace:         "default",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test.io/block"},
+			Labels:            map[string]string{InferenceSetCreatedByLabelKey: "falcon-7b-instruct"},
+		},
+		Spec:   corev1.PodSpec{NodeName: "fake-ws1"},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	// Shadow pod does NOT exist — already cleaned up by a previous reconcile.
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(original).Build()
+	r := &ShadowPodReconciler{Client: cl, Config: testConfig()}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "falcon-1", Namespace: "default"}})
+	if err != nil {
+		t.Fatalf("should not error when shadow already gone: %v", err)
+	}
+}
+
+// TestIsFakeNode verifies the isFakeNode helper.
+func TestIsFakeNode(t *testing.T) {
+	tests := []struct {
+		name string
+		node *corev1.Node
+		want bool
+	}{
+		{"fake node", &corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{LabelFakeNode: "true"}}}, true},
+		{"non-fake node", &corev1.Node{ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"node.k8s.io/worker": "true"}}}, false},
+		{"no labels", &corev1.Node{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isFakeNode(tt.node); got != tt.want {
+				t.Errorf("isFakeNode() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestFakeNodeToOriginalPods verifies that the mapper enqueues reconcile
+// requests for KAITO InferenceSet pods that were scheduled on the deleted node.
+func TestFakeNodeToOriginalPods(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+
+	fakeNode := &corev1.Node{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "fake-ws1",
+			Labels: map[string]string{LabelFakeNode: "true"},
+		},
+	}
+
+	// Pod on the fake node with KAITO label → should be enqueued.
+	kaitoPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "kaito-pod-0",
+			Namespace: "default",
+			Labels:    map[string]string{InferenceSetCreatedByLabelKey: "phi"},
+		},
+		Spec: corev1.PodSpec{NodeName: "fake-ws1"},
+	}
+	// Pod on the fake node WITHOUT KAITO label → should NOT be enqueued.
+	otherPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "other-pod",
+			Namespace: "default",
+			Labels:    map[string]string{"app": "nginx"},
+		},
+		Spec: corev1.PodSpec{NodeName: "fake-ws1"},
+	}
+	// Pod on a DIFFERENT node with KAITO label → should NOT be enqueued.
+	diffNodePod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "diff-pod-0",
+			Namespace: "default",
+			Labels:    map[string]string{InferenceSetCreatedByLabelKey: "phi"},
+		},
+		Spec: corev1.PodSpec{NodeName: "fake-ws2"},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(kaitoPod, otherPod, diffNodePod).Build()
+	r := &ShadowPodReconciler{Client: cl, Config: testConfig()}
+
+	requests := r.fakeNodeToOriginalPods(ctx, fakeNode)
+	if len(requests) != 1 {
+		t.Fatalf("expected 1 request, got %d: %v", len(requests), requests)
+	}
+	if requests[0].Name != "kaito-pod-0" || requests[0].Namespace != "default" {
+		t.Errorf("unexpected request: %v", requests[0])
+	}
+}
+
+// TestFakeNodeToOriginalPods_NonNode verifies the mapper returns nil for
+// non-Node objects.
+func TestFakeNodeToOriginalPods_NonNode(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &ShadowPodReconciler{Client: cl, Config: testConfig()}
+
+	// Pass a Pod instead of a Node.
+	pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "p", Namespace: "default"}}
+	if got := r.fakeNodeToOriginalPods(ctx, pod); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+// TestShadowPodReconcile_FakeNodeGone verifies that when the fake node has
+// been deleted (scale-down cleanup) the reconciler deletes the shadow pod for
+// the original pod, which is still alive in Running phase.
+func TestShadowPodReconcile_FakeNodeGone(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+
+	original := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "phi-0",
+			Namespace: "default",
+			Labels:    map[string]string{InferenceSetCreatedByLabelKey: "phi"},
+		},
+		Spec:   corev1.PodSpec{NodeName: "fake-ws1"},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+	shadowPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      shadowPodName(original),
+			Namespace: "default",
+			Labels:    map[string]string{ShadowPodLabelKey: "default.phi-0"},
+		},
+		Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "i"}}},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	// Note: no Node object in the fake client → Get("fake-ws1") returns NotFound.
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(original, shadowPod).Build()
+	r := &ShadowPodReconciler{Client: cl, Config: testConfig()}
+
+	result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "phi-0", Namespace: "default"}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if result.Requeue || result.RequeueAfter != 0 {
+		t.Error("should not requeue after cleanup")
+	}
+
+	// Shadow pod must have been deleted.
+	got := &corev1.Pod{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: shadowPod.Name, Namespace: "default"}, got); err == nil {
+		t.Error("shadow pod should have been deleted when fake node is gone")
+	}
+}
+
+// TestShadowPodReconcile_OriginalAlreadyGoneButShadowPresent verifies that
+// when the original pod has already been removed from the API (force-deleted by
+// pod-GC or KAITO) but the shadow pod is still present, the reconciler cleans
+// up the orphaned shadow pod. This covers the case where the fake-node
+// deletion watch fires after the original pod is already gone.
+func TestShadowPodReconcile_OriginalAlreadyGoneButShadowPresent(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+
+	// Compute shadow name from the original pod name WITHOUT adding the
+	// original pod to the fake client — it has already been deleted.
+	original := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "phi-1",
+			Namespace: "default",
+		},
+	}
+	shadowName := shadowPodName(original)
+	shadowPod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      shadowName,
+			Namespace: "default",
+			Labels:    map[string]string{ShadowPodLabelKey: "default.phi-1"},
+		},
+		Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "i"}}},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(shadowPod).Build()
+	r := &ShadowPodReconciler{Client: cl, Config: testConfig()}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "phi-1", Namespace: "default"}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	// Orphaned shadow pod must have been deleted.
+	got := &corev1.Pod{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: shadowName, Namespace: "default"}, got); err == nil {
+		t.Error("orphaned shadow pod should have been deleted")
+	}
+}


### PR DESCRIPTION
**Reason for Change**:
add cleanup path in ShadowPodReconciler to delete fake pod

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
