### PR TITLE
ci: add nightly image and chart publishing workflows

### DIFF
--- a/.github/workflows/publish-nightly-acr.yaml
+++ b/.github/workflows/publish-nightly-acr.yaml
@@ -1,0 +1,122 @@
+name: Publish nightly ACR images and charts
+
+on:
+  schedule:
+    - cron: '30 1 * * *'
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: 'Git ref to build from (branch, tag, or SHA)'
+        required: false
+        default: 'main'
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-acr
+  cancel-in-progress: true
+
+jobs:
+  build-publish-image-acr:
+    runs-on:
+      labels:
+        - self-hosted
+        - 1ES.Pool=1es-aks-kaito-agent-pool-ubuntu
+        - JobId=nightlyAcrImage-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    environment: publish-mcr
+    outputs:
+      img_tag: ${{ steps.get-image-tag.outputs.img_tag }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image_name: gpu-node-mocker
+            chart_path: charts/gpu-node-mocker
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.git_ref || 'main' }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - id: get-image-tag
+        name: Compute nightly image tag
+        run: |
+          # Semver-compatible nightly tag: <chart version>-<UTC date>, e.g. 0.2.1-20260623.
+          base_version="$(yq '.version' ${{ matrix.chart_path }}/Chart.yaml)"
+          date_tag="$(date -u +%Y%m%d)"
+          echo "img_tag=${base_version}-${date_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to ACR
+        run: |
+          az login --identity
+          az acr login -n "${REGISTRY}"
+        env:
+          REGISTRY: ${{ secrets.KAITO_ACR_REGISTRY }}
+
+      - name: Build and push ${{ matrix.image_name }}:${{ steps.get-image-tag.outputs.img_tag }}
+        run: |
+          OUTPUT_TYPE=type=registry make docker-buildx
+        env:
+          REGISTRY: ${{ secrets.KAITO_ACR_REGISTRY }}
+          IMG_NAME: ${{ matrix.image_name }}
+          IMG_TAG: ${{ steps.get-image-tag.outputs.img_tag }}
+
+  publish-charts-acr:
+    needs: [build-publish-image-acr]
+    runs-on:
+      labels:
+        - self-hosted
+        - 1ES.Pool=1es-aks-kaito-agent-pool-ubuntu
+        - JobId=nightlyAcrCharts-${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
+    environment: publish-mcr
+    env:
+      IMG_TAG: ${{ needs.build-publish-image-acr.outputs.img_tag }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.git_ref || 'main' }}
+
+      - name: Setup Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: v3.20.2
+
+      - name: Authenticate to ACR
+        run: |
+          az login --identity
+          az acr login -n "${REGISTRY}"
+        env:
+          REGISTRY: ${{ secrets.KAITO_ACR_REGISTRY }}
+
+      - name: Pin gpu-node-mocker chart to nightly ACR image
+        # Point values.yaml at the nightly ACR image so an install of the
+        # nightly chart pulls the matching nightly controller image.
+        run: |
+          yq -i ".image.repository = \"${REGISTRY}/gpu-node-mocker\" | .image.tag = \"${IMG_TAG}\"" \
+            charts/gpu-node-mocker/values.yaml
+        env:
+          REGISTRY: ${{ secrets.KAITO_ACR_REGISTRY }}
+
+      - name: Vendor productionstack subchart dependencies
+        # Umbrella chart pulls an OCI subchart at package time; vendor it
+        # into charts/ before make helm-package-and-push runs.
+        run: helm dependency update charts/productionstack
+
+      - name: Package and push charts to ACR
+        run: |
+          export CHART_REGISTRY="${REGISTRY}/helm"
+          export CHART_VERSION="${IMG_TAG}"
+          make helm-package-and-push CHART_NAME='gpu-node-mocker'
+          make helm-package-and-push CHART_NAME='modeldeployment'
+          make helm-package-and-push CHART_NAME='modelharness'
+          make helm-package-and-push CHART_NAME='productionstack'
+        env:
+          REGISTRY: ${{ secrets.KAITO_ACR_REGISTRY }}

--- a/.github/workflows/publish-nightly-image-gh.yaml
+++ b/.github/workflows/publish-nightly-image-gh.yaml
@@ -1,0 +1,98 @@
+name: Publish nightly GH images
+
+# Mirrors publish-image.yaml (release flow) but runs daily on a schedule
+# and tags images with <chart-version>-<UTC-date>, then promotes the
+# nightly-latest alias after a successful Trivy scan.
+on:
+  schedule:
+    - cron: '0 1 * * *'
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: 'Git ref to build from (branch, tag, or SHA)'
+        required: false
+        default: 'main'
+        type: string
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  REGISTRY: ghcr.io
+
+concurrency:
+  group: nightly-ghcr-images
+  cancel-in-progress: true
+
+jobs:
+  build-scan-publish-gh-nightly-images:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - image_name: gpu-node-mocker
+            chart_path: charts/gpu-node-mocker
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          submodules: true
+          fetch-depth: 0
+          ref: ${{ github.event.inputs.git_ref || 'main' }}
+
+      - id: get-registry
+        name: Compute registry repository
+        run: |
+          # registry must be in lowercase
+          echo "registry_repository=$(echo "${{ env.REGISTRY }}/kaito-project" | tr '[:upper:]' '[:lower:]')" >> $GITHUB_OUTPUT
+
+      - id: get-image-tag
+        name: Compute nightly image tag
+        run: |
+          # Semver-compatible nightly tag: <chart version>-<UTC date>, e.g. 0.2.1-20260623.
+          base_version="$(yq '.version' ${{ matrix.chart_path }}/Chart.yaml)"
+          date_tag="$(date -u +%Y%m%d)"
+          echo "IMG_TAG=${base_version}-${date_tag}" >> "$GITHUB_ENV"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
+
+      - name: Login to ${{ steps.get-registry.outputs.registry_repository }}
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.image_name }}:${{ env.IMG_TAG }}
+        run: |
+          OUTPUT_TYPE=type=registry make docker-buildx
+        env:
+          REGISTRY: ${{ steps.get-registry.outputs.registry_repository }}
+          IMG_NAME: ${{ matrix.image_name }}
+
+      - name: Scan ${{ steps.get-registry.outputs.registry_repository }}/${{ matrix.image_name }}:${{ env.IMG_TAG }}
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ steps.get-registry.outputs.registry_repository }}/${{ matrix.image_name }}:${{ env.IMG_TAG }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          timeout: '5m0s'
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update ${{ matrix.image_name }}:nightly-latest
+        run: |
+          # Promote alias only after the scan step succeeds.
+          image_ref="${REGISTRY}/${IMAGE_NAME}"
+          docker buildx imagetools create \
+            --tag "${image_ref}:nightly-latest" \
+            "${image_ref}:${IMG_TAG}"
+        env:
+          REGISTRY: ${{ steps.get-registry.outputs.registry_repository }}
+          IMAGE_NAME: ${{ matrix.image_name }}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

Add two scheduled workflows that mirror the release publish flow:

- publish-nightly-image-gh.yaml: daily build of gpu-node-mocker to GHCR tagged <chart-version>-<UTC-date>, Trivy-scanned, and promoted to the nightly-latest alias on success.
- publish-nightly-acr.yaml: daily build of gpu-node-mocker to ACR plus packaging and pushing of gpu-node-mocker, modeldeployment, modelharness, and productionstack charts, with values.yaml pinned to the nightly ACR image.

Both workflows support workflow_dispatch with a git_ref input.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
