### PR TITLE
feat(gpu-node-mocker): support configurable mock node class for karpenter coexistence

### DIFF
--- a/.github/actions/e2e-base-setup/action.yaml
+++ b/.github/actions/e2e-base-setup/action.yaml
@@ -68,6 +68,16 @@ inputs:
       mocker build/deploy.
     required: false
     default: 'true'
+  node-class:
+    description: >
+      Karpenter NodeClass to use (karpenter mode only). One of "mock"
+      (karpenter.kaito.sh/MockNodeClass — a kind only gpu-node-mocker
+      recognizes, so a real Karpenter provider skips NodePools referencing it)
+      or "azure" (the real karpenter.azure.com/AKSNodeClass). Use "mock" with
+      enable-node-mocker=true and "azure" with a real Karpenter install.
+      Default: mock.
+    required: false
+    default: 'mock'
 
 outputs:
   image:
@@ -90,6 +100,7 @@ runs:
         INPUT_LGA="${{ inputs.llm-gateway-auth-version }}"
         INPUT_NODE_PROVISIONER="${{ inputs.node-provisioner }}"
         INPUT_ENABLE_NODE_MOCKER="${{ inputs.enable-node-mocker }}"
+        INPUT_NODE_CLASS="${{ inputs.node-class }}"
         [ -n "${INPUT_PROVIDER}" ] && E2E_PROVIDER="${INPUT_PROVIDER}"
         [ -n "${INPUT_ISTIO}" ] && ISTIO_VERSION="${INPUT_ISTIO}"
         [ -n "${INPUT_GWAPI}" ] && GATEWAY_API_VERSION="${INPUT_GWAPI}"
@@ -97,6 +108,7 @@ runs:
         [ -n "${INPUT_LGA}" ]   && LLM_GATEWAY_AUTH_VERSION="${INPUT_LGA}"
         KAITO_NODE_PROVISIONER="${INPUT_NODE_PROVISIONER:-karpenter}"
         ENABLE_NODE_MOCKER="${INPUT_ENABLE_NODE_MOCKER:-true}"
+        KAITO_NODE_CLASS="${INPUT_NODE_CLASS:-mock}"
 
         # Validate provider value.
         case "${E2E_PROVIDER}" in
@@ -126,6 +138,7 @@ runs:
           echo "AKS_K8S_VERSION=${AKS_K8S_VERSION}"
           echo "KAITO_NODE_PROVISIONER=${KAITO_NODE_PROVISIONER}"
           echo "ENABLE_NODE_MOCKER=${ENABLE_NODE_MOCKER}"
+          echo "KAITO_NODE_CLASS=${KAITO_NODE_CLASS}"
         } >> "$GITHUB_ENV"
 
     - name: Print versions
@@ -142,6 +155,7 @@ runs:
         echo "AKS_K8S_VERSION=${AKS_K8S_VERSION}"
         echo "KAITO_NODE_PROVISIONER=${KAITO_NODE_PROVISIONER}"
         echo "ENABLE_NODE_MOCKER=${ENABLE_NODE_MOCKER}"
+        echo "KAITO_NODE_CLASS=${KAITO_NODE_CLASS}"
 
     - name: Setup Go
       uses: actions/setup-go@v6
@@ -199,6 +213,7 @@ runs:
         SHADOW_CONTROLLER_IMAGE: ${{ steps.image.outputs.image }}
         KAITO_NODE_PROVISIONER: ${{ inputs.node-provisioner }}
         ENABLE_NODE_MOCKER: ${{ inputs.enable-node-mocker }}
+        KAITO_NODE_CLASS: ${{ inputs.node-class }}
       run: make e2e-install
 
     - name: Validate components

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -77,6 +77,7 @@ jobs:
           node-vm-size: ${{ env.NODE_VM_SIZE }}
           node-provisioner: karpenter
           enable-node-mocker: false
+          node-class: azure
           provider: ${{ github.event.inputs.provider }}
           istio-version: ${{ github.event.inputs.istio_version }}
           gateway-api-version: ${{ github.event.inputs.gateway_api_version }}

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -31,6 +31,14 @@ on:
         description: 'KEDA Helm chart version (e.g. v2.19.0). Leave empty to use default from versions.env'
         required: false
         default: ''
+      node_class:
+        description: 'Karpenter NodeClass: "mock" (gpu-node-mocker MockNodeClass) or "azure" (real AKSNodeClass).'
+        required: false
+        default: 'mock'
+        type: choice
+        options:
+          - mock
+          - azure
 
 env:
   RESOURCE_GROUP: "kaito-gw-e2e-rg-${{ github.run_id }}"
@@ -71,6 +79,7 @@ jobs:
           istio-version: ${{ github.event.inputs.istio_version }}
           gateway-api-version: ${{ github.event.inputs.gateway_api_version }}
           keda-version: ${{ github.event.inputs.keda_version }}
+          node-class: ${{ github.event.inputs.node_class }}
 
       - name: Run E2E tests
         # Skip Nightly-labeled specs (slow/destructive scaling cases, etc.).

--- a/charts/gpu-node-mocker/crds/karpenter.kaito.sh_mocknodeclasses.yaml
+++ b/charts/gpu-node-mocker/crds/karpenter.kaito.sh_mocknodeclasses.yaml
@@ -1,0 +1,98 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.19.0
+  name: mocknodeclasses.karpenter.kaito.sh
+spec:
+  # karpenter.kaito.sh is intentionally a DIFFERENT API group from the real
+  # Azure provider's karpenter.azure.com/AKSNodeClass. A real Karpenter
+  # provider only resolves the NodeClass kind it registers (AKSNodeClass for
+  # the Azure provider), so it cannot resolve a NodePool whose nodeClassRef
+  # points at MockNodeClass and therefore skips that NodePool entirely. Only
+  # gpu-node-mocker watches this kind, marks it Ready, and materializes the
+  # fake NodeClaims — letting the mocker coexist with a real Karpenter install.
+  group: karpenter.kaito.sh
+  names:
+    categories:
+    - karpenter
+    kind: MockNodeClass
+    listKind: MockNodeClassList
+    plural: mocknodeclasses
+    shortNames:
+    - mocknc
+    - mockncs
+    singular: mocknodeclass
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: |-
+          MockNodeClass is a stand-in NodeClass that only gpu-node-mocker
+          recognizes. Its spec is intentionally schema-less (it accepts whatever
+          fields KAITO would set on a real AKSNodeClass, e.g. imageFamily /
+          osDiskSizeGB) because the mocker never reads spec — it only patches
+          status.conditions to Ready=True.
+        properties:
+          apiVersion:
+            description: |-
+              APIVersion defines the versioned schema of this representation of an object.
+              Servers should convert recognized schemas to the latest internal value, and
+              may reject unrecognized values.
+            type: string
+          kind:
+            description: |-
+              Kind is a string value representing the REST resource this object represents.
+              Cannot be updated. In CamelCase.
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: spec mirrors the provider NodeClass spec; fields are not
+              validated because the mocker never reads them.
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+          status:
+            description: status holds the Ready condition gpu-node-mocker patches.
+            properties:
+              conditions:
+                description: conditions describe the readiness of the NodeClass.
+                items:
+                  description: Condition is a standard Kubernetes status condition.
+                  properties:
+                    lastTransitionTime:
+                      type: string
+                    message:
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      type: integer
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+            type: object
+            x-kubernetes-preserve-unknown-fields: true
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/gpu-node-mocker/templates/clusterrole-auto-generated.yaml
+++ b/charts/gpu-node-mocker/templates/clusterrole-auto-generated.yaml
@@ -78,6 +78,22 @@ rules:
   - patch
   - update
 - apiGroups:
+  - karpenter.kaito.sh
+  resources:
+  - mocknodeclasses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - karpenter.kaito.sh
+  resources:
+  - mocknodeclasses/status
+  verbs:
+  - get
+  - patch
+  - update
+- apiGroups:
   - karpenter.sh
   resources:
   - nodeclaims

--- a/charts/gpu-node-mocker/templates/deployment.yaml
+++ b/charts/gpu-node-mocker/templates/deployment.yaml
@@ -30,6 +30,10 @@ spec:
             - --lease-duration-seconds={{ .Values.leaseDurationSeconds }}
             - --lease-renew-interval-seconds={{ .Values.leaseRenewIntervalSeconds }}
             - --node-provisioner={{ .Values.nodeProvisioner }}
+            - --node-class-group={{ .Values.nodeClass.group }}
+            - --node-class-version={{ .Values.nodeClass.version }}
+            - --node-class-kind={{ .Values.nodeClass.kind }}
+            - --node-class-resource={{ .Values.nodeClass.resource }}
           ports:
             - name: metrics
               containerPort: 8080

--- a/charts/gpu-node-mocker/values.yaml
+++ b/charts/gpu-node-mocker/values.yaml
@@ -12,6 +12,21 @@ shadowPod:
 # Must match KAITO's --node-provisioner value: azure-gpu-provisioner or karpenter.
 nodeProvisioner: karpenter
 
+# nodeClass selects the karpenter NodeClass kind the mocker reconciles (and
+# discovery-checks at startup) in karpenter mode. The default mock node class
+# lives in the karpenter.kaito.sh group, which a real Karpenter provider does
+# NOT recognize — so a KAITO NodePool referencing it is ignored by real
+# karpenter and handled only by gpu-node-mocker. Point KAITO's
+# karpenterProviders.<provider> group/kind/version/resourceName at the SAME
+# values so its NodePool nodeClassRef and the NodeClass objects it creates
+# match what the mocker watches. Set to the karpenter.azure.com AKSNodeClass
+# values to mock the real Azure node class instead.
+nodeClass:
+  group: karpenter.kaito.sh
+  version: v1alpha1
+  kind: MockNodeClass
+  resource: mocknodeclasses
+
 leaseDurationSeconds: 40
 leaseRenewIntervalSeconds: 10
 

--- a/cmd/gpu-node-mocker/main.go
+++ b/cmd/gpu-node-mocker/main.go
@@ -68,7 +68,13 @@ func main() {
 		leaseDurationSec      int
 		leaseRenewIntervalSec int
 		nodeProvisioner       string
+		nodeClassGroup        string
+		nodeClassVersion      string
+		nodeClassKind         string
+		nodeClassResource     string
 	)
+
+	defaultNodeClass := controllers.DefaultNodeClassRef()
 
 	flag.StringVar(&metricsAddr, "metrics-bind-address", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
@@ -83,6 +89,14 @@ func main() {
 	flag.StringVar(&nodeProvisioner, "node-provisioner", controllers.ProvisionerAzureGPU,
 		fmt.Sprintf("The KAITO node provisioner to mock (%q or %q).",
 			controllers.ProvisionerAzureGPU, controllers.ProvisionerKarpenter))
+	flag.StringVar(&nodeClassGroup, "node-class-group", defaultNodeClass.Group,
+		"API group of the karpenter NodeClass to reconcile in karpenter mode.")
+	flag.StringVar(&nodeClassVersion, "node-class-version", defaultNodeClass.Version,
+		"API version of the karpenter NodeClass to reconcile in karpenter mode.")
+	flag.StringVar(&nodeClassKind, "node-class-kind", defaultNodeClass.Kind,
+		"Kind of the karpenter NodeClass to reconcile in karpenter mode.")
+	flag.StringVar(&nodeClassResource, "node-class-resource", defaultNodeClass.Resource,
+		"Plural resource name of the karpenter NodeClass (used for the startup CRD discovery check).")
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
@@ -103,6 +117,12 @@ func main() {
 		UDSTokenizerImage:     udsTokenizerImage,
 		LeaseDurationSec:      int32(leaseDurationSec),
 		LeaseRenewIntervalSec: leaseRenewIntervalSec,
+		NodeClass: controllers.NodeClassRef{
+			Group:    nodeClassGroup,
+			Version:  nodeClassVersion,
+			Kind:     nodeClassKind,
+			Resource: nodeClassResource,
+		},
 	}
 
 	restCfg := ctrl.GetConfigOrDie()

--- a/hack/e2e/scripts/install-components.sh
+++ b/hack/e2e/scripts/install-components.sh
@@ -36,6 +36,37 @@ source "${SCRIPT_DIR}/lib-parallel.sh"
 NODE_PROVISIONER="${KAITO_NODE_PROVISIONER:-karpenter}"
 ENABLE_NODE_MOCKER="${ENABLE_NODE_MOCKER:-true}"
 
+# Karpenter NodeClass selection (karpenter mode only):
+#   KAITO_NODE_CLASS — mock (default) | azure.
+#     mock  → karpenter.kaito.sh/MockNodeClass, a kind ONLY gpu-node-mocker
+#             recognizes. A real Karpenter provider cannot resolve it and skips
+#             any NodePool referencing it, so the mocker can run alongside real
+#             karpenter. This is the default.
+#     azure → the real karpenter.azure.com/AKSNodeClass (use when mocking the
+#             real Azure node class end to end).
+# Both KAITO (its NodePool nodeClassRef + the NodeClass objects it creates) and
+# gpu-node-mocker (the NodeClass it watches / discovery-checks) are pointed at
+# the SAME GVK below so they agree on the node class.
+KAITO_NODE_CLASS="${KAITO_NODE_CLASS:-mock}"
+case "${KAITO_NODE_CLASS}" in
+  mock)
+    NODE_CLASS_GROUP="karpenter.kaito.sh"
+    NODE_CLASS_KIND="MockNodeClass"
+    NODE_CLASS_VERSION="v1alpha1"
+    NODE_CLASS_RESOURCE="mocknodeclasses"
+    ;;
+  azure)
+    NODE_CLASS_GROUP="karpenter.azure.com"
+    NODE_CLASS_KIND="AKSNodeClass"
+    NODE_CLASS_VERSION="v1beta1"
+    NODE_CLASS_RESOURCE="aksnodeclasses"
+    ;;
+  *)
+    echo "Invalid KAITO_NODE_CLASS='${KAITO_NODE_CLASS}'. Must be 'mock' or 'azure'." >&2
+    exit 1
+    ;;
+esac
+
 # Derive KEDA install namespace from provider:
 #   upstream → `keda` (Helm-installed KEDA)
 #   azure    → `kube-system` (AKS managed KEDA add-on). keda-kaito-scaler
@@ -57,6 +88,7 @@ echo "=== Component versions ==="
 echo "  E2E_PROVIDER:              ${E2E_PROVIDER}"
 echo "  NODE_PROVISIONER:          ${NODE_PROVISIONER}"
 echo "  ENABLE_NODE_MOCKER:        ${ENABLE_NODE_MOCKER}"
+echo "  KAITO_NODE_CLASS:          ${KAITO_NODE_CLASS} (${NODE_CLASS_GROUP}/${NODE_CLASS_VERSION} ${NODE_CLASS_KIND})"
 echo "  KEDA_NAMESPACE:            ${KEDA_NAMESPACE}"
 echo "  SHADOW_CONTROLLER_IMAGE:   ${SHADOW_CONTROLLER_IMAGE}"
 echo "  INSTALL_PARALLEL:          ${INSTALL_PARALLEL}"
@@ -72,46 +104,59 @@ if ! command -v helm &>/dev/null; then
 fi
 
 # ── KAITO chart resolution ────────────────────────────────────────────────
-# Sets KAITO_CHART_REF (and KAITO_CHART_TMPDIR when a clone is needed). The
-# karpenter provisioner needs the kaito main-branch chart because the published
-# chart does not yet expose `nodeProvisioner`; azure-gpu-provisioner uses the
-# published chart.
-resolve_kaito_chart() {
-  if [[ "${NODE_PROVISIONER}" == "karpenter" ]]; then
-    # The published Helm chart does not yet expose `nodeProvisioner` or template
-    # the corresponding `--node-provisioner` / Karpenter node-class args. Those
-    # chart changes are present on kaito main but not in the published chart repo
-    # yet, so install from the in-tree chart on main.
-    echo "  Karpenter mode: installing from kaito main branch chart (published chart lacks nodeProvisioner)"
-    KAITO_CHART_TMPDIR=$(mktemp -d)
-    git clone --depth 1 --quiet \
-      https://github.com/kaito-project/kaito.git "${KAITO_CHART_TMPDIR}"
-    KAITO_CHART_REF="${KAITO_CHART_TMPDIR}/charts/kaito/workspace"
-  else
-    helm repo add kaito https://kaito-project.github.io/kaito/charts/kaito 2>/dev/null || true
-    helm repo update kaito
-    KAITO_CHART_REF="kaito/workspace"
-  fi
-}
+# KAITO is always installed from the latest main-branch chart cloned from
+# https://github.com/kaito-project/kaito.git. The published Helm chart lags
+# main (e.g. `nodeProvisioner` / the Karpenter node-class args land on main
+# first), so cloning keeps install behavior consistent across provisioners.
 
 install_kaito() {
   echo "=== Installing KAITO workspace operator (image: nightly-latest) ==="
 
-  KAITO_CHART_REF=""
-  KAITO_CHART_TMPDIR=""
-  resolve_kaito_chart
-  if [[ -n "${KAITO_CHART_TMPDIR}" ]]; then
-    trap 'rm -rf "${KAITO_CHART_TMPDIR}"' RETURN
-  fi
+  echo "  Installing from kaito main branch chart (clone of kaito.git)"
+  KAITO_CHART_TMPDIR=$(mktemp -d)
+  trap 'rm -rf "${KAITO_CHART_TMPDIR}"' RETURN
+  git clone --depth 1 --quiet \
+    https://github.com/kaito-project/kaito.git "${KAITO_CHART_TMPDIR}"
+  KAITO_CHART_REF="${KAITO_CHART_TMPDIR}/charts/kaito/workspace"
 
   # Per-model GAIE artifacts are provisioned by charts/modeldeployment; enabling
   # the gate would render a duplicate set of resources via Flux and conflict.
+  #
+  # In karpenter mode, point KAITO's karpenter provider at the selected
+  # NodeClass GVK (default: the mock node class only gpu-node-mocker
+  # recognizes). KAITO renders the `kaito-nodeclasses` ConfigMap from
+  # karpenterProviders.azure.{group,kind,version,resourceName,nodeClasses} and
+  # creates one NodeClass CR per nodeClasses entry, then references the
+  # `default: true` one from every NodePool's nodeClassRef. So both the GVK and
+  # the nodeClasses list must match what the mocker watches.
+  KAITO_NODE_CLASS_ARGS=()
+  if [[ "${NODE_PROVISIONER}" == "karpenter" ]]; then
+    KAITO_NODE_CLASS_ARGS=(
+      --set karpenterProviders.azure.group="${NODE_CLASS_GROUP}"
+      --set karpenterProviders.azure.kind="${NODE_CLASS_KIND}"
+      --set karpenterProviders.azure.version="${NODE_CLASS_VERSION}"
+      --set karpenterProviders.azure.resourceName="${NODE_CLASS_RESOURCE}"
+    )
+    if [[ "${KAITO_NODE_CLASS}" == "mock" ]]; then
+      # Replace the chart-default Azure node classes (image-family-ubuntu /
+      # image-family-azure-linux, whose specs carry AKSNodeClass-only fields
+      # like imageFamily/osDiskSizeGB) with a single mock node class. KAITO
+      # creates one MockNodeClass CR named "mock-nodeclass" (default) that
+      # gpu-node-mocker marks Ready. The spec is empty because MockNodeClass is
+      # schema-less and neither KAITO nor the mocker reads it in mock mode.
+      KAITO_NODE_CLASS_ARGS+=(
+        --set-json 'karpenterProviders.azure.nodeClasses=[{"name":"mock-nodeclass","default":true,"spec":{}}]'
+      )
+    fi
+  fi
+
   helm upgrade --install kaito "${KAITO_CHART_REF}" \
     --namespace kaito-system \
     --create-namespace \
     --set featureGates.enableInferenceSetController=true \
     --set featureGates.gatewayAPIInferenceExtension=false \
     --set nodeProvisioner="${NODE_PROVISIONER}" \
+    "${KAITO_NODE_CLASS_ARGS[@]+"${KAITO_NODE_CLASS_ARGS[@]}"}" \
     --set image.repository=ghcr.io/kaito-project/kaito/workspace \
     --set image.tag=nightly-latest \
     --set image.pullPolicy=Always \
@@ -138,30 +183,31 @@ install_gwie_crds() {
 # instead: karpenter is installed via separate helm steps (CI / make targets)
 # and azure-gpu-provisioner is handled by KAITO itself — so there is nothing to
 # install in-cluster here.
-install_gpu_node_mocker() {
+install_node_provisioner() {
+  if [[ "${ENABLE_NODE_MOCKER}" != "true" ]]; then
+    echo "=== ENABLE_NODE_MOCKER=false: skipping gpu-node-mocker (using real ${NODE_PROVISIONER}) ==="
+    return
+  fi
+
   echo "=== Deploying gpu-node-mocker (GPU node mocker, --node-provisioner=${NODE_PROVISIONER}) ==="
   helm install gpu-node-mocker ./charts/gpu-node-mocker \
     --namespace kaito-system \
     --create-namespace \
     --set nodeProvisioner="${NODE_PROVISIONER}" \
+    --set nodeClass.group="${NODE_CLASS_GROUP}" \
+    --set nodeClass.version="${NODE_CLASS_VERSION}" \
+    --set nodeClass.kind="${NODE_CLASS_KIND}" \
+    --set nodeClass.resource="${NODE_CLASS_RESOURCE}" \
     --set image.repository="${SHADOW_CONTROLLER_IMAGE%:*}" \
     --set image.tag="${SHADOW_CONTROLLER_IMAGE##*:}"
 
   # In karpenter mode the mocker discovery-checks nodeclaims.karpenter.sh
-  # (shipped by KAITO) plus nodepools.karpenter.sh and aksnodeclasses.karpenter.
-  # azure.com (both shipped by this chart's crds/) at startup and exits if any
-  # is not served, so early restarts are expected while the KAITO-owned
-  # nodeclaims CRD comes online in parallel.
+  # (shipped by KAITO) plus nodepools.karpenter.sh and the selected NodeClass
+  # CRD (mocknodeclasses.karpenter.kaito.sh by default, both shipped by this
+  # chart's crds/) at startup and exits if any is not served, so early restarts
+  # are expected while the KAITO-owned nodeclaims CRD comes online in parallel.
   echo "⏳ Waiting for gpu-node-mocker (will tolerate restarts while karpenter CRDs come online)..."
   kubectl -n kaito-system rollout status deployment/gpu-node-mocker --timeout=420s || true
-}
-
-install_node_provisioner() {
-  if [[ "${ENABLE_NODE_MOCKER}" == "true" ]]; then
-    install_gpu_node_mocker
-    return
-  fi
-  echo "=== ENABLE_NODE_MOCKER=false: skipping gpu-node-mocker (using real ${NODE_PROVISIONER}) ==="
 }
 
 

--- a/hack/e2e/scripts/install-components.sh
+++ b/hack/e2e/scripts/install-components.sh
@@ -47,15 +47,20 @@ ENABLE_NODE_MOCKER="${ENABLE_NODE_MOCKER:-true}"
 # Both KAITO (its NodePool nodeClassRef + the NodeClass objects it creates) and
 # gpu-node-mocker (the NodeClass it watches / discovery-checks) are pointed at
 # the SAME GVK below so they agree on the node class.
+# KARPENTER_PROVIDER selects which key under the chart's `karpenterProviders`
+# map KAITO reads (`karpenterProvider`). The mock node class lives under its own
+# `mock` key so it never collides with the chart-default `azure` provider.
 KAITO_NODE_CLASS="${KAITO_NODE_CLASS:-mock}"
 case "${KAITO_NODE_CLASS}" in
   mock)
+    KARPENTER_PROVIDER="mock"
     NODE_CLASS_GROUP="karpenter.kaito.sh"
     NODE_CLASS_KIND="MockNodeClass"
     NODE_CLASS_VERSION="v1alpha1"
     NODE_CLASS_RESOURCE="mocknodeclasses"
     ;;
   azure)
+    KARPENTER_PROVIDER="azure"
     NODE_CLASS_GROUP="karpenter.azure.com"
     NODE_CLASS_KIND="AKSNodeClass"
     NODE_CLASS_VERSION="v1beta1"
@@ -122,30 +127,31 @@ install_kaito() {
   # Per-model GAIE artifacts are provisioned by charts/modeldeployment; enabling
   # the gate would render a duplicate set of resources via Flux and conflict.
   #
-  # In karpenter mode, point KAITO's karpenter provider at the selected
-  # NodeClass GVK (default: the mock node class only gpu-node-mocker
-  # recognizes). KAITO renders the `kaito-nodeclasses` ConfigMap from
-  # karpenterProviders.azure.{group,kind,version,resourceName,nodeClasses} and
-  # creates one NodeClass CR per nodeClasses entry, then references the
-  # `default: true` one from every NodePool's nodeClassRef. So both the GVK and
-  # the nodeClasses list must match what the mocker watches.
+  # In karpenter mode, select the karpenter provider via `karpenterProvider`
+  # first, then populate that provider's entry under `karpenterProviders`. The
+  # chart looks up `index .Values.karpenterProviders .Values.karpenterProvider`,
+  # so `karpenterProvider=${KARPENTER_PROVIDER}` plus
+  # karpenterProviders.${KARPENTER_PROVIDER}.{group,kind,version,resourceName,nodeClasses}
+  # drive both the controller's --karpenter-node-class-* args and the
+  # `kaito-nodeclasses` ConfigMap (one NodeClass CR per nodeClasses entry,
+  # NodePool nodeClassRef -> the `default: true` one). So the GVK and the
+  # nodeClasses list must match what the mocker watches.
   KAITO_NODE_CLASS_ARGS=()
   if [[ "${NODE_PROVISIONER}" == "karpenter" ]]; then
     KAITO_NODE_CLASS_ARGS=(
-      --set karpenterProviders.azure.group="${NODE_CLASS_GROUP}"
-      --set karpenterProviders.azure.kind="${NODE_CLASS_KIND}"
-      --set karpenterProviders.azure.version="${NODE_CLASS_VERSION}"
-      --set karpenterProviders.azure.resourceName="${NODE_CLASS_RESOURCE}"
+      --set "karpenterProvider=${KARPENTER_PROVIDER}"
+      --set "karpenterProviders.${KARPENTER_PROVIDER}.group=${NODE_CLASS_GROUP}"
+      --set "karpenterProviders.${KARPENTER_PROVIDER}.kind=${NODE_CLASS_KIND}"
+      --set "karpenterProviders.${KARPENTER_PROVIDER}.version=${NODE_CLASS_VERSION}"
+      --set "karpenterProviders.${KARPENTER_PROVIDER}.resourceName=${NODE_CLASS_RESOURCE}"
     )
     if [[ "${KAITO_NODE_CLASS}" == "mock" ]]; then
-      # Replace the chart-default Azure node classes (image-family-ubuntu /
-      # image-family-azure-linux, whose specs carry AKSNodeClass-only fields
-      # like imageFamily/osDiskSizeGB) with a single mock node class. KAITO
+      # Define a single mock node class under the `mock` provider key. KAITO
       # creates one MockNodeClass CR named "mock-nodeclass" (default) that
       # gpu-node-mocker marks Ready. The spec is empty because MockNodeClass is
       # schema-less and neither KAITO nor the mocker reads it in mock mode.
       KAITO_NODE_CLASS_ARGS+=(
-        --set-json 'karpenterProviders.azure.nodeClasses=[{"name":"mock-nodeclass","default":true,"spec":{}}]'
+        --set-json "karpenterProviders.${KARPENTER_PROVIDER}.nodeClasses=[{\"name\":\"mock-nodeclass\",\"default\":true,\"spec\":{}}]"
       )
     fi
   fi

--- a/pkg/gpu-node-mocker/controllers/config.go
+++ b/pkg/gpu-node-mocker/controllers/config.go
@@ -36,6 +36,8 @@ limitations under the License.
 //	  real shadow pod and the LLM Mocker.
 package controllers
 
+import "k8s.io/apimachinery/pkg/runtime/schema"
+
 const (
 	// LabelFakeNode is set on every Node created by Phase 1 so Phase 2 can
 	// cheaply filter pods assigned to fake nodes without re-fetching nodes.
@@ -113,7 +115,53 @@ const (
 	// stamps on the NodePool it creates in karpenter mode.
 	KarpenterManagedByLabel = "karpenter.kaito.sh/managed-by"
 	KarpenterManagedByValue = "kaito"
+
+	// MockNodeClass* identify the gpu-node-mocker's own karpenter NodeClass
+	// kind. It lives in the karpenter.kaito.sh group — NOT karpenter.azure.com —
+	// so a real Azure Karpenter provider (which only understands
+	// karpenter.azure.com AKSNodeClass) does not recognize it and therefore
+	// skips any KAITO NodePool whose nodeClassRef points at it. That lets the
+	// mocker run alongside a real karpenter install: the mocker reconciles the
+	// MockNodeClass (marks it Ready, materializes fake NodeClaims) while real
+	// karpenter ignores the same NodePool. It is the default NodeClass the
+	// mocker watches.
+	MockNodeClassGroup    = "karpenter.kaito.sh"
+	MockNodeClassVersion  = "v1alpha1"
+	MockNodeClassKind     = "MockNodeClass"
+	MockNodeClassResource = "mocknodeclasses"
 )
+
+// NodeClassRef identifies the cluster-scoped karpenter NodeClass resource that
+// KAITO's NodePool template references and that the NodeClassReconciler marks
+// Ready in karpenter mode. It is configurable so the mocker can target either
+// its own mock node class (karpenter.kaito.sh/MockNodeClass — the default) or
+// the real karpenter.azure.com AKSNodeClass.
+type NodeClassRef struct {
+	Group    string
+	Version  string
+	Kind     string
+	Resource string
+}
+
+// DefaultNodeClassRef returns the gpu-node-mocker mock node class, the kind a
+// real karpenter provider does not recognize.
+func DefaultNodeClassRef() NodeClassRef {
+	return NodeClassRef{
+		Group:    MockNodeClassGroup,
+		Version:  MockNodeClassVersion,
+		Kind:     MockNodeClassKind,
+		Resource: MockNodeClassResource,
+	}
+}
+
+// GroupVersion returns the discovery group/version string, e.g.
+// "karpenter.kaito.sh/v1alpha1".
+func (n NodeClassRef) GroupVersion() string { return n.Group + "/" + n.Version }
+
+// GVK returns the GroupVersionKind for the NodeClass.
+func (n NodeClassRef) GVK() schema.GroupVersionKind {
+	return schema.GroupVersionKind{Group: n.Group, Version: n.Version, Kind: n.Kind}
+}
 
 // Config holds operator-wide settings injected via CLI flags.
 type Config struct {
@@ -130,4 +178,8 @@ type Config struct {
 	// LeaseRenewIntervalSec controls how often the background goroutine
 	// refreshes each lease's renewTime.
 	LeaseRenewIntervalSec int
+
+	// NodeClass is the karpenter NodeClass GVK the mocker reconciles (and
+	// discovery-checks) in karpenter mode. Defaults to the mock node class.
+	NodeClass NodeClassRef
 }

--- a/pkg/gpu-node-mocker/controllers/node_claim_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/node_claim_controller_test.go
@@ -54,6 +54,7 @@ func testConfig() Config {
 		UDSTokenizerImage:     DefaultUDSTokenizerImage,
 		LeaseDurationSec:      40,
 		LeaseRenewIntervalSec: 10,
+		NodeClass:             DefaultNodeClassRef(),
 	}
 }
 

--- a/pkg/gpu-node-mocker/controllers/nodeclass_controller.go
+++ b/pkg/gpu-node-mocker/controllers/nodeclass_controller.go
@@ -24,76 +24,63 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-const (
-	// AKSNodeClassGroup / AKSNodeClassVersion / AKSNodeClassKind identify the
-	// Azure karpenter provider's NodeClass resource. In karpenter mode KAITO's
-	// NodePool template references an AKSNodeClass by name and, before it will
-	// provision nodes, polls that NodeClass for a Ready=True status condition.
-	AKSNodeClassGroup   = "karpenter.azure.com"
-	AKSNodeClassVersion = "v1beta1"
-	AKSNodeClassKind    = "AKSNodeClass"
+// NodeClassReadyCondition is the rollup condition type KAITO waits on. In a
+// real cluster the karpenter provider sets it once it has resolved images,
+// subnets and the Kubernetes version; in the mock environment no provider
+// runs, so this reconciler sets it instead.
+const NodeClassReadyCondition = "Ready"
 
-	// AKSNodeClassReadyCondition is the rollup condition type KAITO waits on.
-	// In a real cluster the Azure karpenter provider sets it once it has
-	// resolved images, subnets and the Kubernetes version; in the mock
-	// environment no provider runs, so this reconciler sets it instead.
-	AKSNodeClassReadyCondition = "Ready"
-)
-
-// AKSNodeClassReconciler mocks the Azure karpenter provider's NodeClass
-// readiness. KAITO creates one or more AKSNodeClass objects on startup (e.g.
+// NodeClassReconciler mocks the karpenter provider's NodeClass readiness. In
+// karpenter mode KAITO creates one or more NodeClass objects on startup (e.g.
 // "image-family-ubuntu") and blocks ProvisionNodes() until the default class
 // reports Ready=True. Since no real provider runs in the mock environment, this
-// reconciler watches AKSNodeClass objects and patches their status to Ready so
+// reconciler watches NodeClass objects and patches their status to Ready so
 // KAITO proceeds to create the NodePool that NodePoolReconciler then mocks.
 //
-// AKSNodeClass is handled as an unstructured object so the mocker does not have
-// to vendor the karpenter-provider-azure API types; the CRD is shipped by this
-// chart and the only field this reconciler touches is status.conditions.
-type AKSNodeClassReconciler struct {
+// The NodeClass GVK is taken from Config.NodeClass so the mocker can target its
+// own mock node class (karpenter.kaito.sh/MockNodeClass — a kind only the
+// mocker recognizes, so a real karpenter provider skips any NodePool that
+// references it) or, when configured to, the real karpenter.azure.com
+// AKSNodeClass. The object is handled as unstructured so the mocker does not
+// have to vendor any provider API types; the only field this reconciler
+// touches is status.conditions.
+type NodeClassReconciler struct {
 	client.Client
 	Config Config
 }
 
-func aksNodeClassGVK() schema.GroupVersionKind {
-	return schema.GroupVersionKind{
-		Group:   AKSNodeClassGroup,
-		Version: AKSNodeClassVersion,
-		Kind:    AKSNodeClassKind,
-	}
-}
-
-// SetupWithManager registers the controller. It watches every AKSNodeClass;
-// there is no managed-by filter because KAITO owns the only AKSNodeClass
-// objects in the mock cluster and they all need to be marked Ready.
-func (r *AKSNodeClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
+// SetupWithManager registers the controller. It watches every NodeClass of the
+// configured GVK; there is no managed-by filter because KAITO owns the only
+// NodeClass objects in the mock cluster and they all need to be marked Ready.
+func (r *NodeClassReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	nc := &unstructured.Unstructured{}
-	nc.SetGroupVersionKind(aksNodeClassGVK())
+	nc.SetGroupVersionKind(r.Config.NodeClass.GVK())
 	return ctrl.NewControllerManagedBy(mgr).
 		For(nc).
-		Named("aksnodeclass").
+		Named("nodeclass").
 		Complete(r)
 }
 
+// +kubebuilder:rbac:groups=karpenter.kaito.sh,resources=mocknodeclasses,verbs=get;list;watch
+// +kubebuilder:rbac:groups=karpenter.kaito.sh,resources=mocknodeclasses/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=karpenter.azure.com,resources=aksnodeclasses,verbs=get;list;watch
 // +kubebuilder:rbac:groups=karpenter.azure.com,resources=aksnodeclasses/status,verbs=get;update;patch
 
-func (r *AKSNodeClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	log := log.FromContext(ctx).WithValues("aksnodeclass", req.Name)
+func (r *NodeClassReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx).WithValues("nodeclass", req.Name)
 
 	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(aksNodeClassGVK())
+	obj.SetGroupVersionKind(r.Config.NodeClass.GVK())
 	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		if errors.IsNotFound(err) {
 			return ctrl.Result{}, nil
 		}
-		return ctrl.Result{}, fmt.Errorf("get AKSNodeClass: %w", err)
+		return ctrl.Result{}, fmt.Errorf("get NodeClass: %w", err)
 	}
 
 	// Nothing to do for objects on their way out.
@@ -102,25 +89,25 @@ func (r *AKSNodeClassReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	}
 
 	// Already Ready for the current generation — avoid a no-op status write.
-	if aksNodeClassReady(obj) {
+	if nodeClassReady(obj) {
 		return ctrl.Result{}, nil
 	}
 
 	if err := r.markReady(ctx, obj); err != nil {
 		return ctrl.Result{}, err
 	}
-	log.Info("patched AKSNodeClass status to Ready=True")
+	log.Info("patched NodeClass status to Ready=True")
 	return ctrl.Result{}, nil
 }
 
-// markReady patches the AKSNodeClass status subresource so it carries a single
+// markReady patches the NodeClass status subresource so it carries a single
 // Ready=True condition, which is all KAITO's checkNodeClassReady inspects.
-func (r *AKSNodeClassReconciler) markReady(ctx context.Context, obj *unstructured.Unstructured) error {
+func (r *NodeClassReconciler) markReady(ctx context.Context, obj *unstructured.Unstructured) error {
 	cond := map[string]interface{}{
-		"type":               AKSNodeClassReadyCondition,
+		"type":               NodeClassReadyCondition,
 		"status":             "True",
 		"reason":             "Mocked",
-		"message":            "AKSNodeClass marked Ready by gpu-node-mocker",
+		"message":            "NodeClass marked Ready by gpu-node-mocker",
 		"lastTransitionTime": metav1.Now().Format(time.RFC3339),
 		"observedGeneration": obj.GetGeneration(),
 	}
@@ -130,14 +117,14 @@ func (r *AKSNodeClassReconciler) markReady(ctx context.Context, obj *unstructure
 		return fmt.Errorf("set status.conditions: %w", err)
 	}
 	if err := r.Status().Patch(ctx, patched, client.MergeFrom(obj)); err != nil {
-		return fmt.Errorf("patch AKSNodeClass status: %w", err)
+		return fmt.Errorf("patch NodeClass status: %w", err)
 	}
 	return nil
 }
 
-// aksNodeClassReady reports whether the object already has a Ready=True
-// status condition.
-func aksNodeClassReady(obj *unstructured.Unstructured) bool {
+// nodeClassReady reports whether the object already has a Ready=True status
+// condition.
+func nodeClassReady(obj *unstructured.Unstructured) bool {
 	conds, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
 	if err != nil || !found {
 		return false
@@ -147,7 +134,7 @@ func aksNodeClassReady(obj *unstructured.Unstructured) bool {
 		if !ok {
 			continue
 		}
-		if m["type"] == AKSNodeClassReadyCondition && m["status"] == "True" {
+		if m["type"] == NodeClassReadyCondition && m["status"] == "True" {
 			return true
 		}
 	}

--- a/pkg/gpu-node-mocker/controllers/nodeclass_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/nodeclass_controller_test.go
@@ -24,65 +24,66 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
-// aksScheme extends the shared test scheme with the unstructured AKSNodeClass
-// GVK so the fake client can serve get/list/patch for it.
-func aksScheme() *runtime.Scheme {
+// nodeClassScheme extends the shared test scheme with the unstructured mock
+// NodeClass GVK so the fake client can serve get/list/patch for it.
+func nodeClassScheme() *runtime.Scheme {
 	s := testScheme()
-	s.AddKnownTypeWithName(aksNodeClassGVK(), &unstructured.Unstructured{})
-	listGVK := aksNodeClassGVK()
+	gvk := DefaultNodeClassRef().GVK()
+	s.AddKnownTypeWithName(gvk, &unstructured.Unstructured{})
+	listGVK := gvk
 	listGVK.Kind += "List"
 	s.AddKnownTypeWithName(listGVK, &unstructured.UnstructuredList{})
 	return s
 }
 
-func newAKSNodeClass(name string) *unstructured.Unstructured {
+func newNodeClass(name string) *unstructured.Unstructured {
 	obj := &unstructured.Unstructured{}
-	obj.SetGroupVersionKind(aksNodeClassGVK())
+	obj.SetGroupVersionKind(DefaultNodeClassRef().GVK())
 	obj.SetName(name)
 	return obj
 }
 
-func getAKSNodeClass(t *testing.T, r *AKSNodeClassReconciler, name string) *unstructured.Unstructured {
+func getNodeClass(t *testing.T, r *NodeClassReconciler, name string) *unstructured.Unstructured {
 	t.Helper()
 	got := &unstructured.Unstructured{}
-	got.SetGroupVersionKind(aksNodeClassGVK())
+	got.SetGroupVersionKind(DefaultNodeClassRef().GVK())
 	if err := r.Get(context.Background(), types.NamespacedName{Name: name}, got); err != nil {
-		t.Fatalf("get AKSNodeClass %q: %v", name, err)
+		t.Fatalf("get NodeClass %q: %v", name, err)
 	}
 	return got
 }
 
-func reconcileAKSNodeClass(t *testing.T, r *AKSNodeClassReconciler, name string) {
+func reconcileNodeClass(t *testing.T, r *NodeClassReconciler, name string) {
 	t.Helper()
 	if _, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: name}}); err != nil {
-		t.Fatalf("reconcile AKSNodeClass %q: %v", name, err)
+		t.Fatalf("reconcile NodeClass %q: %v", name, err)
 	}
 }
 
-func TestAKSNodeClassReconciler_MarksReady(t *testing.T) {
-	scheme := aksScheme()
-	nc := newAKSNodeClass("image-family-ubuntu")
+func TestNodeClassReconciler_MarksReady(t *testing.T) {
+	scheme := nodeClassScheme()
+	nc := newNodeClass("image-family-ubuntu")
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nc).WithStatusSubresource(nc).Build()
-	r := &AKSNodeClassReconciler{Client: cl, Config: testConfig()}
+	r := &NodeClassReconciler{Client: cl, Config: testConfig()}
 
-	reconcileAKSNodeClass(t, r, "image-family-ubuntu")
+	reconcileNodeClass(t, r, "image-family-ubuntu")
 
-	got := getAKSNodeClass(t, r, "image-family-ubuntu")
-	if !aksNodeClassReady(got) {
-		t.Fatalf("expected AKSNodeClass to be Ready=True, got conditions: %v", got.Object["status"])
+	got := getNodeClass(t, r, "image-family-ubuntu")
+	if !nodeClassReady(got) {
+		t.Fatalf("expected NodeClass to be Ready=True, got conditions: %v", got.Object["status"])
 	}
 }
 
-func TestAKSNodeClassReconciler_Idempotent(t *testing.T) {
-	scheme := aksScheme()
-	nc := newAKSNodeClass("image-family-ubuntu")
+func TestNodeClassReconciler_Idempotent(t *testing.T) {
+	scheme := nodeClassScheme()
+	nc := newNodeClass("image-family-ubuntu")
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nc).WithStatusSubresource(nc).Build()
-	r := &AKSNodeClassReconciler{Client: cl, Config: testConfig()}
+	r := &NodeClassReconciler{Client: cl, Config: testConfig()}
 
-	reconcileAKSNodeClass(t, r, "image-family-ubuntu")
-	reconcileAKSNodeClass(t, r, "image-family-ubuntu")
+	reconcileNodeClass(t, r, "image-family-ubuntu")
+	reconcileNodeClass(t, r, "image-family-ubuntu")
 
-	got := getAKSNodeClass(t, r, "image-family-ubuntu")
+	got := getNodeClass(t, r, "image-family-ubuntu")
 	conds, found, err := unstructured.NestedSlice(got.Object, "status", "conditions")
 	if err != nil || !found {
 		t.Fatalf("expected status.conditions, found=%v err=%v", found, err)
@@ -92,11 +93,11 @@ func TestAKSNodeClassReconciler_Idempotent(t *testing.T) {
 	}
 }
 
-func TestAKSNodeClassReconciler_NotFound(t *testing.T) {
-	scheme := aksScheme()
+func TestNodeClassReconciler_NotFound(t *testing.T) {
+	scheme := nodeClassScheme()
 	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
-	r := &AKSNodeClassReconciler{Client: cl, Config: testConfig()}
+	r := &NodeClassReconciler{Client: cl, Config: testConfig()}
 
 	// Reconciling a non-existent object must be a no-op, not an error.
-	reconcileAKSNodeClass(t, r, "does-not-exist")
+	reconcileNodeClass(t, r, "does-not-exist")
 }

--- a/pkg/gpu-node-mocker/controllers/provisioner.go
+++ b/pkg/gpu-node-mocker/controllers/provisioner.go
@@ -108,7 +108,7 @@ func (m *GPUProvisionerMocker) SetupWithManager(mgr ctrl.Manager) error {
 // NodeClaims from it. Since no real karpenter engine runs in the mock
 // environment, three reconcilers stand in for it:
 //
-//   - AKSNodeClassReconciler marks the AKSNodeClass KAITO references Ready, so
+//   - NodeClassReconciler marks the NodeClass KAITO references Ready, so
 //     KAITO stops blocking and creates the NodePool.
 //   - NodePoolReconciler materializes Spec.Replicas NodeClaims from the pool.
 //   - the shared NodeClaimReconciler turns each NodeClaim into a fake Node.
@@ -120,26 +120,26 @@ func (m *KarpenterMocker) Type() string { return ProvisionerKarpenter }
 
 func (m *KarpenterMocker) RequiredCRDs() []RequiredCRD {
 	return []RequiredCRD{
-		// nodeclaims is shipped by KAITO; nodepools and aksnodeclasses are
+		// nodeclaims is shipped by KAITO; nodepools and the NodeClass CRD are
 		// shipped by this chart's crds/ directory (upstream KAITO installs only
 		// nodeclaims, and no real karpenter provider runs in the mock to install
-		// NodePool/AKSNodeClass). KAITO references the AKSNodeClass from the
-		// NodePool template and blocks until it is Ready.
+		// NodePool/NodeClass). KAITO references the NodeClass from the NodePool
+		// template and blocks until it is Ready.
 		{GroupVersion: "karpenter.sh/v1", Resource: "nodeclaims"},
 		{GroupVersion: "karpenter.sh/v1", Resource: "nodepools"},
-		{GroupVersion: AKSNodeClassGroup + "/" + AKSNodeClassVersion, Resource: "aksnodeclasses"},
+		{GroupVersion: m.Config.NodeClass.GroupVersion(), Resource: m.Config.NodeClass.Resource},
 	}
 }
 
 func (m *KarpenterMocker) SetupWithManager(mgr ctrl.Manager) error {
-	// Phase 1-pre: AKSNodeClass -> Ready (mimics the Azure karpenter provider).
-	// KAITO blocks node provisioning until the referenced AKSNodeClass is Ready,
-	// so this must run for the NodePool to ever be created.
-	if err := (&AKSNodeClassReconciler{
+	// Phase 1-pre: NodeClass -> Ready (mimics the karpenter provider). KAITO
+	// blocks node provisioning until the referenced NodeClass is Ready, so this
+	// must run for the NodePool to ever be created.
+	if err := (&NodeClassReconciler{
 		Client: mgr.GetClient(),
 		Config: m.Config,
 	}).SetupWithManager(mgr); err != nil {
-		return fmt.Errorf("unable to create AKSNodeClass controller: %w", err)
+		return fmt.Errorf("unable to create NodeClass controller: %w", err)
 	}
 	// Phase 1a: NodePool -> NodeClaim materialization (mimics karpenter engine).
 	if err := (&NodePoolReconciler{


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

Add a karpenter.kaito.sh/MockNodeClass kind that only gpu-node-mocker recognizes, so it can run alongside a real Azure Karpenter provider (which skips NodePools referencing the unknown kind). Make the watched NodeClass GVK configurable via CLI flags and Helm values, and wire a KAITO_NODE_CLASS (mock|azure) parameter through the e2e scripts and GitHub Actions workflows.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
