### PR TITLE
Move all cluster components and umbrella release to kube-system

### DIFF
--- a/.github/actions/e2e-base-setup/action.yaml
+++ b/.github/actions/e2e-base-setup/action.yaml
@@ -82,7 +82,7 @@ runs:
 
         # Derive KEDA install namespace from provider.
         case "${E2E_PROVIDER}" in
-          upstream) KEDA_NAMESPACE="keda" ;;
+          upstream) KEDA_NAMESPACE="kube-system" ;;
           azure)    KEDA_NAMESPACE="kube-system" ;;
         esac
 

--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -109,7 +109,7 @@ jobs:
 
           OCI (GHCR):
           \`\`\`
-          helm install productionstack  oci://ghcr.io/kaito-project/productionstack  --version ${IMG_TAG} -n kaito-system --create-namespace
+          helm install productionstack  oci://ghcr.io/kaito-project/productionstack  --version ${IMG_TAG} -n kube-system --create-namespace
           helm install modelharness     oci://ghcr.io/kaito-project/modelharness     --version ${IMG_TAG} -n my-models     --create-namespace
           helm install qwen             oci://ghcr.io/kaito-project/modeldeployment  --version ${IMG_TAG} -n my-models     --set name=gemma --set model=google/gemma-4-e4b-it
           \`\`\`

--- a/README.md
+++ b/README.md
@@ -53,15 +53,15 @@ The OCI commands below assume `ghcr.io`; swap the registry to suit. Pin `--versi
 Install the `productionstack` umbrella chart, plus any external prerequisites your environment does not already provide (Gateway API CRDs, Istio, GAIE CRDs, KEDA, KAITO). The umbrella chart bundles the cluster-level singletons every model deployment shares: BBR data plane, KEDA Kaito scaler, and the `llm-gateway-auth` control plane.
 
 ```sh
-# keda must already exist (Helm only auto-creates the release namespace).
-kubectl create namespace keda
-
 helm install productionstack oci://ghcr.io/kaito-project/productionstack \
   --version <X.Y.Z> \
-  --namespace kaito-system \
-  --create-namespace \
-  --set keda-kaito-scaler.namespaceOverride=keda
+  --namespace kube-system \
+  --create-namespace
 ```
+
+With the default values the umbrella release and all the cluster-level
+singletons it bundles — BBR data plane, KEDA Kaito scaler, and the
+`llm-gateway-auth` control plane — install into `kube-system`.
 
 The full list of prerequisites the E2E suite installs alongside the umbrella chart is in [`hack/e2e/scripts/install-components.sh`](hack/e2e/scripts/install-components.sh). For the bundled subcharts, toggles, and per-subchart values, see [`charts/productionstack/README.md`](charts/productionstack/README.md).
 

--- a/charts/modelharness/README.md
+++ b/charts/modelharness/README.md
@@ -58,7 +58,7 @@ helm install modelharness oci://ghcr.io/kaito-project/modelharness \
   --namespace my-models \
   --create-namespace \
   --set auth.enabled=true \
-  --set 'networkPolicy.allowedIngressNamespaces={keda,kaito-system,kube-system,monitoring}'
+  --set 'networkPolicy.allowedIngressNamespaces={kube-system,monitoring}'
 ```
 
 ## Inputs
@@ -72,14 +72,14 @@ Top-level values (see [`values.yaml`](./values.yaml) for the full schema, defaul
 | `gatewayName`                             | `<namespace>-gw`                 | Per-namespace Istio Gateway name. The Service follows Istio's `<gatewayName>-istio` convention.                                                                                                            |
 | `gatewayClassName`                        | `istio`                          | `GatewayClass` the Gateway binds to (AKS Istio add-on with App Routing: `approuting-istio`).                                                                                                               |
 | `gatewayPort`                             | `80`                             | HTTP listener port on the Gateway.                                                                                                                                                                         |
-| `bbr.name` / `bbr.namespace` / `bbr.port` | `body-based-router` / `kaito-system` / `9004` | Cluster FQDN coordinates of the BBR Service installed by `productionstack/body-based-routing`. Must match wherever BBR was installed.                                                              |
+| `bbr.name` / `bbr.namespace` / `bbr.port` | `body-based-router` / `kube-system` / `9004` | Cluster FQDN coordinates of the BBR Service installed by `productionstack/body-based-routing`. Must match wherever BBR was installed.                                                              |
 | `bbr.envoyFilter.operation` / `anchorSubFilter` | `INSERT_BEFORE` / `envoy.filters.http.ext_proc` | Filter-chain placement so BBR injects `X-Gateway-Model-Name` before the InferencePool / EPP ext_proc and the `HTTPRoute` match run.                                                |
 | `bbr.outlierDetection.*`                  | see `values.yaml`                | Passive outlier detection on the BBR ext_proc upstream cluster so an erroring replica is ejected before tripping the fail-closed `502 bbr_unavailable` path.                                               |
 | `auth.enabled`                            | `false`                          | Render the per-namespace API-key auth artifacts (`AuthorizationPolicy`, `APIKey`, `apikey-ext-authz` `EnvoyFilter`).                                                                                       |
 | `auth.apiKeyName`                         | `default`                        | Name of the rendered `APIKey` CR.                                                                                                                                                                          |
-| `auth.extAuthz.*`                         | `apikey-authz` / `llm-gateway-auth` / `9001` / `5s` | Cluster-wide `apikey-authz` gRPC Service coordinates the per-namespace `EnvoyFilter` targets. Defaults match the `llm-gateway-apikey` subchart.                                              |
+| `auth.extAuthz.*`                         | `apikey-authz` / `kube-system` / `9001` / `5s` | Cluster-wide `apikey-authz` gRPC Service coordinates the per-namespace `EnvoyFilter` targets. Defaults match the `llm-gateway-apikey` subchart.                                              |
 | `networkPolicy.enabled`                   | `true`                           | Render the per-namespace `CiliumNetworkPolicy`. **Requires the Cilium dataplane** (see above). Disable when running on a non-Cilium cluster.                                                               |
-| `networkPolicy.allowedIngressNamespaces`  | `[keda, kaito-system, kube-system, monitoring]` | Cross-namespace ingress allowlist for inference pods. Each entry renders a `fromEndpoints` clause keyed off `k8s:io.kubernetes.pod.namespace`. Empty = strict per-namespace isolation. |
+| `networkPolicy.allowedIngressNamespaces`  | `[kube-system, monitoring]` | Cross-namespace ingress allowlist for inference pods. Each entry renders a `fromEndpoints` clause keyed off `k8s:io.kubernetes.pod.namespace`. Empty = strict per-namespace isolation. |
 
 ## Companion charts
 

--- a/charts/modelharness/templates/envoyfilter-ext-authz.yaml
+++ b/charts/modelharness/templates/envoyfilter-ext-authz.yaml
@@ -9,7 +9,7 @@ release renders its own EnvoyFilter that splices
 `envoy.filters.http.ext_authz` into this namespace's Gateway pod
 (`<namespace>-gw`), pointing at the cluster-wide apikey-authz gRPC Service
 installed by the `llm-gateway-apikey` subchart of `productionstack`
-(defaults: `apikey-authz` in `llm-gateway-auth`, port 9001).
+(defaults: `apikey-authz` in `kube-system`, port 9001).
 
 Why per-namespace and not cluster-wide:
   - Auth scope is per workload namespace — different tenants get different

--- a/charts/modelharness/values.yaml
+++ b/charts/modelharness/values.yaml
@@ -50,9 +50,10 @@ bbr:
   # BBR Service name.
   name: body-based-router
 
-  # Namespace BBR's Deployment/Service run in (the umbrella release
-  # namespace by default).
-  namespace: kaito-system
+  # Namespace BBR's Deployment/Service run in (kube-system by default,
+  # matching the productionstack umbrella's body-based-routing
+  # namespaceOverride).
+  namespace: kube-system
 
   # BBR ext_proc gRPC port.
   port: 9004
@@ -124,7 +125,7 @@ auth:
   # targets. Defaults match the `llm-gateway-apikey` subchart.
   extAuthz:
     serviceName: apikey-authz
-    serviceNamespace: llm-gateway-auth
+    serviceNamespace: kube-system
     grpcPort: 9001
     # gRPC call timeout for the ext_authz check. ext_authz fires once per
     # request on headers only (not in the streaming body path), so a low
@@ -163,11 +164,9 @@ networkPolicy:
   # inference pods in this workload namespace. Each entry renders a
   # `fromEndpoints` clause keyed off the `k8s:io.kubernetes.pod.namespace`
   # label. Use it to permit control-plane / metric-scraper components
-  # outside the namespace (e.g. `keda-kaito-scaler` in `keda` reaching
-  # vLLM / InferencePool metric endpoints). An empty list keeps strict
-  # per-namespace isolation.
+  # outside the namespace (e.g. `keda-kaito-scaler` in `kube-system`
+  # reaching vLLM / InferencePool metric endpoints). An empty list keeps
+  # strict per-namespace isolation.
   allowedIngressNamespaces:
-    - keda
-    - kaito-system
     - kube-system
     - monitoring

--- a/charts/productionstack/README.md
+++ b/charts/productionstack/README.md
@@ -11,9 +11,9 @@ the inference data plane relies on.
 
 | Subchart             | Purpose                                                                                                  | Toggle                              | Default install namespace |
 |----------------------|----------------------------------------------------------------------------------------------------------|-------------------------------------|---------------------------|
-| `body-based-routing` | Cluster-wide singleton Body-Based Router (BBR) ext_proc **workload** (Deployment + Service + cluster RBAC). The Istio `EnvoyFilter` that injects BBR into each Gateway is rendered per-namespace by `charts/modelharness`, not here. | always installed (mandatory) | `kaito-system` (umbrella release namespace) |
-| `keda-kaito-scaler`  | KEDA external scaler that aggregates vLLM / `InferenceSet` metrics for workload-aware autoscaling.       | always installed (mandatory)  | `keda` |
-| `llm-gateway-apikey` (upstream OCI dep, 0.0.11-alpha) | API-key auth control plane for the inference Gateway: installs the `APIKey` CRD, the `apikey-operator` (reconciles `APIKey` CRs into per-namespace `llm-api-key` Secrets), and the `apikey-authz` ext_authz gRPC dataplane (single cluster-wide Service). **ext_authz wiring on inference Gateway pods is rendered per-namespace by [`charts/modelharness`](../modelharness/) — not by this subchart.** The upstream chart's own cluster-wide `EnvoyFilter` is neutralised via a sentinel `gatewaySelector` so per-namespace EnvoyFilters in `modelharness` are the sole source of ext_authz wiring. The upstream chart's STRICT `PeerAuthentication` is disabled by default (`llm-gateway-apikey.istio.strictMTLS: false`) to avoid blocking control-plane probes during rollout on mixed-mTLS clusters; flip it back on once the cluster is fully meshed. | `llm-gateway-apikey.enabled` (default `true`) | `llm-gateway-auth` |
+| `body-based-routing` | Cluster-wide singleton Body-Based Router (BBR) ext_proc **workload** (Deployment + Service + cluster RBAC). The Istio `EnvoyFilter` that injects BBR into each Gateway is rendered per-namespace by `charts/modelharness`, not here. | always installed (mandatory) | `kube-system` |
+| `keda-kaito-scaler`  | KEDA external scaler that aggregates vLLM / `InferenceSet` metrics for workload-aware autoscaling.       | always installed (mandatory)  | `kube-system` |
+| `llm-gateway-apikey` (upstream OCI dep, 0.0.11-alpha) | API-key auth control plane for the inference Gateway: installs the `APIKey` CRD, the `apikey-operator` (reconciles `APIKey` CRs into per-namespace `llm-api-key` Secrets), and the `apikey-authz` ext_authz gRPC dataplane (single cluster-wide Service). **ext_authz wiring on inference Gateway pods is rendered per-namespace by [`charts/modelharness`](../modelharness/) — not by this subchart.** The upstream chart's own cluster-wide `EnvoyFilter` is neutralised via a sentinel `gatewaySelector` so per-namespace EnvoyFilters in `modelharness` are the sole source of ext_authz wiring. The upstream chart's STRICT `PeerAuthentication` is disabled by default (`llm-gateway-apikey.istio.strictMTLS: false`) to avoid blocking control-plane probes during rollout on mixed-mTLS clusters; flip it back on once the cluster is fully meshed. | `llm-gateway-apikey.enabled` (default `true`) | `kube-system` |
 
 The three subcharts each expose a `namespaceOverride` value pinning
 **all of their namespaced resources** to a specific namespace,
@@ -50,26 +50,21 @@ avoids accidental coupling between components.
 ## Install standalone
 
 ```sh
-# keda must already exist (Helm only auto-creates the release
-# namespace).
-kubectl create namespace keda         --dry-run=client -o yaml | kubectl apply -f -
-
 # Vendor the upstream llm-gateway-apikey tarball into ./charts/ from
 # the OCI registry declared in Chart.yaml. Required once after a fresh
 # clone (and after bumping the dependency version).
 helm dependency update charts/productionstack
 
 helm upgrade --install productionstack charts/productionstack \
-  --namespace kaito-system \
+  --namespace kube-system \
   --create-namespace \
   --wait
 ```
 
-With the default values BBR lands in `kaito-system` (the release
-namespace), the KEDA scaler in `keda`, and the upstream
-llm-gateway-apikey control plane in `llm-gateway-auth` (the
-`namespaceOverride` defaults). The umbrella release itself can live in
-any namespace.
+With the default values the umbrella release and all the components it
+bundles — BBR, the KEDA scaler, and the upstream llm-gateway-apikey
+control plane — land in `kube-system` (the `namespaceOverride`
+defaults).
 
 ### API-key ext_authz is per-namespace
 
@@ -118,11 +113,11 @@ umbrella's release namespace.
 ```yaml
 # my-values.yaml
 body-based-routing:
-  namespaceOverride: ""                # inherit release namespace (kaito-system)
+  namespaceOverride: kube-system
 keda-kaito-scaler:
-  namespaceOverride: keda
+  namespaceOverride: kube-system
 llm-gateway-apikey:
-  namespaceOverride: llm-gateway-auth
+  namespaceOverride: kube-system
 ```
 
 Caveats:
@@ -145,7 +140,7 @@ stack:
 
 ```sh
 helm upgrade --install productionstack charts/productionstack \
-  --namespace kaito-system \
+  --namespace kube-system \
   --set llm-gateway-apikey.enabled=false
 ```
 
@@ -177,7 +172,7 @@ llm-gateway-apikey:
 
 ```sh
 helm upgrade --install productionstack charts/productionstack \
-  --namespace kaito-system \
+  --namespace kube-system \
   -f my-values.yaml
 ```
 

--- a/charts/productionstack/charts/body-based-routing/README.md
+++ b/charts/productionstack/charts/body-based-routing/README.md
@@ -13,7 +13,7 @@ Gateway's HCM is rendered **per workload namespace** by the
 (`templates/envoyfilter-bbr.yaml`) and scoped to that namespace's Gateway
 pod via a `workloadSelector`. Because BBR is reached purely by its
 cluster FQDN, it no longer has to live in Istio's root namespace and is
-co-located with the umbrella release (`kaito-system` by default).
+installed into `kube-system` by default.
 
 BBR always serves **plaintext HTTP/2** (`--secure-serving=false`): the
 gateway↔BBR hop never leaves the pod network, so there is no upstream
@@ -37,7 +37,7 @@ comments, and recapped here:
 | Filter anchored INSERT_BEFORE the InferencePool `envoy.filters.http.ext_proc` (configured in `modelharness`) | Enforces the gateway HTTP filter-chain order required by this repo: `ext_authz (if any) → bbr → ext_proc/epp → router`. BBR must inject `X-Gateway-Model-Name` before the InferencePool ext_proc resolves its per-route override. |
 | BBR always serves plaintext HTTP/2; the `bbr.secureServing` toggle and the upstream `DestinationRule` are removed | The gateway↔BBR hop never leaves the pod network, so upstream TLS adds a per-request self-signed-cert handshake for no benefit. `--secure-serving=false` is hardcoded and no `DestinationRule` is rendered. |
 | `bbr.multiNamespace` value removed; RBAC is **always** cluster-wide | Upstream defaults `multiNamespace: false` and renders a namespace-scoped `Role`/`RoleBinding`, which would leave BBR blind to the LoRA-adapter → base-model ConfigMaps living in workload namespaces and silently break adapter-aware routing. This fork ships a single `ClusterRole` + `ClusterRoleBinding` unconditionally. |
-| `namespaceOverride` value retained | Lets the umbrella `productionstack` chart place BBR in a namespace independent of the parent release namespace if needed. Empty string falls back to the release namespace (`kaito-system`). BBR no longer needs to live in Istio's root namespace. |
+| `namespaceOverride` value retained | Lets the umbrella `productionstack` chart place BBR in a namespace independent of the parent release namespace if needed. Empty string falls back to the release namespace. BBR no longer needs to live in Istio's root namespace. |
 | GKE provider template dropped | Upstream offers a `provider.name=gke` rendering path; this repo only ships the Istio data plane today. Reintroduce when a GKE-backed E2E lane lands. |
 | Image tag pinned (`v1.5.0`) instead of upstream `main` | Reproducible installs; `main` is a moving floating tag in the upstream staging registry. |
 | `app.kubernetes.io/*` labels added via `bbr.labels` / `bbr.selectorLabels` helpers; ConfigMap-reader `ClusterRole` name is release-scoped (`<bbr.name>-<release>-configmap-reader`) | Lets multiple unrelated releases coexist on the same cluster and makes `kubectl ... -l app.kubernetes.io/name=body-based-routing` work for ops. |
@@ -45,12 +45,12 @@ comments, and recapped here:
 ## Install via the umbrella chart (recommended)
 
 When consumed through [`productionstack`](../../README.md) a single
-`helm install` of the parent is enough; BBR is co-located with the
-umbrella release namespace:
+`helm install` of the parent is enough; BBR is installed into
+`kube-system` (the umbrella's default for this subchart):
 
 ```sh
 helm upgrade --install productionstack charts/productionstack \
-  --namespace kaito-system --create-namespace --wait
+  --namespace kube-system --create-namespace --wait
 ```
 
 Override BBR-specific values by nesting them under `body-based-routing:`
@@ -68,7 +68,7 @@ FQDN); co-locating with the rest of the stack is typical:
 ```sh
 helm upgrade --install body-based-router \
   charts/productionstack/charts/body-based-routing \
-  --namespace kaito-system \
+  --namespace kube-system \
   --create-namespace \
   --wait
 ```
@@ -99,7 +99,7 @@ so the per-namespace EnvoyFilter targets the right Service FQDN.
 
 | Parameter                                        | Default                                                                       | Description                                                                                                                    |
 |--------------------------------------------------|-------------------------------------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------|
-| `namespaceOverride`                              | `""`                                                                          | Pin the BBR Deployment / Service / RBAC (and the upstream FQDN modelharness uses) to this namespace. Empty ⇒ inherit the Helm release namespace (`kaito-system`). |
+| `namespaceOverride`                              | `""`                                                                          | Pin the BBR Deployment / Service / RBAC (and the upstream FQDN modelharness uses) to this namespace. Empty ⇒ inherit the Helm release namespace. |
 | `bbr.name`                                       | `body-based-router`                                                           | Name of the Deployment / Service.                                                                                              |
 | `bbr.replicas`                                   | `2`                                                                           | Replica count. BBR is a cluster-scope singleton on the request hot path, so it runs HA by default. `values.schema.json` pins the minimum to **2**; lowering it below 2 is rejected at render time. |
 | `bbr.podAntiAffinity.type`                       | `soft`                                                                        | `soft` ⇒ `preferredDuringScheduling…` (best-effort spread, still schedules on a single-node cluster); `hard` ⇒ `requiredDuringScheduling…` (a replica stays Pending until a distinct node is free). The anti-affinity rule itself is load-bearing for HA and is always rendered. |
@@ -152,5 +152,5 @@ replica is unhealthy.
 ## Uninstall
 
 ```sh
-helm uninstall body-based-router --namespace kaito-system
+helm uninstall body-based-router --namespace kube-system
 ```

--- a/charts/productionstack/charts/body-based-routing/values.yaml
+++ b/charts/productionstack/charts/body-based-routing/values.yaml
@@ -3,11 +3,10 @@
 #
 # Design intent for this fork:
 #   1. BBR is a cluster-wide WORKLOAD singleton: a single Deployment +
-#      Service + cluster-scoped RBAC. It is co-located with the
-#      productionstack umbrella release (kaito-system by default) — it
-#      no longer has to live in Istio's root namespace because this
-#      chart no longer renders any EnvoyFilter. The gateway dataplane
-#      wiring (the ext_proc EnvoyFilter that injects BBR into a
+#      Service + cluster-scoped RBAC. It is installed into kube-system
+#      by default — it no longer has to live in Istio's root namespace
+#      because this chart no longer renders any EnvoyFilter. The gateway
+#      dataplane wiring (the ext_proc EnvoyFilter that injects BBR into a
 #      Gateway's HCM) is rendered per-workload-namespace by
 #      charts/modelharness and scoped to that namespace's Gateway pod
 #      via a workloadSelector, so BBR's Service is reached purely by
@@ -29,9 +28,10 @@
 # (standard Helm behavior).
 #
 # BBR no longer renders an EnvoyFilter, so it is NOT required to live in
-# Istio's root namespace; co-locating it with the umbrella release
-# (kaito-system) is the default. The target namespace MUST already
-# exist — Helm only auto-creates the release namespace.
+# Istio's root namespace; installing it into kube-system is the
+# default (set via the umbrella chart's namespaceOverride). The target
+# namespace MUST already exist — Helm only auto-creates the release
+# namespace.
 namespaceOverride: ""
 
 bbr:

--- a/charts/productionstack/charts/keda-kaito-scaler/README.md
+++ b/charts/productionstack/charts/keda-kaito-scaler/README.md
@@ -49,13 +49,13 @@ kubectl -n keda logs deploy/keda-kaito-scaler | head
 
 ## Install as a subchart of `productionstack`
 
-The umbrella chart pins `keda-kaito-scaler.namespaceOverride: keda` by
-default, so the scaler lands in the `keda` namespace regardless of the
-Helm release namespace:
+The umbrella chart pins `keda-kaito-scaler.namespaceOverride: kube-system`
+by default, so the scaler lands in the `kube-system` namespace
+regardless of the Helm release namespace:
 
 ```sh
 helm upgrade --install productionstack charts/productionstack \
-  --namespace kaito-system \
+  --namespace kube-system \
   --create-namespace
 ```
 

--- a/charts/productionstack/charts/keda-kaito-scaler/values.yaml
+++ b/charts/productionstack/charts/keda-kaito-scaler/values.yaml
@@ -13,9 +13,9 @@ nameOverrider: ""
 #
 # Set this when the chart is consumed as a subchart of an umbrella
 # release that is installed into a different namespace than where the
-# scaler should actually run (e.g. parent installed into
-# `kaito-system`, scaler pinned to `keda`). The target namespace MUST
-# already exist — Helm only auto-creates the release namespace.
+# scaler should actually run (e.g. parent installed into `kube-system`,
+# scaler pinned to `keda`). The target namespace MUST already exist —
+# Helm only auto-creates the release namespace.
 namespaceOverride: ""
 
 image:

--- a/charts/productionstack/values.yaml
+++ b/charts/productionstack/values.yaml
@@ -29,10 +29,12 @@
 # name. The keys below mirror each subchart's `values.yaml` exactly;
 # see the subchart's own README for the full set of supported keys.
 #
-# Example — install BBR into istio-system and the scaler into keda
-# while the umbrella release itself lives in kaito-system:
+# By default every subchart below installs into kube-system, and the
+# umbrella release itself is also installed into kube-system. Override a
+# subchart's namespaceOverride to relocate it — e.g. install BBR into
+# istio-system and the scaler into keda:
 #   helm upgrade --install productionstack charts/productionstack \
-#     --namespace kaito-system --create-namespace \
+#     --namespace kube-system --create-namespace \
 #     --set body-based-routing.namespaceOverride=istio-system \
 #     --set keda-kaito-scaler.namespaceOverride=keda
 # (`istio-system` and `keda` must already exist.)
@@ -41,25 +43,24 @@
 # Body-Based Router (BBR) for the Gateway API Inference Extension.
 # Cluster-wide WORKLOAD singleton: a single Deployment + Service. It no
 # longer renders an EnvoyFilter, so it does NOT need to live in Istio's
-# root namespace — it is co-located with this umbrella release.
+# root namespace — it is installed into kube-system by default.
 # The per-namespace gateway wiring (ext_proc EnvoyFilter + outage
 # local_reply, both scoped to each Gateway pod) is rendered by
 # charts/modelharness; keep its `bbr.namespace` in sync with whatever
 # namespace BBR ends up in here.
 # See charts/body-based-routing/README.md for the full value reference.
 body-based-routing:
-  # Inherit the umbrella release namespace (kaito-system by default).
-  # BBR is reached by its cluster FQDN, so it can live anywhere; set a
-  # namespaceOverride only if you need it elsewhere (and then update
-  # modelharness `bbr.namespace` to match).
-  namespaceOverride: ""
+  # Install BBR into kube-system by default. BBR is reached by its
+  # cluster FQDN, so it can live anywhere; change this only if you need
+  # it elsewhere (and then update modelharness `bbr.namespace` to match).
+  namespaceOverride: kube-system
 
 # KEDA external scaler for vLLM / InferenceSet workloads.
 # See charts/keda-kaito-scaler/values.yaml for the full value reference.
 keda-kaito-scaler:
-  # Co-locate with the KEDA control plane by default. Set to "" to
-  # inherit the umbrella release namespace instead.
-  namespaceOverride: keda
+  # Co-locate with the KEDA control plane in kube-system by default. Set
+  # to "" to inherit the umbrella release namespace instead.
+  namespaceOverride: kube-system
 
 # LLM Gateway Auth — API-key ext_authz for the inference Gateway.
 # Pulled from the upstream `oci://mcr.microsoft.com/aks/kaito/helm`
@@ -103,10 +104,9 @@ keda-kaito-scaler:
 llm-gateway-apikey:
   enabled: true
   # Co-locate the LGA control plane (apikey-operator, apikey-authz,
-  # webhook cert Secret) in a dedicated namespace so the umbrella
-  # release itself can live elsewhere (e.g. kaito-system). Set to "" to
+  # webhook cert Secret) in kube-system by default. Set to "" to
   # inherit the umbrella release namespace instead.
-  namespaceOverride: llm-gateway-auth
+  namespaceOverride: kube-system
   # Mirror the umbrella's default LGA wiring so a single
   # `helm install productionstack` provisions a working data plane
   # without extra --set flags. Override at install time as needed.
@@ -129,7 +129,7 @@ llm-gateway-apikey:
     # otherwise render in the LGA namespace. We disable it because:
     #   * saturn-we (and other AKS Istio add-on clusters) may run a
     #     mix of mTLS modes across namespaces, and a STRICT PA in
-    #     llm-gateway-auth would block plaintext probes from the
+    #     kube-system would block plaintext probes from the
     #     control plane during the rollout.
     #   * the gateway pods that talk to apikey-authz already run an
     #     Istio sidecar (managed by the AKS Istio add-on), so mTLS to
@@ -140,10 +140,10 @@ llm-gateway-apikey:
     # want to fail-closed on any non-mTLS traffic into apikey-authz.
     strictMTLS: false
     # Pin the cluster-wide EnvoyFilter to the LGA control-plane
-    # namespace (rather than `default`) so the no-op resource lives
-    # alongside the rest of the chart's manifests and never collides
-    # with a user Gateway.
-    gatewayNamespace: llm-gateway-auth
+    # namespace (kube-system) so the no-op resource lives alongside the
+    # rest of the chart's manifests and never collides with a user
+    # Gateway.
+    gatewayNamespace: kube-system
     # Sentinel label that no Gateway pod carries. The cluster-wide
     # EnvoyFilter still renders (required by the upstream template)
     # but selects zero workloads, so it has no effect on the data

--- a/hack/e2e/scripts/dump-cluster-state.sh
+++ b/hack/e2e/scripts/dump-cluster-state.sh
@@ -95,17 +95,10 @@ echo "── Recent events (last 5 min) ─────────────�
 kubectl get events -A --sort-by='.lastTimestamp' 2>/dev/null | tail -40 || true
 
 echo ""
-echo "── kaito-system logs (last 80 lines per pod) ─────────────────"
-for pod in $(kubectl -n kaito-system get pods --no-headers -o custom-columns=':metadata.name' 2>/dev/null); do
+echo "── kube-system logs (last 80 lines per pod) ──────────────────"
+for pod in $(kubectl -n kube-system get pods --no-headers -o custom-columns=':metadata.name' 2>/dev/null); do
   echo "  ── ${pod} ──"
-  kubectl -n kaito-system logs "${pod}" --all-containers --tail=80 2>/dev/null || true
-done
-
-echo ""
-echo "── keda logs (last 80 lines per pod) ─────────────────────────"
-for pod in $(kubectl -n keda get pods --no-headers -o custom-columns=':metadata.name' 2>/dev/null); do
-  echo "  ── ${pod} ──"
-  kubectl -n keda logs "${pod}" --all-containers --tail=80 2>/dev/null || true
+  kubectl -n kube-system logs "${pod}" --all-containers --tail=80 2>/dev/null || true
 done
 
 echo ""

--- a/hack/e2e/scripts/install-components.sh
+++ b/hack/e2e/scripts/install-components.sh
@@ -30,13 +30,13 @@ E2E_PROVIDER="${E2E_PROVIDER:-upstream}"
 source "${SCRIPT_DIR}/lib-parallel.sh"
 
 # Derive KEDA install namespace from provider:
-#   upstream → `keda` (Helm-installed KEDA)
+#   upstream → `kube-system` (Helm-installed KEDA)
 #   azure    → `kube-system` (AKS managed KEDA add-on). keda-kaito-scaler
 #              must be co-located with KEDA so KEDA can resolve the
 #              ClusterTriggerAuthentication Secrets it ships.
 if [[ -z "${KEDA_NAMESPACE:-}" ]]; then
   case "${E2E_PROVIDER}" in
-    upstream) KEDA_NAMESPACE="keda" ;;
+    upstream) KEDA_NAMESPACE="kube-system" ;;
     azure)    KEDA_NAMESPACE="kube-system" ;;
     *)
       echo "Invalid E2E_PROVIDER='${E2E_PROVIDER}'. Must be 'upstream' or 'azure'." >&2
@@ -71,8 +71,7 @@ install_kaito() {
   # Per-model GAIE artifacts are provisioned by charts/modeldeployment; enabling
   # the gate would render a duplicate set of resources via Flux and conflict.
   helm install kaito kaito/workspace \
-    --namespace kaito-system \
-    --create-namespace \
+    --namespace kube-system \
     --set featureGates.enableInferenceSetController=true \
     --set featureGates.gatewayAPIInferenceExtension=false \
     --set image.repository=ghcr.io/kaito-project/kaito/workspace \
@@ -81,8 +80,8 @@ install_kaito() {
     --wait --timeout=300s
 
   echo "⏳ Waiting for KAITO controller..."
-  kubectl -n kaito-system rollout status deployment -l app.kubernetes.io/name=workspace --timeout=120s || true
-  kubectl -n kaito-system wait --for=condition=ready pod -l app.kubernetes.io/name=workspace --timeout=120s || \
+  kubectl -n kube-system rollout status deployment -l app.kubernetes.io/name=workspace --timeout=120s || true
+  kubectl -n kube-system wait --for=condition=ready pod -l app.kubernetes.io/name=workspace --timeout=120s || \
     echo "⚠️  KAITO pods not ready yet — continuing (will re-check later)."
 }
 
@@ -98,8 +97,7 @@ install_gwie_crds() {
 install_gpu_mocker() {
   echo "=== Deploying gpu-node-mocker (GPU node mocker) ==="
   helm install gpu-node-mocker ./charts/gpu-node-mocker \
-    --namespace kaito-system \
-    --create-namespace \
+    --namespace kube-system \
     --set image.repository="${SHADOW_CONTROLLER_IMAGE%:*}" \
     --set image.tag="${SHADOW_CONTROLLER_IMAGE##*:}"
 
@@ -107,7 +105,7 @@ install_gpu_mocker() {
   # exits if the CRD is not served, so early restarts are expected while
   # KAITO installs that CRD in parallel.
   echo "⏳ Waiting for gpu-node-mocker (will tolerate restarts while KAITO CRDs come online)..."
-  kubectl -n kaito-system rollout status deployment/gpu-node-mocker --timeout=420s || true
+  kubectl -n kube-system rollout status deployment/gpu-node-mocker --timeout=420s || true
 }
 
 
@@ -120,26 +118,25 @@ install_productionstack() {
   #
   # Per-subchart install namespaces (each via the subchart's own
   # `namespaceOverride` value):
-  #   * body-based-routing → kaito-system    (inherits the umbrella
-  #     release namespace). BBR is a workload-only singleton now: this
-  #     subchart renders just the Deployment + Service + RBAC and NO
-  #     EnvoyFilter, so it no longer has to live in Istio's root
-  #     namespace. The ext_proc EnvoyFilter that injects BBR into each
-  #     Gateway's HCM (anchored INSERT_BEFORE the InferencePool
-  #     ext_proc, giving ext_authz → bbr → ext_proc/epp → router) is
-  #     rendered per-namespace by charts/modelharness and scoped to that
-  #     namespace's Gateway pod.
+  #   * body-based-routing → kube-system. BBR is a workload-only
+  #     singleton now: this subchart renders just the Deployment +
+  #     Service + RBAC and NO EnvoyFilter, so it no longer has to live
+  #     in Istio's root namespace. The ext_proc EnvoyFilter that injects
+  #     BBR into each Gateway's HCM (anchored INSERT_BEFORE the
+  #     InferencePool ext_proc, giving ext_authz → bbr → ext_proc/epp →
+  #     router) is rendered per-namespace by charts/modelharness and
+  #     scoped to that namespace's Gateway pod.
   #   * keda-kaito-scaler  → ${KEDA_NAMESPACE}  (co-located with KEDA so
   #     KEDA can resolve the ClusterTriggerAuthentication Secrets it
   #     ships.)
-  #   * llm-gateway-apikey → llm-gateway-auth  (upstream chart 0.0.8-alpha+
+  #   * llm-gateway-apikey → kube-system  (upstream chart 0.0.8-alpha+
   #     supports namespaceOverride; the LGA operator + authz control
   #     plane live here, matching where validate-components.sh and the
   #     e2e suite expect them.)
   #
-  # The umbrella release itself is installed into `kaito-system`; the
-  # release Secret therefore lives in `kaito-system`. `helm uninstall
-  # productionstack -n kaito-system` correctly cleans up across all
+  # The umbrella release itself is installed into `kube-system`; the
+  # release Secret therefore lives in `kube-system`. `helm uninstall
+  # productionstack -n kube-system` correctly cleans up across all
   # override namespaces because Helm tracks the rendered manifest, not
   # the namespace.
   #
@@ -148,39 +145,35 @@ install_productionstack() {
   # Istio has injected the InferencePool ext_proc anchor; it is created
   # up-front and attaches lazily, which is fine.
 
-  echo "⏳ Ensuring per-subchart target namespaces exist..."
-  kubectl create namespace "${KEDA_NAMESPACE}" --dry-run=client -o yaml | kubectl apply -f -
-  kubectl create namespace llm-gateway-auth  --dry-run=client -o yaml | kubectl apply -f -
-
   echo "⏳ Vendoring upstream llm-gateway-apikey OCI dependency..."
   helm dependency update "${PRODUCTIONSTACK_CHART_DIR}"
 
   echo "=== Installing productionstack umbrella chart ==="
-  echo "    body-based-routing → kaito-system (umbrella release namespace)"
+  echo "    body-based-routing → kube-system"
   echo "    keda-kaito-scaler  → ${KEDA_NAMESPACE}"
-  echo "    llm-gateway-apikey → llm-gateway-auth (chart version pinned in Chart.yaml)"
+  echo "    llm-gateway-apikey → kube-system (chart version pinned in Chart.yaml)"
   helm upgrade --install productionstack "${PRODUCTIONSTACK_CHART_DIR}" \
-    --namespace kaito-system \
-    --create-namespace \
+    --namespace kube-system \
+    --set body-based-routing.namespaceOverride=kube-system \
     --set keda-kaito-scaler.namespaceOverride="${KEDA_NAMESPACE}" \
     --set llm-gateway-apikey.enabled=true \
-    --set llm-gateway-apikey.namespaceOverride=llm-gateway-auth \
+    --set llm-gateway-apikey.namespaceOverride=kube-system \
     --wait --timeout=600s
 
   echo "⏳ Waiting for BBR..."
-  kubectl -n kaito-system rollout status deployment/body-based-router --timeout=120s 2>/dev/null || \
-    kubectl -n kaito-system wait --for=condition=ready pod -l app=body-based-router --timeout=120s 2>/dev/null || \
+  kubectl -n kube-system rollout status deployment/body-based-router --timeout=120s 2>/dev/null || \
+    kubectl -n kube-system wait --for=condition=ready pod -l app=body-based-router --timeout=120s 2>/dev/null || \
     echo "⚠️  BBR not ready yet — continuing."
 
   echo "⏳ Waiting for keda-kaito-scaler..."
   kubectl -n "${KEDA_NAMESPACE}" rollout status deployment -l app.kubernetes.io/name=keda-kaito-scaler --timeout=180s || true
 
   echo "⏳ Waiting for apikey-operator..."
-  kubectl -n llm-gateway-auth wait --for=condition=Available \
+  kubectl -n kube-system wait --for=condition=Available \
     deployment/apikey-operator --timeout=15m
 
   echo "⏳ Waiting for apikey-authz..."
-  kubectl -n llm-gateway-auth wait --for=condition=Available \
+  kubectl -n kube-system wait --for=condition=Available \
     deployment/apikey-authz --timeout=15m
 }
 

--- a/hack/e2e/scripts/run-e2e-local.sh
+++ b/hack/e2e/scripts/run-e2e-local.sh
@@ -50,14 +50,14 @@ case "${E2E_PROVIDER}" in
 esac
 
 # Derive KEDA install namespace from provider.
-#   upstream → install KEDA via Helm into the dedicated `keda` namespace.
+#   upstream → install KEDA via Helm into `kube-system`.
 #   azure    → KEDA is provided by the AKS managed add-on, which lives in
 #              `kube-system`. The keda-kaito-scaler chart must be installed
 #              in the same namespace as KEDA so KEDA can resolve the
 #              ClusterTriggerAuthentication Secrets it ships.
 if [ -z "${KEDA_NAMESPACE:-}" ]; then
   case "${E2E_PROVIDER}" in
-    upstream) KEDA_NAMESPACE="keda" ;;
+    upstream) KEDA_NAMESPACE="kube-system" ;;
     azure)    KEDA_NAMESPACE="kube-system" ;;
   esac
 fi

--- a/hack/e2e/scripts/setup-cluster.sh
+++ b/hack/e2e/scripts/setup-cluster.sh
@@ -185,9 +185,9 @@ kubectl -n kube-system wait --for=condition=ready pod \
 #              --enable-gateway-api`. We only wait for their controllers
 #              / CRDs to be served. Istio is still installed via
 #              istioctl here.
-#   upstream → install KEDA via Helm into a dedicated `keda` namespace
-#              and apply the upstream Gateway API base CRDs via kubectl.
-#              Istio is installed via istioctl.
+#   upstream → install KEDA via Helm into `kube-system` and apply the
+#              upstream Gateway API base CRDs via kubectl. Istio is
+#              installed via istioctl.
 #
 # Istio is installed here (rather than in install-components.sh's
 # phase1-base) so the productionstack umbrella chart — which ships an
@@ -210,7 +210,7 @@ kubectl -n kube-system wait --for=condition=ready pod \
 # Derive KEDA install namespace from provider when not explicitly provided.
 if [[ -z "${KEDA_NAMESPACE:-}" ]]; then
   case "${E2E_PROVIDER}" in
-    upstream) KEDA_NAMESPACE="keda" ;;
+    upstream) KEDA_NAMESPACE="kube-system" ;;
     azure)    KEDA_NAMESPACE="kube-system" ;;
   esac
 fi
@@ -252,7 +252,6 @@ install_keda() {
       helm upgrade --install keda kedacore/keda \
         --version "${KEDA_VERSION}" \
         --namespace "${KEDA_NAMESPACE}" \
-        --create-namespace \
         --wait --timeout=300s
       echo "⏳ Waiting for KEDA operator..."
       kubectl -n "${KEDA_NAMESPACE}" rollout status deployment/keda-operator --timeout=180s || true

--- a/hack/e2e/scripts/validate-components.sh
+++ b/hack/e2e/scripts/validate-components.sh
@@ -14,7 +14,7 @@ E2E_PROVIDER="${E2E_PROVIDER:-upstream}"
 # Derive KEDA namespace from provider when not explicitly provided.
 if [[ -z "${KEDA_NAMESPACE:-}" ]]; then
   case "${E2E_PROVIDER}" in
-    upstream) KEDA_NAMESPACE="keda" ;;
+    upstream) KEDA_NAMESPACE="kube-system" ;;
     azure)    KEDA_NAMESPACE="kube-system" ;;
     *)
       echo "Invalid E2E_PROVIDER='${E2E_PROVIDER}'. Must be 'upstream' or 'azure'." >&2
@@ -38,22 +38,22 @@ echo ""
 
 # ── KAITO controller ─────────────────────────────────────────────────────
 echo "=== KAITO workspace controller ==="
-if kubectl -n kaito-system wait --for=condition=ready pod -l app.kubernetes.io/name=workspace --timeout="${TIMEOUT}" >/dev/null 2>&1; then
+if kubectl -n kube-system wait --for=condition=ready pod -l app.kubernetes.io/name=workspace --timeout="${TIMEOUT}" >/dev/null 2>&1; then
   pass "KAITO controller is Running"
 else
   fail "KAITO controller is NOT Running"
 fi
-kubectl -n kaito-system get pods -l app.kubernetes.io/name=workspace
+kubectl -n kube-system get pods -l app.kubernetes.io/name=workspace
 echo ""
 
 # ── Shadow-pod-controller (GPU node mocker) ──────────────────────────────
 echo "=== Shadow-pod-controller ==="
-if kubectl -n kaito-system wait --for=condition=ready pod -l app.kubernetes.io/name=gpu-node-mocker --timeout="${TIMEOUT}" >/dev/null 2>&1; then
+if kubectl -n kube-system wait --for=condition=ready pod -l app.kubernetes.io/name=gpu-node-mocker --timeout="${TIMEOUT}" >/dev/null 2>&1; then
   pass "gpu-node-mocker is Running"
 else
   fail "gpu-node-mocker is NOT Running"
 fi
-kubectl -n kaito-system get pods -l app.kubernetes.io/name=gpu-node-mocker
+kubectl -n kube-system get pods -l app.kubernetes.io/name=gpu-node-mocker
 echo ""
 
 # ── Istio (istiod) ──────────────────────────────────────────────────────
@@ -67,17 +67,17 @@ kubectl -n istio-system get pods -l app=istiod
 echo ""
 
 # ── BBR ──────────────────────────────────────────────────────────────────
-# BBR is a workload-only singleton co-located with the umbrella release
-# (kaito-system). The per-namespace ext_proc EnvoyFilter that wires it
+# BBR is a workload-only singleton installed into kube-system by the
+# umbrella release. The per-namespace ext_proc EnvoyFilter that wires it
 # into each Gateway's HCM is rendered by charts/modelharness; here we
 # only validate the BBR Deployment is Running.
 echo "=== BBR (Body-Based Router) ==="
-if kubectl -n kaito-system wait --for=condition=ready pod -l app=body-based-router --timeout="${TIMEOUT}" >/dev/null 2>&1; then
+if kubectl -n kube-system wait --for=condition=ready pod -l app=body-based-router --timeout="${TIMEOUT}" >/dev/null 2>&1; then
   pass "BBR is Running"
 else
   fail "BBR is NOT Running"
 fi
-kubectl -n kaito-system get pods -l app=body-based-router 2>/dev/null || true
+kubectl -n kube-system get pods -l app=body-based-router 2>/dev/null || true
 echo ""
 
 # (Catch-all 404 handling is now produced by an EnvoyFilter
@@ -111,22 +111,22 @@ echo ""
 
 # ── LLM Gateway Auth (apikey-operator) ──────────────────────────────────
 echo "=== LLM Gateway Auth (operator) ==="
-if kubectl -n llm-gateway-auth wait --for=condition=ready pod -l app.kubernetes.io/component=apikey-operator --timeout="${TIMEOUT}" >/dev/null 2>&1; then
+if kubectl -n kube-system wait --for=condition=ready pod -l app.kubernetes.io/component=apikey-operator --timeout="${TIMEOUT}" >/dev/null 2>&1; then
   pass "apikey-operator is Running"
 else
   fail "apikey-operator is NOT Running"
 fi
-kubectl -n llm-gateway-auth get pods -l app.kubernetes.io/component=apikey-operator 2>/dev/null || true
+kubectl -n kube-system get pods -l app.kubernetes.io/component=apikey-operator 2>/dev/null || true
 echo ""
 
 # ── LLM Gateway Auth (apikey-authz) ─────────────────────────────────────
 echo "=== LLM Gateway Auth (authz) ==="
-if kubectl -n llm-gateway-auth wait --for=condition=ready pod -l app.kubernetes.io/component=apikey-authz --timeout="${TIMEOUT}" >/dev/null 2>&1; then
+if kubectl -n kube-system wait --for=condition=ready pod -l app.kubernetes.io/component=apikey-authz --timeout="${TIMEOUT}" >/dev/null 2>&1; then
   pass "apikey-authz is Running"
 else
   fail "apikey-authz is NOT Running"
 fi
-kubectl -n llm-gateway-auth get pods -l app.kubernetes.io/component=apikey-authz 2>/dev/null || true
+kubectl -n kube-system get pods -l app.kubernetes.io/component=apikey-authz 2>/dev/null || true
 echo ""
 
 # ── CRDs ─────────────────────────────────────────────────────────────────

--- a/test/e2e/bbr_outage_test.go
+++ b/test/e2e/bbr_outage_test.go
@@ -57,7 +57,7 @@ var _ = Describe("BBR outage (fail-closed cluster filter)",
 	Ordered, Serial, utils.GinkgoLabelClusterOutage, func() {
 
 		const (
-			bbrNamespace      = "kaito-system"
+			bbrNamespace      = "kube-system"
 			bbrDeploymentName = "body-based-router"
 		)
 

--- a/test/e2e/cases.go
+++ b/test/e2e/cases.go
@@ -96,7 +96,7 @@ const (
 	// high-availability and single-replica-loss failover (issue #89).
 	// A lightweight gpu-mocker-style deployment provides a working
 	// BBR → EPP request path; the test then perturbs the cluster-wide
-	// BBR Deployment in kaito-system (delete one replica / scale to
+	// BBR Deployment in kube-system (delete one replica / scale to
 	// zero) and asserts the request path stays healthy while ≥1 replica
 	// survives and only fails closed when ALL replicas are down.
 	CaseClusterFilterHA = "cluster-filter-ha"

--- a/test/e2e/cluster_filter_ha_test.go
+++ b/test/e2e/cluster_filter_ha_test.go
@@ -49,7 +49,7 @@ import (
 //	so that the loss of ONE replica is a transparent failover and the
 //	fail-closed `502` path only fires when ALL replicas are down.
 //
-//	This suite perturbs the shared kaito-system BBR Deployment, so it is
+//	This suite perturbs the shared kube-system BBR Deployment, so it is
 //	decorated Serial — no other spec may run while BBR is degraded.
 //
 // Scope note: the structured `502 bbr_unavailable` envelope (+
@@ -62,7 +62,7 @@ var _ = Describe("BBR cluster-filter HA",
 	Ordered, Serial, utils.GinkgoLabelClusterFilterHA, utils.GinkgoLabelSmoke, func() {
 
 		const (
-			bbrNamespace  = "kaito-system"
+			bbrNamespace  = "kube-system"
 			bbrDeployment = "body-based-router"
 			bbrHealthPort = 9005
 		)

--- a/test/e2e/ext_authz_outage_test.go
+++ b/test/e2e/ext_authz_outage_test.go
@@ -62,7 +62,7 @@ var _ = Describe("ext_authz outage (fail-closed cluster filter)",
 	Ordered, Serial, utils.GinkgoLabelClusterOutage, utils.GinkgoLabelAuth, func() {
 
 		const (
-			authNamespace      = "llm-gateway-auth"
+			authNamespace      = "kube-system"
 			authDeploymentName = "apikey-authz"
 		)
 

--- a/test/e2e/filter_order_test.go
+++ b/test/e2e/filter_order_test.go
@@ -159,7 +159,7 @@ var _ = Describe("Filter execution order",
 				clientset, err := utils.GetK8sClientset()
 				Expect(err).NotTo(HaveOccurred())
 
-				bbrNS := "kaito-system"
+				bbrNS := "kube-system"
 				bbrPod, err := firstRunningPod(ctx, bbrNS,
 					"app.kubernetes.io/name=body-based-routing")
 				Expect(err).NotTo(HaveOccurred(),
@@ -197,7 +197,7 @@ var _ = Describe("Filter execution order",
 				clientset, err := utils.GetK8sClientset()
 				Expect(err).NotTo(HaveOccurred())
 
-				bbrNS := "kaito-system"
+				bbrNS := "kube-system"
 				bbrPod, err := firstRunningPod(ctx, bbrNS,
 					"app.kubernetes.io/name=body-based-routing")
 				Expect(err).NotTo(HaveOccurred())
@@ -469,7 +469,7 @@ var _ = Describe("Filter execution order",
 				clientset, err := utils.GetK8sClientset()
 				Expect(err).NotTo(HaveOccurred())
 
-				bbrNS := "kaito-system"
+				bbrNS := "kube-system"
 				bbrPod, err := firstRunningPod(ctx, bbrNS,
 					"app.kubernetes.io/name=body-based-routing")
 				Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/utils/ginkgo.go
+++ b/test/e2e/utils/ginkgo.go
@@ -66,7 +66,7 @@ var (
 
 	// GinkgoLabelClusterFilterHA marks tests that verify the cluster-wide
 	// BBR ext_proc filter's high availability and single-replica-loss
-	// failover (issue #89). These tests perturb the shared kaito-system
+	// failover (issue #89). These tests perturb the shared kube-system
 	// BBR Deployment, so the suite MUST decorate them Serial.
 	// See test/e2e/cluster_filter_ha_test.go.
 	GinkgoLabelClusterFilterHA = g.Label("ClusterFilterHA")

--- a/test/e2e/utils/helm.go
+++ b/test/e2e/utils/helm.go
@@ -183,8 +183,8 @@ func modelHarnessChartPath() string {
 // default-deny-ingress / allow-inference-traffic NetworkPolicies that
 // lock down East-West ingress while keeping the gateway pod reachable;
 // the chart-default `allowedIngressNamespaces` (currently
-// keda + kaito-system) covers the control-plane scrapers every workload
-// in this repo needs.
+// kube-system + monitoring) covers the control-plane scrapers every
+// workload in this repo needs.
 //
 // Idempotent: re-running on an existing release reconciles the values.
 func InstallModelHarness(namespace string, authEnabled bool) error {

--- a/test/e2e/utils/setup.go
+++ b/test/e2e/utils/setup.go
@@ -43,8 +43,8 @@ import (
 // per-namespace gateway pod reachable from outside the namespace
 // (matched via the standard `gateway.networking.k8s.io/gateway-name`
 // label that Istio stamps on every gateway pod). The chart-default
-// `allowedIngressNamespaces` (currently keda + kaito-system) covers
-// the control-plane scrapers — `keda-kaito-scaler` and the
+// `allowedIngressNamespaces` (currently kube-system + monitoring)
+// covers the control-plane scrapers — `keda-kaito-scaler` and the
 // gpu-node-mocker / kaito-workspace controllers — that need to reach
 // shadow pods directly from outside the workload namespace.
 //

--- a/versions.env
+++ b/versions.env
@@ -14,9 +14,9 @@
 
 # E2E provider — master switch selecting the component-install mix.
 #   upstream  → install every component from its upstream source via Helm
-#               (KAITO, KEDA, KEDA Kaito Scaler, BBR, Istio, …). The
-#               underlying K8s cluster is still AKS, but no Azure-managed
-#               add-ons are enabled.
+#               (KAITO, KEDA, KEDA Kaito Scaler, BBR, Istio, …) into
+#               `kube-system` by default. The underlying K8s cluster is
+#               still AKS, but no Azure-managed add-ons are enabled.
 #   azure     → use Azure-managed services where available. Currently this
 #               only swaps Helm-KEDA for the AKS managed KEDA add-on
 #               (`az aks create --enable-keda`), which installs KEDA into
@@ -24,7 +24,7 @@
 #               KEDA resolves Secrets referenced by ClusterTriggerAuthentication
 #               from its own install namespace, the keda-kaito-scaler chart
 #               is installed alongside KEDA (i.e. in `kube-system`) under
-#               this provider.
+#               both providers.
 E2E_PROVIDER="upstream"
 
 # Go toolchain version


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

Install KEDA, keda-kaito-scaler, BBR, KAITO, llm-gateway-auth, the productionstack umbrella release, and gpu-node-mocker into kube-system by default. Retire kaito-system from the stack: remove it from modelharness networkPolicy.allowedIngressNamespaces and purge it from all README/values comments. Drop redundant namespace creation for kube-system (always present) from the e2e scripts.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
