### PR TITLE
release: bump charts to 0.2.0 and publish productionstack

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -37,6 +37,18 @@ jobs:
           fetch-depth: 0
           ref: ${{ inputs.release_version }}
 
+      - name: Setup Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.20.2
+
+      - name: Update productionstack chart dependencies
+        # productionstack is an umbrella chart with an OCI subchart
+        # (llm-gateway-apikey) pulled from a public registry at
+        # `helm dependency update` time. Vendor the dependency tarballs
+        # into charts/ before staging so helm-gh-pages can package it.
+        run: helm dependency update charts/productionstack
+
       - name: Stage charts for publishing
         # Copy each releasable chart into a clean staging dir so that any
         # in-tree dev-only Helm folders (added later) are not picked up by
@@ -46,6 +58,7 @@ jobs:
           cp -r charts/gpu-node-mocker packaged-charts/
           cp -r charts/modeldeployment packaged-charts/
           cp -r charts/modelharness    packaged-charts/
+          cp -r charts/productionstack packaged-charts/
 
       - name: Publish helm charts to gh-pages
         uses: stefanprodan/helm-gh-pages@0ad2bb377311d61ac04ad9eb6f252fb68e207260 # v1.7.0
@@ -81,3 +94,6 @@ jobs:
           make helm-package-and-push CHART_NAME='gpu-node-mocker'
           make helm-package-and-push CHART_NAME='modeldeployment'
           make helm-package-and-push CHART_NAME='modelharness'
+          # Umbrella chart: vendor its OCI subchart dependency before packaging.
+          helm dependency update charts/productionstack
+          make helm-package-and-push CHART_NAME='productionstack'

--- a/README.md
+++ b/README.md
@@ -169,10 +169,13 @@ into one synchronous run. A release publishes:
 
 - a multi-arch container image at
   `ghcr.io/kaito-project/gpu-node-mocker:<X.Y.Z>` (no leading `v`);
-- the three Helm charts under [`charts/`](charts/) — `gpu-node-mocker`,
-  `modeldeployment`, and `modelharness` — to the chart repository hosted on
+- the four Helm charts under [`charts/`](charts/) — `gpu-node-mocker`,
+  `modeldeployment`, `modelharness`, and the `productionstack` umbrella
+  chart — to the chart repository hosted on
   this repo's `gh-pages` branch
   (`https://kaito-project.github.io/production-stack/charts/kaito-project`);
+  the `productionstack` chart has its OCI subchart dependency vendored via
+  `helm dependency update` before packaging.
 - a GitHub Release at the same `vX.Y.Z` tag with auto-generated changelog
   notes.
 
@@ -187,6 +190,7 @@ To publish `vX.Y.Z`:
      [`charts/gpu-node-mocker/values.yaml`](charts/gpu-node-mocker/values.yaml)
    - [`charts/modeldeployment/Chart.yaml`](charts/modeldeployment/Chart.yaml)
    - [`charts/modelharness/Chart.yaml`](charts/modelharness/Chart.yaml)
+   - [`charts/productionstack/Chart.yaml`](charts/productionstack/Chart.yaml)
 
 2. **After the PR is merged**, run **Actions → "Create release (manually)"**
    with `release_version=vX.Y.Z`.

--- a/charts/gpu-node-mocker/Chart.yaml
+++ b/charts/gpu-node-mocker/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gpu-node-mocker
 description: GPU Node Mocker controller for KAITO production-stack
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"

--- a/charts/modeldeployment/Chart.yaml
+++ b/charts/modeldeployment/Chart.yaml
@@ -4,5 +4,5 @@ description: |
   Deploys a KAITO InferenceSet together with the Istio DestinationRule and
   Gateway API HTTPRoute required to route inference traffic to it.
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"

--- a/charts/modelharness/Chart.yaml
+++ b/charts/modelharness/Chart.yaml
@@ -15,5 +15,5 @@ description: |
   Service itself is installed once per cluster by the E2E install
   script.
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"

--- a/charts/productionstack/Chart.yaml
+++ b/charts/productionstack/Chart.yaml
@@ -21,8 +21,8 @@ description: |
   under `charts/` and appending a new entry to the `dependencies` list
   below.
 type: application
-version: 0.1.0
-appVersion: "0.1.0"
+version: 0.2.0
+appVersion: "0.2.0"
 keywords:
   - kaito
   - production-stack


### PR DESCRIPTION
- Bump version/appVersion to 0.2.0 for gpu-node-mocker, modeldeployment, modelharness, and the productionstack umbrella chart
- Publish productionstack in both gh-pages and MCR jobs, running helm dependency update to vendor its OCI subchart before packaging
- Document the productionstack chart in the README release process

**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
