### PR TITLE
chore: bump llm-gateway-apikey to 0.0.10-alpha

### DIFF
--- a/charts/productionstack/Chart.lock
+++ b/charts/productionstack/Chart.lock
@@ -7,6 +7,6 @@ dependencies:
   version: 0.5.1
 - name: llm-gateway-apikey
   repository: oci://mcr.microsoft.com/aks/kaito/helm
-  version: 0.0.9-alpha
-digest: sha256:ff2d68278897f0a32890f443a4e14165a90b075a79150a72aeb2f5c75f82b387
-generated: "2026-05-29T13:47:07.64521+10:00"
+  version: 0.0.10-alpha
+digest: sha256:da9f0424782fbba7b33e766f541318350b2b3cefb0ca0b88b7c76a9c1cd20df1
+generated: "2026-06-03T12:11:52.986237+10:00"

--- a/charts/productionstack/Chart.yaml
+++ b/charts/productionstack/Chart.yaml
@@ -52,7 +52,7 @@ dependencies:
   # are passed through under the upstream chart name `llm-gateway-apikey`
   # in values.yaml.
   - name: llm-gateway-apikey
-    version: 0.0.9-alpha
+    version: 0.0.10-alpha
     repository: oci://mcr.microsoft.com/aks/kaito/helm
     condition: llm-gateway-apikey.enabled
     tags:


### PR DESCRIPTION
## Summary
- Bump `llm-gateway-apikey` OCI helm chart dependency in `charts/productionstack` from `0.0.9-alpha` to `0.0.10-alpha`
- Regenerate `charts/productionstack/Chart.lock` via `helm dependency update`

## Test plan
- [ ] E2E passes against the new chart version