### PR TITLE
docs(charts): publish to GHCR OCI and split per-chart READMEs

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -104,7 +104,17 @@ jobs:
           \`\`\`
 
           ### Helm charts
-          Add the chart repository (once):
+          Charts are published to three channels on every release. Pick
+          whichever installation source matches your environment.
+
+          OCI (GHCR):
+          \`\`\`
+          helm install productionstack  oci://ghcr.io/kaito-project/productionstack  --version ${IMG_TAG} -n kaito-system --create-namespace
+          helm install modelharness     oci://ghcr.io/kaito-project/modelharness     --version ${IMG_TAG} -n my-models     --create-namespace
+          helm install qwen             oci://ghcr.io/kaito-project/modeldeployment  --version ${IMG_TAG} -n my-models     --set name=gemma --set model=google/gemma-4-e4b-it
+          \`\`\`
+
+          Helm repo (gh-pages):
           \`\`\`
           helm repo add production-stack https://kaito-project.github.io/production-stack/charts/kaito-project
           helm repo update production-stack
@@ -116,6 +126,7 @@ jobs:
           - \`production-stack/gpu-node-mocker\`
           - \`production-stack/modeldeployment\`
           - \`production-stack/modelharness\`
+          - \`production-stack/productionstack\`
 
           See [README.md](https://github.com/kaito-project/production-stack/blob/${TAG}/README.md) for installation steps.
 

--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -68,6 +68,50 @@ jobs:
           target_dir: charts/kaito-project
           linting: off
 
+  push-charts-to-ghcr:
+    # Publish the same four releasable charts as OCI artifacts to GHCR
+    # under oci://ghcr.io/kaito-project/<chart>. This mirrors the
+    # gh-pages publication so consumers can `helm install ... oci://...`
+    # without adding a Helm repo first.
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@a5ad31d6a139d249332a2605b85202e8c0b78450 # v2.19.1
+        with:
+          egress-policy: audit
+          disable-sudo: true
+          disable-telemetry: true
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.release_version }}
+
+      - name: Setup Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.20.2
+
+      - name: Helm login to GHCR
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | \
+            helm registry login ghcr.io -u '${{ github.actor }}' --password-stdin
+
+      - name: Push charts to GHCR
+        run: |
+          export CHART_REGISTRY='ghcr.io/kaito-project'
+          export CHART_VERSION="$(sed -e 's/^v//g' <<< '${{ inputs.release_version }}')"
+          make helm-package-and-push CHART_NAME='gpu-node-mocker'
+          make helm-package-and-push CHART_NAME='modeldeployment'
+          make helm-package-and-push CHART_NAME='modelharness'
+          # Umbrella chart: vendor its OCI subchart dependency before packaging.
+          helm dependency update charts/productionstack
+          make helm-package-and-push CHART_NAME='productionstack'
+
   push-charts-to-mcr:
     runs-on:
       labels:

--- a/README.md
+++ b/README.md
@@ -35,94 +35,66 @@ This project evaluates a production inference stack built on top of existing OSS
 
 ## Installation
 
-Install the stack in three steps. Step 1 is one-time per cluster;
-steps 2 and 3 are repeated per workload namespace and per model.
+Install the stack in three steps. Step 1 is one-time per cluster; steps 2 and 3 are repeated per workload namespace and per model.
+
+All three releasable charts are published as OCI artifacts on every release; pick whichever installation source matches your environment:
+
+| Source       | Reference                                                                          |
+| ------------ | ---------------------------------------------------------------------------------- |
+| OCI (GHCR)   | `oci://ghcr.io/kaito-project/{productionstack,modelharness,modeldeployment}`       |
+| OCI (MCR)    | `oci://mcr.microsoft.com/aks/kaito/helm/{productionstack,modelharness,modeldeployment}` |
+| Helm repo    | `helm repo add production-stack https://kaito-project.github.io/production-stack/charts/kaito-project` |
+| In-tree      | `./charts/{productionstack,modelharness,modeldeployment}`                          |
+
+The OCI commands below assume `ghcr.io`; swap the registry to suit. Pin `--version <X.Y.Z>` to a specific release tag — see the latest release on [GitHub Releases](https://github.com/kaito-project/production-stack/releases).
 
 ### Step 1. Cluster + addons (one-time, cluster-wide)
 
-Installed by [`hack/e2e/scripts/install-components.sh`](hack/e2e/scripts/install-components.sh)
-(or its production equivalent). These components live across multiple
-namespaces and are shared by every model deployment:
-
-| Component                            | Namespace        | Version (`versions.env`)                | Install method | Role                                                                                  |
-| ------------------------------------ | ---------------- | --------------------------------------- | -------------- | ------------------------------------------------------------------------------------- |
-| KAITO workspace controller           | `kaito-system`   | latest chart, image `nightly-latest`    | helm           | Reconciles `InferenceSet` and provisions inference pods.                              |
-| `gpu-node-mocker` (E2E-only)         | `kaito-system`   | repo `HEAD` (`SHADOW_CONTROLLER_IMAGE`) | helm           | Creates fake GPU nodes + shadow pods on CPU-only clusters.                            |
-| Gateway API CRDs                     | _cluster-scoped_ | `GATEWAY_API_VERSION` (v1.2.0)          | kubectl        | Required for `Gateway`, `HTTPRoute`, `ReferenceGrant`.                                |
-| Istio control plane (`istiod`)       | `istio-system`   | `ISTIO_VERSION` (1.29.2)                | istioctl       | Implements the Gateway dataplane (Envoy) and ext_proc filter chain.                   |
-| GAIE CRDs                            | _cluster-scoped_ | latest                                  | kubectl        | `InferencePool`, `InferenceObjective`.                                                |
-| KEDA                                 | `keda` (upstream) / `kube-system` (azure) | `KEDA_VERSION` (v2.19.0) | helm (upstream) / AKS managed add-on (azure) | Workload-metric autoscaling control plane.                                            |
-| `productionstack` umbrella chart ([`charts/productionstack`](charts/productionstack)) | release in `kaito-system`; subcharts pinned per-namespace via `namespaceOverride` | in-tree (`charts/productionstack`) | helm | Single Helm release that bundles every cluster-level helper. Currently ships **three** subcharts (versions pinned in `Chart.yaml`, not `versions.env`): `body-based-routing` → `kaito-system` (BBR `v1.5.0` ext_proc **workload** only; the per-namespace `EnvoyFilter` injecting `X-Gateway-Model-Name` is rendered by `charts/modelharness`), `keda-kaito-scaler` `v0.5.1` → KEDA's namespace (vLLM / `InferenceSet` metric aggregator for KEDA-driven autoscaling), and `llm-gateway-apikey` `0.0.9-alpha` (OCI dep from `mcr.microsoft.com/aks/kaito/helm`) → `llm-gateway-auth` (API-key ext_authz: `APIKey` CRD + `apikey-operator` + `apikey-authz` wired into Istio via `MeshConfig` + `AuthorizationPolicy`). |
-
-The `productionstack` umbrella chart consolidates the BBR and KEDA-Kaito-Scaler installs into a **single `helm install`**. The E2E suite installs it via [`hack/e2e/scripts/install-components.sh`](hack/e2e/scripts/install-components.sh) with the following overrides:
+Install the `productionstack` umbrella chart, plus any external prerequisites your environment does not already provide (Gateway API CRDs, Istio, GAIE CRDs, KEDA, KAITO). The umbrella chart bundles the cluster-level singletons every model deployment shares: BBR data plane, KEDA Kaito scaler, and the `llm-gateway-auth` control plane.
 
 ```sh
-helm upgrade --install productionstack charts/productionstack \
-  --namespace kaito-system --create-namespace \
-  --set keda-kaito-scaler.namespaceOverride="${KEDA_NAMESPACE}"
+# keda must already exist (Helm only auto-creates the release namespace).
+kubectl create namespace keda
+
+helm install productionstack oci://ghcr.io/kaito-project/productionstack \
+  --version <X.Y.Z> \
+  --namespace kaito-system \
+  --create-namespace \
+  --set keda-kaito-scaler.namespaceOverride=keda
 ```
 
-Each subchart can be independently disabled via `<subchart>.enabled=false` (see [`charts/productionstack/README.md`](charts/productionstack/README.md) for the full value reference). Additional cluster-level components will be folded into this umbrella over time.
+The full list of prerequisites the E2E suite installs alongside the umbrella chart is in [`hack/e2e/scripts/install-components.sh`](hack/e2e/scripts/install-components.sh). For the bundled subcharts, toggles, and per-subchart values, see [`charts/productionstack/README.md`](charts/productionstack/README.md).
 
 ### Step 2. modelharness (one-time per workload namespace)
 
-Provisioned by the [`charts/modelharness`](charts/modelharness) Helm
-chart. One Helm release per workload namespace owns every per-namespace
-shared resource — the Istio `Gateway` that fronts the namespace, the
-catch-all `EnvoyFilter` (`model-not-found-direct`) that returns an
-OpenAI-compatible 404 for unknown models directly from Envoy, and —
-when enabled — the per-namespace `AuthorizationPolicy` + `APIKey` CR
-that wire that Gateway into the cluster-wide `apikey-ext-authz` CUSTOM
-provider, plus optional `CiliumNetworkPolicy` resources that lock down
-East-West ingress to inference workloads. A namespace may host one or
-more model deployments, all of which share its Gateway.
+One Helm release per workload namespace provisions every per-namespace shared resource: the Istio `Gateway`, the BBR / catch-all 404 / unified-error `EnvoyFilter`s, and — when enabled — the API-key auth artifacts and a Cilium-based East-West network policy.
 
-> **Cilium is required for the network-policy path.** The chart renders
-> `cilium.io/v2` `CiliumNetworkPolicy` (CNP) rather than
-> `networking.k8s.io/v1` `NetworkPolicy`, because on the AKS Azure-CNI
-> overlay dataplane a vanilla K8s `NetworkPolicy` that selects a pod
-> created **before** the policy is installed is intermittently never
-> compiled into the per-endpoint BPF map (the `CiliumEndpoint` reports
-> `status.policy.ingress.enforcing=false` and traffic flows
-> unrestricted). Native CNPs bypass that translation step and reconcile
-> through Cilium's own path, becoming enforcing within a single tick.
-> Production deployments should therefore run on a cluster with the
-> Cilium dataplane enabled — for AKS this means `--network-dataplane
-> cilium --network-policy cilium` (see [`hack/e2e/scripts/setup-cluster.sh`](hack/e2e/scripts/setup-cluster.sh)).
-> If you cannot run Cilium, set `networkPolicy.enabled=false` and apply
-> equivalent ingress isolation out-of-band.
+```sh
+helm install modelharness oci://ghcr.io/kaito-project/modelharness \
+  --version <X.Y.Z> \
+  --namespace my-models \
+  --create-namespace
+```
 
-| Resource                                                       | Where                     | Version                | Source                                | Role                                                                                                                                       |
-| -------------------------------------------------------------- | ------------------------- | ---------------------- | ------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
-| `Gateway` (`gateway.networking.k8s.io/v1`)                     | Per namespace             | API `v1`               | `charts/modelharness`                 | Public entry point; `gatewayClassName: istio`, HTTP/80.                                                                                    |
-| Catch-all `EnvoyFilter` `model-not-found-direct`               | Per namespace             | `networking.istio.io/v1alpha3` | `charts/modelharness`         | Patches a `direct_response` onto the namespace Gateway's HCM, returning an OpenAI 404 for any path not matched by a deployment-specific `HTTPRoute`. Required to keep API-key ext_authz running on unknown-model requests. |
-| `AuthorizationPolicy` `apikey-gateway-ext-authz` (auth-enabled) | Per namespace             | `security.istio.io/v1` | `charts/modelharness` (`auth.enabled`) | Wires the per-namespace Gateway pod into the cluster-wide `apikey-ext-authz` CUSTOM provider (registered in `MeshConfig` by `llm-gateway-auth`). |
-| `APIKey` `default` (auth-enabled)                              | Per namespace             | `apikeys.kaito.sh/v1alpha1` | `charts/modelharness` (`auth.enabled`) | Triggers the `apikey-operator` to reconcile a Secret (`llm-api-key`) holding the bearer token clients send.                                 |
-| `CiliumNetworkPolicy` `inference-pods-ingress` (network-policy enabled, **requires Cilium dataplane**) | Per namespace | `cilium.io/v2` | `charts/modelharness` (`networkPolicy.enabled`) | Selects pods labelled `kaito.sh/owned-by: modeldeployment` (EPP, KAITO-rendered inference, shadow pods) and admits ingress from the same namespace plus the `networkPolicy.allowedIngressNamespaces` allowlist (e.g. `keda` for the keda-kaito-scaler); all other ingress is dropped by Cilium's implicit default-deny. |
-
-In the E2E suite the chart is installed and uninstalled by
-[`EnsureNamespace` / `DeleteNamespace`](test/e2e/utils/setup.go) (called
-from `InstallCase` / `UninstallCase` in
-[`cases.go`](test/e2e/cases.go)). The auth- and network-policy-related
-resources are skipped when `auth.enabled=false` /
-`networkPolicy.enabled=false`.
+For the rendered resource list, the API-key auth / network-policy toggles, the Cilium dataplane requirement, and the full value reference, see [`charts/modelharness/README.md`](charts/modelharness/README.md).
 
 ### Step 3. modeldeployment (per model deployment)
 
-Provisioned by the [`charts/modeldeployment`](charts/modeldeployment) Helm chart. One Helm release
-per model deployment, parented to the namespace's `Gateway`:
+One Helm release per model deployment, parented to the namespace's `Gateway`. Renders the `InferenceSet`, `InferencePool`, EPP (`llm-d-inference-scheduler`) Deployment / Service / RBAC / ConfigMap, and the `HTTPRoute` that matches `X-Gateway-Model-Name: <name>`.
 
-| Resource                                         | Version (chart-rendered) | Install method | Role                                                                  |
-| ------------------------------------------------ | ------------------------ | -------------- | --------------------------------------------------------------------- |
-| `InferenceSet` (`kaito.sh/v1alpha1`)             | `v1alpha1`               | helm           | Reconciled by KAITO; renders inference pods running vLLM.             |
-| `InferencePool` (`inference.networking.k8s.io/v1`) | `v1`                   | helm           | Selects the inference pods backing this deployment.                   |
-| EPP `Deployment` + `Service` + RBAC + `ConfigMap` | `apps/v1`, `v1`, `rbac/v1` | helm         | Endpoint Picker (`llm-d-inference-scheduler`) for KV-cache aware routing. |
-| `HTTPRoute` (`gateway.networking.k8s.io/v1`)     | `v1`                     | helm           | Matches `X-Gateway-Model-Name == <name>` on the namespace's Gateway and forwards to the InferencePool. |
+```sh
+helm install qwen oci://ghcr.io/kaito-project/modeldeployment \
+  --version <X.Y.Z> \
+  --namespace my-models \
+  --set name=qwen \
+  --set model=qwen2-5-coder-7b-instruct \
+  --set replicas=2 \
+  --set maxReplicas=5 \
+  --set enableScaling=true \
+  --set scalingThreshold=10
+```
 
-The chart's `name` value is the per-deployment routing key; `model` is
-the underlying KAITO preset. See the
-[`charts/modeldeployment` chart README](charts/modeldeployment/README.md)
-for the full value schema and install examples.
+For the full value schema (EPP image / ports / resources, scaling knobs, naming conventions, KAITO `FeatureFlagGatewayAPIInferenceExtension` compatibility note), see [`charts/modeldeployment/README.md`](charts/modeldeployment/README.md).
 
 ## Resource Reference
 
@@ -167,17 +139,13 @@ chains two reusable workflows
 [`publish-helm-chart.yaml`](.github/workflows/publish-helm-chart.yaml))
 into one synchronous run. A release publishes:
 
-- a multi-arch container image at
-  `ghcr.io/kaito-project/gpu-node-mocker:<X.Y.Z>` (no leading `v`);
-- the four Helm charts under [`charts/`](charts/) — `gpu-node-mocker`,
-  `modeldeployment`, `modelharness`, and the `productionstack` umbrella
-  chart — to the chart repository hosted on
-  this repo's `gh-pages` branch
-  (`https://kaito-project.github.io/production-stack/charts/kaito-project`);
-  the `productionstack` chart has its OCI subchart dependency vendored via
-  `helm dependency update` before packaging.
-- a GitHub Release at the same `vX.Y.Z` tag with auto-generated changelog
-  notes.
+- a multi-arch container image at `ghcr.io/kaito-project/gpu-node-mocker:<X.Y.Z>` (no leading `v`);
+- the four Helm charts under [`charts/`](charts/) — `gpu-node-mocker`, `modeldeployment`, `modelharness`, and the `productionstack` umbrella chart — published to **all three** chart distribution channels:
+  - the gh-pages Helm repo `https://kaito-project.github.io/production-stack/charts/kaito-project`,
+  - OCI artifacts under `oci://ghcr.io/kaito-project/<chart>`,
+  - OCI artifacts under `oci://mcr.microsoft.com/aks/kaito/helm/<chart>`;
+  the `productionstack` chart has its OCI subchart dependency vendored via `helm dependency update` before packaging.
+- a GitHub Release at the same `vX.Y.Z` tag with auto-generated changelog notes.
 
 To publish `vX.Y.Z`:
 

--- a/charts/modelharness/README.md
+++ b/charts/modelharness/README.md
@@ -1,0 +1,87 @@
+# modelharness
+
+Per-namespace shared resources for production-stack workloads. One `modelharness` release per workload namespace provisions everything every model deployment in that namespace shares:
+
+- the Istio `Gateway` that fronts the namespace,
+- the catch-all `EnvoyFilter` (`model-not-found-direct`) that returns an OpenAI-compatible `404 model_not_found` directly from Envoy for any path not matched by a deployment-specific `HTTPRoute`,
+- the per-namespace `EnvoyFilter` that injects BBR's ext_proc into the Gateway HCM,
+- the unified-error `local_reply` filter that maps fail-closed BBR / ext_authz outages and any other `>= 500` reply onto a consistent OpenAI-compatible error envelope,
+- (when `auth.enabled`) the `AuthorizationPolicy` and `APIKey` CR that wire the Gateway into the cluster-wide `apikey-ext-authz` CUSTOM provider,
+- (when `networkPolicy.enabled`) a `CiliumNetworkPolicy` that locks down East-West ingress to inference workloads in the namespace.
+
+A namespace may host one or more `modeldeployment` releases, all of which share its Gateway.
+
+## Rendered resources
+
+| Resource (Kind)                                | Group / Version                  | Toggle                       | Purpose                                                                                                                                                                                |
+| ---------------------------------------------- | -------------------------------- | ---------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Gateway`                                      | `gateway.networking.k8s.io/v1`   | always                       | Public entry point for the namespace; `gatewayClassName: istio`, HTTP/80 by default.                                                                                                   |
+| `EnvoyFilter` `bbr-ext-proc`                   | `networking.istio.io/v1alpha3`   | always                       | Injects the cluster-wide BBR ext_proc into the Gateway HCM, scoped via `workloadSelector`. BBR itself ships in `productionstack` / `body-based-routing`.                               |
+| `EnvoyFilter` `model-not-found-direct`         | `networking.istio.io/v1alpha3`   | always                       | Patches a `direct_response` onto the Gateway HCM; returns an OpenAI 404 for any unknown-model path. Required to keep API-key ext_authz running on unknown-model requests.              |
+| `EnvoyFilter` `gateway-filter-outage-local-reply` | `networking.istio.io/v1alpha3` | always                       | Single namespace-scoped `local_reply` that maps fail-closed BBR / ext_authz outages, gateway data-plane health failures, and any remaining 5xx onto the unified error envelope.        |
+| `EnvoyFilter` `apikey-ext-authz`               | `networking.istio.io/v1alpha3`   | `auth.enabled`               | Splices `envoy.filters.http.ext_authz` into the Gateway pod and points it at the cluster-wide `apikey-authz` gRPC Service installed by `productionstack/llm-gateway-apikey`.           |
+| `AuthorizationPolicy` `apikey-gateway-ext-authz` | `security.istio.io/v1`         | `auth.enabled`               | Per-namespace CUSTOM policy that gates traffic through the cluster-wide `apikey-ext-authz` extension provider on the Gateway pod.                                                       |
+| `APIKey` `default`                             | `apikeys.kaito.sh/v1alpha1`      | `auth.enabled`               | Triggers the `apikey-operator` to reconcile a Secret (`llm-api-key`) holding the bearer token clients send.                                                                            |
+| `CiliumNetworkPolicy` `inference-pods-ingress` | `cilium.io/v2`                   | `networkPolicy.enabled`      | Selects pods labelled `kaito.sh/owned-by: modeldeployment` and admits ingress from the same namespace plus `networkPolicy.allowedIngressNamespaces`; all other ingress is dropped.     |
+| `Namespace`                                    | `v1`                             | `manageNamespace` (default `true`) | Stamped with `productionstack.kaito.sh/managed-by: modelharness` so the status reporter can discover it. Skipped when the release namespace is the workload namespace.            |
+
+## Cilium requirement for the network-policy path
+
+The chart renders `cilium.io/v2` `CiliumNetworkPolicy` (CNP) rather than `networking.k8s.io/v1` `NetworkPolicy`, because on the AKS Azure-CNI overlay dataplane a vanilla K8s `NetworkPolicy` that selects a pod created **before** the policy is installed is intermittently never compiled into the per-endpoint BPF map (the `CiliumEndpoint` reports `status.policy.ingress.enforcing=false` and traffic flows unrestricted). Native CNPs bypass that translation step and reconcile through Cilium's own path, becoming enforcing within a single tick.
+
+Production deployments should therefore run on a cluster with the Cilium dataplane enabled — for AKS this means `--network-dataplane cilium --network-policy cilium` (see [`hack/e2e/scripts/setup-cluster.sh`](../../hack/e2e/scripts/setup-cluster.sh)). If you cannot run Cilium, set `networkPolicy.enabled=false` and apply equivalent ingress isolation out-of-band.
+
+## Install
+
+OCI (recommended):
+
+```sh
+helm install modelharness oci://ghcr.io/kaito-project/modelharness \
+  --version <X.Y.Z> \
+  --namespace my-models \
+  --create-namespace
+```
+
+In-tree:
+
+```sh
+helm install modelharness ./charts/modelharness \
+  --namespace my-models \
+  --create-namespace
+```
+
+Enable API-key auth and customize the allowed ingress namespaces:
+
+```sh
+helm install modelharness oci://ghcr.io/kaito-project/modelharness \
+  --version <X.Y.Z> \
+  --namespace my-models \
+  --create-namespace \
+  --set auth.enabled=true \
+  --set 'networkPolicy.allowedIngressNamespaces={keda,kaito-system,kube-system,monitoring}'
+```
+
+## Inputs
+
+Top-level values (see [`values.yaml`](./values.yaml) for the full schema, defaults, and inline documentation; cross-field constraints that JSON Schema cannot express are enforced by [`values.schema.json`](./values.schema.json) at install time).
+
+| Key                                       | Default                          | Description                                                                                                                                                                                                |
+| ----------------------------------------- | -------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `namespace`                               | `.Release.Namespace`             | Workload namespace that owns the rendered resources.                                                                                                                                                       |
+| `manageNamespace`                         | `true`                           | Render the workload `Namespace` object (stamped with the discovery label). Skipped when the release namespace is the workload namespace.                                                                   |
+| `gatewayName`                             | `<namespace>-gw`                 | Per-namespace Istio Gateway name. The Service follows Istio's `<gatewayName>-istio` convention.                                                                                                            |
+| `gatewayClassName`                        | `istio`                          | `GatewayClass` the Gateway binds to (AKS Istio add-on with App Routing: `approuting-istio`).                                                                                                               |
+| `gatewayPort`                             | `80`                             | HTTP listener port on the Gateway.                                                                                                                                                                         |
+| `bbr.name` / `bbr.namespace` / `bbr.port` | `body-based-router` / `kaito-system` / `9004` | Cluster FQDN coordinates of the BBR Service installed by `productionstack/body-based-routing`. Must match wherever BBR was installed.                                                              |
+| `bbr.envoyFilter.operation` / `anchorSubFilter` | `INSERT_BEFORE` / `envoy.filters.http.ext_proc` | Filter-chain placement so BBR injects `X-Gateway-Model-Name` before the InferencePool / EPP ext_proc and the `HTTPRoute` match run.                                                |
+| `bbr.outlierDetection.*`                  | see `values.yaml`                | Passive outlier detection on the BBR ext_proc upstream cluster so an erroring replica is ejected before tripping the fail-closed `502 bbr_unavailable` path.                                               |
+| `auth.enabled`                            | `false`                          | Render the per-namespace API-key auth artifacts (`AuthorizationPolicy`, `APIKey`, `apikey-ext-authz` `EnvoyFilter`).                                                                                       |
+| `auth.apiKeyName`                         | `default`                        | Name of the rendered `APIKey` CR.                                                                                                                                                                          |
+| `auth.extAuthz.*`                         | `apikey-authz` / `llm-gateway-auth` / `9001` / `5s` | Cluster-wide `apikey-authz` gRPC Service coordinates the per-namespace `EnvoyFilter` targets. Defaults match the `llm-gateway-apikey` subchart.                                              |
+| `networkPolicy.enabled`                   | `true`                           | Render the per-namespace `CiliumNetworkPolicy`. **Requires the Cilium dataplane** (see above). Disable when running on a non-Cilium cluster.                                                               |
+| `networkPolicy.allowedIngressNamespaces`  | `[keda, kaito-system, kube-system, monitoring]` | Cross-namespace ingress allowlist for inference pods. Each entry renders a `fromEndpoints` clause keyed off `k8s:io.kubernetes.pod.namespace`. Empty = strict per-namespace isolation. |
+
+## Companion charts
+
+- [`charts/productionstack`](../productionstack/README.md) — cluster-level components (BBR data plane, KEDA Kaito scaler, llm-gateway-apikey control plane) that `modelharness` references.
+- [`charts/modeldeployment`](../modeldeployment/README.md) — installed per model into a namespace whose Gateway / harness this chart provisioned.


### PR DESCRIPTION


**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

- publish-helm-chart.yaml: add push-charts-to-ghcr job that pushes gpu-node-mocker, modeldeployment, modelharness, and productionstack to oci://ghcr.io/kaito-project/<chart> via 'make helm-package-and-push' (helm registry login uses GITHUB_TOKEN).
- create-release.yaml: surface OCI (GHCR) install commands first in the auto-generated release notes; include productionstack in the chart list.
- README.md: slim Installation section. Each step now shows a runnable 'helm install oci://ghcr.io/kaito-project/<chart>' command and points to the chart's own README for detailed values and rendered resources. Add a sources table covering GHCR, MCR, gh-pages repo, and in-tree. Update Release Process to document publication to all three channels.
- charts/modelharness/README.md: new per-chart README (rendered resources, Cilium dataplane requirement, install examples, value reference).

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
