### PR TITLE
ci: install yq on self-hosted runner for nightly ACR workflow

### DIFF
--- a/.github/workflows/publish-nightly-acr.yaml
+++ b/.github/workflows/publish-nightly-acr.yaml
@@ -44,6 +44,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2 # v3.10.0
 
+      - name: Setup yq
+        # The 1ES self-hosted pool does not ship yq; install a pinned binary.
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
+
       - id: get-image-tag
         name: Compute nightly image tag
         run: |
@@ -88,6 +94,12 @@ jobs:
         uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
         with:
           version: v3.20.2
+
+      - name: Setup yq
+        # The 1ES self-hosted pool does not ship yq; install a pinned binary.
+        run: |
+          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/v4.44.3/yq_linux_amd64
+          sudo chmod +x /usr/local/bin/yq
 
       - name: Authenticate to ACR
         run: |


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

The 1ES self-hosted pool does not ship yq, so the Compute nightly image tag and chart-pinning steps failed with exit 127. Add a pinned yq install step to both jobs of publish-nightly-acr.yaml.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
