### PR TITLE
fix label filters for report data

### DIFF
--- a/hack/e2e/report/main.go
+++ b/hack/e2e/report/main.go
@@ -31,9 +31,10 @@ import (
 
 // Block represents a single Ginkgo Describe, Context, or It block.
 type Block struct {
-	Type   string // "Describe", "Context", or "It"
-	Title  string
-	Labels []string
+	Type            string // "Describe", "Context", or "It"
+	Title           string
+	Labels          []string // labels declared directly on this block
+	EffectiveLabels []string // Labels plus labels inherited from ancestor Describe/Context blocks
 }
 
 // TestFile collects all parsed blocks from a single *_test.go file.

--- a/hack/e2e/report/main.go
+++ b/hack/e2e/report/main.go
@@ -39,11 +39,9 @@ type Block struct {
 
 // TestFile collects all parsed blocks from a single *_test.go file.
 type TestFile struct {
-	Name         string
-	Blocks       []Block
-	TestCount    int // number of It blocks
-	SuiteCount   int // number of Describe blocks
-	ContextCount int // number of Context blocks
+	Name      string
+	Blocks    []Block
+	TestCount int // number of It blocks
 }
 
 func main() {

--- a/hack/e2e/report/parser.go
+++ b/hack/e2e/report/parser.go
@@ -83,6 +83,48 @@ func extractLabels(line string, labelMap map[string]string) []string {
 	return labels
 }
 
+// labelFrame is one entry in the label-inheritance stack maintained while
+// parsing a single file. Each Describe or Context block pushes a frame;
+// the frame is popped when we encounter a new block at an equal or shallower
+// indentation level.
+type labelFrame struct {
+	indent int
+	labels []string
+}
+
+// stackLabels returns the flattened, deduplicated union of all labels
+// currently on the inheritance stack.
+func stackLabels(stack []labelFrame) []string {
+	seen := make(map[string]bool)
+	var result []string
+	for _, frame := range stack {
+		for _, lbl := range frame.labels {
+			if !seen[lbl] {
+				seen[lbl] = true
+				result = append(result, lbl)
+			}
+		}
+	}
+	return result
+}
+
+// mergeLabels returns a deduplicated union of base and extra.
+func mergeLabels(base, extra []string) []string {
+	seen := make(map[string]bool, len(base))
+	result := make([]string, len(base))
+	copy(result, base)
+	for _, l := range base {
+		seen[l] = true
+	}
+	for _, l := range extra {
+		if !seen[l] {
+			seen[l] = true
+			result = append(result, l)
+		}
+	}
+	return result
+}
+
 // parseTestFiles scans every *_test.go file in e2eDir (skipping e2e_test.go)
 // and returns the parsed blocks grouped by file.
 func parseTestFiles(e2eDir string, labelMap map[string]string) []TestFile {
@@ -103,11 +145,21 @@ func parseTestFiles(e2eDir string, labelMap map[string]string) []TestFile {
 
 		var blocks []Block
 		tests, suites, contexts := 0, 0, 0
+		// labelStack tracks label inheritance: each Describe/Context pushes its
+		// own labels; a frame is popped when we see a block at the same or
+		// shallower indentation level.
+		var labelStack []labelFrame
 		sc := bufio.NewScanner(f)
 		for sc.Scan() {
 			line := sc.Text()
 			if strings.TrimSpace(line) == "" {
 				continue
+			}
+			// Measure leading whitespace to determine nesting depth.
+			indent := len(line) - len(strings.TrimLeft(line, "\t "))
+			// Pop any frames whose block has ended (current indent ≤ frame indent).
+			for len(labelStack) > 0 && indent <= labelStack[len(labelStack)-1].indent {
+				labelStack = labelStack[:len(labelStack)-1]
 			}
 			m := blockRe.FindStringSubmatch(line)
 			if m == nil {
@@ -123,10 +175,17 @@ func parseTestFiles(e2eDir string, labelMap map[string]string) []TestFile {
 				}
 				full += " " + strings.TrimSpace(sc.Text())
 			}
+			ownLabels := extractLabels(full, labelMap)
 			b := Block{
-				Type:   m[1],
-				Title:  m[2],
-				Labels: extractLabels(full, labelMap),
+				Type:            m[1],
+				Title:           m[2],
+				Labels:          ownLabels,
+				EffectiveLabels: mergeLabels(stackLabels(labelStack), ownLabels),
+			}
+			// Describe/Context blocks push their own labels onto the stack so
+			// descendant It blocks can inherit them.
+			if b.Type == "Describe" || b.Type == "Context" {
+				labelStack = append(labelStack, labelFrame{indent: indent, labels: ownLabels})
 			}
 			blocks = append(blocks, b)
 			switch b.Type {

--- a/hack/e2e/report/parser.go
+++ b/hack/e2e/report/parser.go
@@ -144,7 +144,7 @@ func parseTestFiles(e2eDir string, labelMap map[string]string) []TestFile {
 		}
 
 		var blocks []Block
-		tests, suites, contexts := 0, 0, 0
+		tests := 0
 		// labelStack tracks label inheritance: each Describe/Context pushes its
 		// own labels; a frame is popped when we see a block at the same or
 		// shallower indentation level.
@@ -188,23 +188,16 @@ func parseTestFiles(e2eDir string, labelMap map[string]string) []TestFile {
 				labelStack = append(labelStack, labelFrame{indent: indent, labels: ownLabels})
 			}
 			blocks = append(blocks, b)
-			switch b.Type {
-			case "It":
+			if b.Type == "It" {
 				tests++
-			case "Describe":
-				suites++
-			case "Context":
-				contexts++
 			}
 		}
 		f.Close()
 
 		files = append(files, TestFile{
-			Name:         name,
-			Blocks:       blocks,
-			TestCount:    tests,
-			SuiteCount:   suites,
-			ContextCount: contexts,
+			Name:      name,
+			Blocks:    blocks,
+			TestCount: tests,
 		})
 	}
 	return files

--- a/hack/e2e/report/parser_test.go
+++ b/hack/e2e/report/parser_test.go
@@ -169,12 +169,6 @@ var _ = Describe("Suite A", utils.GinkgoLabelSmoke, func() {
 	if f.Name != "alpha_test.go" {
 		t.Errorf("expected alpha_test.go, got %s", f.Name)
 	}
-	if f.SuiteCount != 1 {
-		t.Errorf("expected 1 suite, got %d", f.SuiteCount)
-	}
-	if f.ContextCount != 1 {
-		t.Errorf("expected 1 context, got %d", f.ContextCount)
-	}
 	if f.TestCount != 2 {
 		t.Errorf("expected 2 tests, got %d", f.TestCount)
 	}
@@ -212,8 +206,8 @@ var _ = Describe("Multi-line Suite",
 		t.Fatalf("expected 1 file, got %d", len(files))
 	}
 	f := files[0]
-	if f.SuiteCount != 1 || f.TestCount != 1 {
-		t.Fatalf("expected 1 suite + 1 test, got %d suites + %d tests", f.SuiteCount, f.TestCount)
+	if f.TestCount != 1 {
+		t.Fatalf("expected 1 test, got %d", f.TestCount)
 	}
 	// The Describe block should have both labels from the continuation line.
 	desc := f.Blocks[0]

--- a/hack/e2e/report/parser_test.go
+++ b/hack/e2e/report/parser_test.go
@@ -259,3 +259,122 @@ func TestParseTestFiles_EmptyDir(t *testing.T) {
 		t.Fatalf("expected 0 files, got %d", len(files))
 	}
 }
+
+func TestParseTestFiles_LabelInheritance(t *testing.T) {
+	// Verify that It blocks inside a Describe inherit the Describe's labels
+	// via EffectiveLabels, even when the It itself has no labels.
+	dir := t.TempDir()
+	content := `package e2e
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/kaito-project/production-stack/test/e2e/utils"
+)
+
+var _ = Describe("Scaling Suite",
+	Ordered, utils.GinkgoLabelScaling, utils.GinkgoLabelNightly, func() {
+	It("scale up", func() {})
+	It("scale down", func() {})
+})
+`
+	if err := os.WriteFile(filepath.Join(dir, "scaling_test.go"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	labelMap := map[string]string{
+		"GinkgoLabelScaling": "Scaling",
+		"GinkgoLabelNightly": "Nightly",
+	}
+	files := parseTestFiles(dir, labelMap)
+
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	f := files[0]
+	if f.TestCount != 2 {
+		t.Fatalf("expected 2 tests, got %d", f.TestCount)
+	}
+
+	// Find the It blocks and check EffectiveLabels.
+	var itBlocks []Block
+	for _, b := range f.Blocks {
+		if b.Type == "It" {
+			itBlocks = append(itBlocks, b)
+		}
+	}
+	if len(itBlocks) != 2 {
+		t.Fatalf("expected 2 It blocks, got %d", len(itBlocks))
+	}
+
+	for _, it := range itBlocks {
+		// Own labels should be empty (no Label() on the It line).
+		if len(it.Labels) != 0 {
+			t.Errorf("It %q: expected no own labels, got %v", it.Title, it.Labels)
+		}
+		// Effective labels should include the parent Describe's labels.
+		effective := make(map[string]bool)
+		for _, l := range it.EffectiveLabels {
+			effective[l] = true
+		}
+		if !effective["Scaling"] {
+			t.Errorf("It %q: expected EffectiveLabels to contain Scaling, got %v", it.Title, it.EffectiveLabels)
+		}
+		if !effective["Nightly"] {
+			t.Errorf("It %q: expected EffectiveLabels to contain Nightly, got %v", it.Title, it.EffectiveLabels)
+		}
+	}
+}
+
+func TestParseTestFiles_TwoDescribesSeparateLabels(t *testing.T) {
+	// Verify that two sibling Describe blocks don't leak labels into each other.
+	dir := t.TempDir()
+	content := `package e2e
+
+import . "github.com/onsi/ginkgo/v2"
+
+var _ = Describe("Nightly Suite", Label("Nightly"), func() {
+	It("nightly test", func() {})
+})
+
+var _ = Describe("Smoke Suite", Label("Smoke"), func() {
+	It("smoke test", func() {})
+})
+`
+	if err := os.WriteFile(filepath.Join(dir, "two_test.go"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	files := parseTestFiles(dir, nil)
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	f := files[0]
+
+	var itBlocks []Block
+	for _, b := range f.Blocks {
+		if b.Type == "It" {
+			itBlocks = append(itBlocks, b)
+		}
+	}
+	if len(itBlocks) != 2 {
+		t.Fatalf("expected 2 It blocks, got %d", len(itBlocks))
+	}
+
+	// "nightly test" should only have Nightly in EffectiveLabels.
+	eff0 := make(map[string]bool)
+	for _, l := range itBlocks[0].EffectiveLabels {
+		eff0[l] = true
+	}
+	if !eff0["Nightly"] || eff0["Smoke"] {
+		t.Errorf("nightly test EffectiveLabels: want [Nightly], got %v", itBlocks[0].EffectiveLabels)
+	}
+
+	// "smoke test" should only have Smoke in EffectiveLabels.
+	eff1 := make(map[string]bool)
+	for _, l := range itBlocks[1].EffectiveLabels {
+		eff1[l] = true
+	}
+	if eff1["Nightly"] || !eff1["Smoke"] {
+		t.Errorf("smoke test EffectiveLabels: want [Smoke], got %v", itBlocks[1].EffectiveLabels)
+	}
+}

--- a/hack/e2e/report/report.go
+++ b/hack/e2e/report/report.go
@@ -121,6 +121,91 @@ var chartColors = []string{
 }
 
 // ---------------------------------------------------------------------------
+// Label filter evaluation
+// ---------------------------------------------------------------------------
+
+// matchesLabelFilter evaluates a Ginkgo-style label filter expression against
+// a set of labels. Supported operators: !, &&, ||, and parentheses.
+// An empty filter or "(all)" matches every spec.
+func matchesLabelFilter(filter string, labels []string) bool {
+	filter = strings.TrimSpace(filter)
+	if filter == "" || filter == "(all)" {
+		return true
+	}
+	set := make(map[string]bool, len(labels))
+	for _, l := range labels {
+		set[l] = true
+	}
+	result, _ := evalOrExpr(filter, set)
+	return result
+}
+
+func evalOrExpr(s string, labels map[string]bool) (bool, string) {
+	left, rest := evalAndExpr(s, labels)
+	for {
+		rest = strings.TrimSpace(rest)
+		if !strings.HasPrefix(rest, "||") {
+			break
+		}
+		rest = strings.TrimSpace(rest[2:])
+		var right bool
+		right, rest = evalAndExpr(rest, labels)
+		left = left || right
+	}
+	return left, rest
+}
+
+func evalAndExpr(s string, labels map[string]bool) (bool, string) {
+	left, rest := evalUnary(s, labels)
+	for {
+		rest = strings.TrimSpace(rest)
+		if !strings.HasPrefix(rest, "&&") {
+			break
+		}
+		rest = strings.TrimSpace(rest[2:])
+		var right bool
+		right, rest = evalUnary(rest, labels)
+		left = left && right
+	}
+	return left, rest
+}
+
+func evalUnary(s string, labels map[string]bool) (bool, string) {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "!") {
+		val, rest := evalPrimary(strings.TrimSpace(s[1:]), labels)
+		return !val, rest
+	}
+	return evalPrimary(s, labels)
+}
+
+func evalPrimary(s string, labels map[string]bool) (bool, string) {
+	s = strings.TrimSpace(s)
+	if strings.HasPrefix(s, "(") {
+		val, rest := evalOrExpr(strings.TrimSpace(s[1:]), labels)
+		rest = strings.TrimSpace(rest)
+		if strings.HasPrefix(rest, ")") {
+			rest = rest[1:]
+		}
+		return val, rest
+	}
+	// Parse an identifier (label name).
+	end := 0
+	for end < len(s) {
+		c := rune(s[end])
+		if c >= 'a' && c <= 'z' || c >= 'A' && c <= 'Z' || c >= '0' && c <= '9' || c == '-' || c == '_' {
+			end++
+		} else {
+			break
+		}
+	}
+	if end == 0 {
+		return false, s
+	}
+	return labels[s[:end]], s[end:]
+}
+
+// ---------------------------------------------------------------------------
 // Report data construction
 // ---------------------------------------------------------------------------
 
@@ -129,38 +214,80 @@ func buildReportData(files []TestFile, workflow, labelFilter string) *ReportData
 		Workflow:    workflow,
 		LabelFilter: labelFilter,
 		Timestamp:   time.Now().UTC().Format("2006-01-02 15:04:05 UTC"),
-		Files:       files,
-		TotalFiles:  len(files),
 		AllLabels:   orderedLabels,
 	}
 
+	// Compute per-file filtered test counts for the bar / donut charts.
+	// Files with zero matching tests are excluded from the visual charts and
+	// from TotalFiles / TotalIts.
+	type fileCount struct {
+		file  TestFile
+		count int
+	}
+	var filteredFiles []fileCount
 	for _, f := range files {
-		data.TotalIts += f.TestCount
-		data.TotalDescribes += f.SuiteCount
-		data.TotalContexts += f.ContextCount
+		n := 0
+		for _, b := range f.Blocks {
+			if b.Type == "It" && matchesLabelFilter(labelFilter, b.EffectiveLabels) {
+				n++
+			}
+		}
+		if n > 0 {
+			filteredFiles = append(filteredFiles, fileCount{f, n})
+			data.TotalFiles++
+			data.TotalIts += n
+		}
+	}
+
+	// TotalDescribes and TotalContexts are derived from the filtered set so
+	// they match the files and tests the report actually covers.
+	for _, fc := range filteredFiles {
+		data.TotalDescribes += fc.file.SuiteCount
+		data.TotalContexts += fc.file.ContextCount
+	}
+	// Populate data.Files with filtered copies of each file: non-matching It
+	// blocks are omitted so that the detail sections in Markdown/HTML only
+	// show tests that actually run under this label filter.  TestCount on the
+	// copy reflects the filtered count so that "N tests" headers are correct.
+	for _, fc := range filteredFiles {
+		f := fc.file
+		filtered := TestFile{
+			Name:         f.Name,
+			SuiteCount:   f.SuiteCount,
+			ContextCount: f.ContextCount,
+			TestCount:    fc.count, // filtered count, not f.TestCount
+		}
+		for _, b := range f.Blocks {
+			if b.Type == "It" && !matchesLabelFilter(labelFilter, b.EffectiveLabels) {
+				continue // omit non-matching test cases
+			}
+			filtered.Blocks = append(filtered.Blocks, b)
+		}
+		data.Files = append(data.Files, filtered)
 	}
 
 	// Bar chart data.
 	maxTests := 0
-	for _, f := range files {
-		if f.TestCount > maxTests {
-			maxTests = f.TestCount
+	for _, fc := range filteredFiles {
+		if fc.count > maxTests {
+			maxTests = fc.count
 		}
 	}
 
 	cumulative := 0
 	var gradientParts []string
-	for i, f := range files {
+	for i, fc := range filteredFiles {
+		f := fc.file
 		color := chartColors[i%len(chartColors)]
 		pct := 0
 		if maxTests > 0 {
-			pct = f.TestCount * 100 / maxTests
+			pct = fc.count * 100 / maxTests
 		}
 		shortName := strings.TrimSuffix(f.Name, "_test.go")
 
 		data.BarChart = append(data.BarChart, BarEntry{
 			Label:   shortName,
-			Value:   f.TestCount,
+			Value:   fc.count,
 			Percent: pct,
 			Color:   color,
 		})
@@ -170,7 +297,7 @@ func buildReportData(files []TestFile, workflow, labelFilter string) *ReportData
 		if data.TotalIts > 0 {
 			startDeg = cumulative * 360 / data.TotalIts
 		}
-		cumulative += f.TestCount
+		cumulative += fc.count
 		endDeg := 0
 		if data.TotalIts > 0 {
 			endDeg = cumulative * 360 / data.TotalIts

--- a/hack/e2e/report/report.go
+++ b/hack/e2e/report/report.go
@@ -34,13 +34,11 @@ var htmlTemplateStr string
 
 // ReportData holds all data needed to render both Markdown and HTML reports.
 type ReportData struct {
-	Workflow       string
-	LabelFilter    string
-	Timestamp      string
-	TotalFiles     int
-	TotalDescribes int
-	TotalContexts  int
-	TotalIts       int
+	Workflow    string
+	LabelFilter string
+	Timestamp   string
+	TotalFiles  int
+	TotalIts    int
 
 	Files         []TestFile
 	BarChart      []BarEntry
@@ -239,12 +237,6 @@ func buildReportData(files []TestFile, workflow, labelFilter string) *ReportData
 		}
 	}
 
-	// TotalDescribes and TotalContexts are derived from the filtered set so
-	// they match the files and tests the report actually covers.
-	for _, fc := range filteredFiles {
-		data.TotalDescribes += fc.file.SuiteCount
-		data.TotalContexts += fc.file.ContextCount
-	}
 	// Populate data.Files with filtered copies of each file: non-matching It
 	// blocks are omitted so that the detail sections in Markdown/HTML only
 	// show tests that actually run under this label filter.  TestCount on the
@@ -252,10 +244,8 @@ func buildReportData(files []TestFile, workflow, labelFilter string) *ReportData
 	for _, fc := range filteredFiles {
 		f := fc.file
 		filtered := TestFile{
-			Name:         f.Name,
-			SuiteCount:   f.SuiteCount,
-			ContextCount: f.ContextCount,
-			TestCount:    fc.count, // filtered count, not f.TestCount
+			Name:      f.Name,
+			TestCount: fc.count, // filtered count, not f.TestCount
 		}
 		for _, b := range f.Blocks {
 			if b.Type == "It" && !matchesLabelFilter(labelFilter, b.EffectiveLabels) {
@@ -313,9 +303,6 @@ func buildReportData(files []TestFile, workflow, labelFilter string) *ReportData
 
 	// Label card counts.
 	labelCounts := make(map[string]int)
-	for _, lbl := range orderedLabels {
-		labelCounts[lbl] = 0
-	}
 	for _, f := range files {
 		for _, b := range f.Blocks {
 			for _, lbl := range b.Labels {

--- a/hack/e2e/report/report_test.go
+++ b/hack/e2e/report/report_test.go
@@ -33,9 +33,7 @@ func sampleFiles() []TestFile {
 				{Type: "It", Title: "test 1", Labels: []string{"Smoke"}, EffectiveLabels: []string{"Smoke", "Infra"}},
 				{Type: "It", Title: "test 2", Labels: nil, EffectiveLabels: []string{"Smoke", "Infra"}},
 			},
-			TestCount:    2,
-			SuiteCount:   1,
-			ContextCount: 1,
+			TestCount: 2,
 		},
 		{
 			Name: "beta_test.go",
@@ -43,9 +41,7 @@ func sampleFiles() []TestFile {
 				{Type: "Describe", Title: "Beta Suite", Labels: []string{"Auth"}, EffectiveLabels: []string{"Auth"}},
 				{Type: "It", Title: "test A", Labels: []string{"Auth"}, EffectiveLabels: []string{"Auth"}},
 			},
-			TestCount:    1,
-			SuiteCount:   1,
-			ContextCount: 0,
+			TestCount: 1,
 		},
 	}
 }
@@ -61,12 +57,6 @@ func TestBuildReportData_Totals(t *testing.T) {
 	}
 	if data.TotalFiles != 2 {
 		t.Errorf("expected 2 files, got %d", data.TotalFiles)
-	}
-	if data.TotalDescribes != 2 {
-		t.Errorf("expected 2 describes, got %d", data.TotalDescribes)
-	}
-	if data.TotalContexts != 1 {
-		t.Errorf("expected 1 context, got %d", data.TotalContexts)
 	}
 	if data.TotalIts != 3 {
 		t.Errorf("expected 3 Its, got %d", data.TotalIts)
@@ -316,8 +306,7 @@ func nightlyFiles() []TestFile {
 				{Type: "It", Title: "scale up", Labels: nil, EffectiveLabels: []string{"Scaling", "Nightly"}},
 				{Type: "It", Title: "scale down", Labels: nil, EffectiveLabels: []string{"Scaling", "Nightly"}},
 			},
-			TestCount:  2,
-			SuiteCount: 1,
+			TestCount: 2,
 		},
 		{
 			Name: "model_routing_test.go",
@@ -325,8 +314,7 @@ func nightlyFiles() []TestFile {
 				{Type: "Describe", Title: "Routing", Labels: []string{"Routing"}, EffectiveLabels: []string{"Routing"}},
 				{Type: "It", Title: "routes correctly", Labels: nil, EffectiveLabels: []string{"Routing"}},
 			},
-			TestCount:  1,
-			SuiteCount: 1,
+			TestCount: 1,
 		},
 	}
 }

--- a/hack/e2e/report/report_test.go
+++ b/hack/e2e/report/report_test.go
@@ -28,10 +28,10 @@ func sampleFiles() []TestFile {
 		{
 			Name: "alpha_test.go",
 			Blocks: []Block{
-				{Type: "Describe", Title: "Alpha Suite", Labels: []string{"Smoke", "Infra"}},
-				{Type: "Context", Title: "when running", Labels: nil},
-				{Type: "It", Title: "test 1", Labels: []string{"Smoke"}},
-				{Type: "It", Title: "test 2", Labels: nil},
+				{Type: "Describe", Title: "Alpha Suite", Labels: []string{"Smoke", "Infra"}, EffectiveLabels: []string{"Smoke", "Infra"}},
+				{Type: "Context", Title: "when running", Labels: nil, EffectiveLabels: []string{"Smoke", "Infra"}},
+				{Type: "It", Title: "test 1", Labels: []string{"Smoke"}, EffectiveLabels: []string{"Smoke", "Infra"}},
+				{Type: "It", Title: "test 2", Labels: nil, EffectiveLabels: []string{"Smoke", "Infra"}},
 			},
 			TestCount:    2,
 			SuiteCount:   1,
@@ -40,8 +40,8 @@ func sampleFiles() []TestFile {
 		{
 			Name: "beta_test.go",
 			Blocks: []Block{
-				{Type: "Describe", Title: "Beta Suite", Labels: []string{"Auth"}},
-				{Type: "It", Title: "test A", Labels: []string{"Auth"}},
+				{Type: "Describe", Title: "Beta Suite", Labels: []string{"Auth"}, EffectiveLabels: []string{"Auth"}},
+				{Type: "It", Title: "test A", Labels: []string{"Auth"}, EffectiveLabels: []string{"Auth"}},
 			},
 			TestCount:    1,
 			SuiteCount:   1,
@@ -221,7 +221,7 @@ func TestWriteMarkdown_NoWorkflow(t *testing.T) {
 }
 
 func TestWriteHTML(t *testing.T) {
-	data := buildReportData(sampleFiles(), "Nightly", "Nightly")
+	data := buildReportData(sampleFiles(), "Nightly", "(all)")
 	dir := t.TempDir()
 	path := filepath.Join(dir, "report.html")
 
@@ -256,5 +256,167 @@ func TestWriteHTML_EmptyFiles(t *testing.T) {
 
 	if err := writeHTML(data, path); err != nil {
 		t.Fatalf("writeHTML should not error with empty files: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Label filter evaluation
+// ---------------------------------------------------------------------------
+
+func TestMatchesLabelFilter_AllCases(t *testing.T) {
+	tests := []struct {
+		filter string
+		labels []string
+		want   bool
+	}{
+		// Empty / (all) always matches.
+		{"", []string{"Smoke"}, true},
+		{"(all)", nil, true},
+		// Simple label presence.
+		{"Smoke", []string{"Smoke"}, true},
+		{"Smoke", []string{"Auth"}, false},
+		{"Smoke", nil, false},
+		// NOT operator.
+		{"!Nightly", nil, true},
+		{"!Nightly", []string{"Smoke"}, true},
+		{"!Nightly", []string{"Nightly"}, false},
+		// AND operator.
+		{"Nightly && !NetworkPolicy", []string{"Nightly"}, true},
+		{"Nightly && !NetworkPolicy", []string{"Nightly", "NetworkPolicy"}, false},
+		{"Nightly && !NetworkPolicy", []string{"Smoke"}, false},
+		// OR operator.
+		{"Smoke || Auth", []string{"Smoke"}, true},
+		{"Smoke || Auth", []string{"Auth"}, true},
+		{"Smoke || Auth", []string{"Nightly"}, false},
+		// Parentheses.
+		{"(Smoke || Auth) && !Nightly", []string{"Smoke"}, true},
+		{"(Smoke || Auth) && !Nightly", []string{"Smoke", "Nightly"}, false},
+	}
+	for _, tc := range tests {
+		got := matchesLabelFilter(tc.filter, tc.labels)
+		if got != tc.want {
+			t.Errorf("matchesLabelFilter(%q, %v) = %v, want %v", tc.filter, tc.labels, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildReportData with label filter
+// ---------------------------------------------------------------------------
+
+// nightlyFiles returns two synthetic files: one with Nightly tests and one
+// with only non-Nightly tests, to verify that the label filter is actually
+// applied when computing TotalFiles and TotalIts.
+func nightlyFiles() []TestFile {
+	return []TestFile{
+		{
+			Name: "scaling_test.go",
+			Blocks: []Block{
+				{Type: "Describe", Title: "Scaling", Labels: []string{"Scaling", "Nightly"}, EffectiveLabels: []string{"Scaling", "Nightly"}},
+				{Type: "It", Title: "scale up", Labels: nil, EffectiveLabels: []string{"Scaling", "Nightly"}},
+				{Type: "It", Title: "scale down", Labels: nil, EffectiveLabels: []string{"Scaling", "Nightly"}},
+			},
+			TestCount:  2,
+			SuiteCount: 1,
+		},
+		{
+			Name: "model_routing_test.go",
+			Blocks: []Block{
+				{Type: "Describe", Title: "Routing", Labels: []string{"Routing"}, EffectiveLabels: []string{"Routing"}},
+				{Type: "It", Title: "routes correctly", Labels: nil, EffectiveLabels: []string{"Routing"}},
+			},
+			TestCount:  1,
+			SuiteCount: 1,
+		},
+	}
+}
+
+func TestBuildReportData_NightlyFilter(t *testing.T) {
+	data := buildReportData(nightlyFiles(), "E2E (nightly)", "Nightly && !NetworkPolicy")
+
+	// Only scaling_test.go has Nightly tests.
+	if data.TotalFiles != 1 {
+		t.Errorf("expected 1 file for Nightly filter, got %d", data.TotalFiles)
+	}
+	if data.TotalIts != 2 {
+		t.Errorf("expected 2 Its for Nightly filter, got %d", data.TotalIts)
+	}
+	if len(data.Files) != 1 || data.Files[0].Name != "scaling_test.go" {
+		t.Errorf("expected data.Files=[scaling_test.go], got %v", data.Files)
+	}
+}
+
+func TestBuildReportData_NonNightlyFilter(t *testing.T) {
+	data := buildReportData(nightlyFiles(), "E2E", "!Nightly")
+
+	// Only model_routing_test.go passes !Nightly.
+	if data.TotalFiles != 1 {
+		t.Errorf("expected 1 file for !Nightly filter, got %d", data.TotalFiles)
+	}
+	if data.TotalIts != 1 {
+		t.Errorf("expected 1 It for !Nightly filter, got %d", data.TotalIts)
+	}
+	if len(data.Files) != 1 || data.Files[0].Name != "model_routing_test.go" {
+		t.Errorf("expected data.Files=[model_routing_test.go], got %v", data.Files)
+	}
+}
+
+func TestBuildReportData_AllFilter(t *testing.T) {
+	data := buildReportData(nightlyFiles(), "", "(all)")
+
+	if data.TotalFiles != 2 {
+		t.Errorf("expected 2 files for (all) filter, got %d", data.TotalFiles)
+	}
+	if data.TotalIts != 3 {
+		t.Errorf("expected 3 Its for (all) filter, got %d", data.TotalIts)
+	}
+}
+
+// TestBuildReportData_DetailFiltering verifies that data.Files contains only
+// the blocks that match the active label filter, and that TestCount reflects
+// the filtered count (not the raw file total).
+func TestBuildReportData_DetailFiltering(t *testing.T) {
+	// scaling_test.go: 2 Its tagged Nightly
+	// model_routing_test.go: 1 It tagged Routing (not Nightly)
+	data := buildReportData(nightlyFiles(), "W", "!Nightly")
+
+	if len(data.Files) != 1 {
+		t.Fatalf("expected 1 file in data.Files, got %d", len(data.Files))
+	}
+	tf := data.Files[0]
+	if tf.Name != "model_routing_test.go" {
+		t.Errorf("expected model_routing_test.go, got %q", tf.Name)
+	}
+	// TestCount should be the filtered count (1), not the raw file count.
+	if tf.TestCount != 1 {
+		t.Errorf("expected filtered TestCount=1, got %d", tf.TestCount)
+	}
+	// Only the matching It block should remain.
+	var itBlocks []Block
+	for _, b := range tf.Blocks {
+		if b.Type == "It" {
+			itBlocks = append(itBlocks, b)
+		}
+	}
+	if len(itBlocks) != 1 {
+		t.Errorf("expected 1 It block in filtered file, got %d", len(itBlocks))
+	}
+
+	// Verify the opposite: Nightly filter should have scaling_test.go with 2 Its.
+	data2 := buildReportData(nightlyFiles(), "W", "Nightly")
+	if len(data2.Files) != 1 || data2.Files[0].Name != "scaling_test.go" {
+		t.Fatalf("expected scaling_test.go for Nightly filter, got %v", data2.Files)
+	}
+	if data2.Files[0].TestCount != 2 {
+		t.Errorf("expected filtered TestCount=2 for scaling, got %d", data2.Files[0].TestCount)
+	}
+	var itBlocks2 []Block
+	for _, b := range data2.Files[0].Blocks {
+		if b.Type == "It" {
+			itBlocks2 = append(itBlocks2, b)
+		}
+	}
+	if len(itBlocks2) != 2 {
+		t.Errorf("expected 2 It blocks for Nightly scaling file, got %d", len(itBlocks2))
 	}
 }


### PR DESCRIPTION
**Reason for Change**:
Apply label-filter to all report data

4 bugs where --label-filter was inconsistently applied:

1. TotalFiles/TotalIts were counted from all parsed It blocks
   regardless of the active label filter, so both workflow builds
   produced identical summary metrics.

2. Detail section headers (writeMarkdown <summary> and HTML) used the
   raw TestFile.TestCount, so a file with 10 tests where 3 matched
   would still report "10 tests".

3. The Blocks list inside each detail section was unfiltered.
   Non-matching It blocks appeared listed under files that happened to
   have at least one matching test.

4. TotalDescribes/TotalContexts were accumulated before the filtered
   file list was built, so they reflected all files/blocks.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
