### PR TITLE
feat: add multi-modelharness deployment example and loadgen script

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -17,9 +17,10 @@ name: ModelDeployment benchmark
 #      complete request path Gateway → BBR → EPP → vLLM (mock) pod can be
 #      exercised from localhost. The endpoint URL and API key are echoed
 #      to the workflow log.
-#   5. Installs guidellm and runs a sweep benchmark against the endpoint,
-#      printing TTFT / TPOT / TPM (and the rest of the guidellm console
-#      summary) into the workflow log.
+#   5. Runs `hack/loadgen.sh` with its `guidellm` engine against the
+#      endpoint (loadgen auto-discovers the gateway/model/API key and
+#      manages its own port-forward), printing TTFT / TPOT / TPM (and the
+#      rest of the guidellm console summary) into the workflow log.
 #
 # All component versions and benchmark parameters are hard-coded in the
 # `env:` block below — there are no workflow_dispatch inputs. To change a
@@ -327,9 +328,10 @@ jobs:
 
       - name: Run benchmark test for inference workload
         env:
-          ENDPOINT: ${{ steps.endpoint.outputs.endpoint }}
-          API_KEY:  ${{ steps.endpoint.outputs.api_key }}
-          MODEL:    ${{ env.DEPLOYMENT_NAME }}
+          MODEL: ${{ env.DEPLOYMENT_NAME }}
+          # Redirect loadgen.sh's guidellm engine output (JSON + CSV) into
+          # ./benchmark-results so the "Collect metrics" step can pick it up.
+          OUT_DIR: ${{ github.workspace }}/benchmark-results
         run: |
           set -euo pipefail
 
@@ -337,49 +339,42 @@ jobs:
           python -m pip install --upgrade pip
           # Mirrors the version pattern used by KAITO's vLLM benchmark
           # entrypoint (https://github.com/kaito-project/kaito/blob/main/presets/workspace/inference/vllm/benchmark_entrypoint.py).
+          # Pre-installing it onto PATH lets hack/loadgen.sh reuse this binary
+          # instead of provisioning its own venv.
           pip install 'guidellm[recommended]'
           guidellm --version
 
-          # ---------- 2. Run guidellm benchmark ----------
-          mkdir -p ./benchmark-results
-          echo "── Running guidellm against ${ENDPOINT} (model=${MODEL}) ──"
+          # ---------- 2. Run the benchmark via hack/loadgen.sh ----------
+          mkdir -p "${OUT_DIR}"
+          echo "── Running hack/loadgen.sh (guidellm engine) against ${MODEL} in ${WORKLOAD_NAMESPACE} ──"
           echo "    profile=${BENCHMARK_PROFILE}  rate=${BENCHMARK_RATE}  max-seconds=${BENCHMARK_MAX_SECONDS}  data=${BENCHMARK_DATA}"
           echo "    processor=${BENCHMARK_PROCESSOR}"
           echo ""
 
-          # `--backend-kwargs` carries the OpenAI bearer token used by the
-          # llm-gateway-apikey AuthorizationPolicy guarding the
-          # `inference-gateway`. The console output below contains the
-          # TTFT, TPOT (per-output-token latency) and request/token
-          # throughput tables that satisfy the "TTFT / TPOT / TPM" report
-          # required by the workflow spec.
-          #
-          # `validate_backend: false` disables guidellm's startup probe
-          # (a `GET /health` against the target). The modeldeployment
-          # HTTPRoute only matches requests carrying the
-          # `X-Gateway-Model-Name` header and routes by model name via
-          # the EPP, so `/health` is not exposed at the gateway and the
-          # probe returns 404. The previous "Wait for Inference
-          # WorkloadEndpoint and API Key" step already smoke-tested the
-          # full path with a real `/v1/chat/completions` request, so
-          # skipping guidellm's redundant validation is safe.
-          guidellm benchmark run \
-            --target "${ENDPOINT}" \
+          # loadgen.sh auto-discovers the per-namespace Gateway, the model,
+          # and (since auth.enabled=true) the bearer token from the
+          # `llm-api-key` Secret. It starts (and tears down) its own
+          # kubectl port-forward to the Gateway Service and then delegates to
+          # the guidellm benchmark CLI — the same tool, and the same
+          # `verify:false` / `validate_backend:false` backend kwargs, this
+          # workflow used to invoke directly. The console output contains the
+          # TTFT / TPOT / throughput tables; --out-dir writes the JSON + CSV
+          # result files into ./benchmark-results for the next step.
+          hack/loadgen.sh \
+            --namespace "${WORKLOAD_NAMESPACE}" \
             --model "${MODEL}" \
+            --gateway "${GATEWAY_NAME}" \
+            --engine guidellm \
             --processor "${BENCHMARK_PROCESSOR}" \
-            --backend-kwargs "{\"api_key\":\"${API_KEY}\",\"verify\":false,\"validate_backend\":false}" \
             --profile "${BENCHMARK_PROFILE}" \
             --rate "${BENCHMARK_RATE}" \
             --max-seconds "${BENCHMARK_MAX_SECONDS}" \
             --data "${BENCHMARK_DATA}" \
-            --output-dir ./benchmark-results \
-            --outputs json \
-            --outputs csv \
-            --disable-console-interactive
+            --out-dir "${OUT_DIR}"
 
           echo ""
           echo "── benchmark-results contents ──"
-          ls -al ./benchmark-results || true
+          ls -al "${OUT_DIR}" || true
 
       - name: Collect metrics for inference workload
         if: always()

--- a/examples/multi-modelharness-deployment.md
+++ b/examples/multi-modelharness-deployment.md
@@ -1,0 +1,418 @@
+# Multi-tenant inference on production-stack: cluster bring-up + multiple ModelHarness / ModelDeployment
+
+This demo walks through a complete, reproducible deployment of the
+production-stack on a fresh **AKS** cluster and then layers a realistic
+multi-tenant workload on top of it:
+
+1. **Cluster bring-up** — use the scripts under [`hack/e2e/scripts`](../hack/e2e/scripts)
+   to create an AKS cluster and install every cluster-scoped component
+   (Istio, KEDA, Gateway API + GAIE CRDs, KAITO, BBR, the API-key auth
+   control plane, and the `gpu-node-mocker`).
+2. **Workload provisioning** — install **two** `modelharness` releases (one
+   per workload namespace), each hosting **two** `modeldeployment` releases,
+   with **at least one** deployment running **multiple replicas**.
+3. **Traffic generation** — drive OpenAI-style chat-completion traffic at a
+   configurable QPS with [`hack/loadgen.sh`](../hack/loadgen.sh)
+   (built-in `curl` engine or `guidellm`).
+
+> The cluster uses the [`gpu-node-mocker`](../pkg/gpu-node-mocker) so the
+> inference pods come up on **mocked GPU nodes** — no real GPU quota is
+> required to exercise the full Gateway → BBR → EPP → vLLM(mock) request
+> path end to end.
+
+---
+
+## Prerequisites
+
+| Tool | Used for |
+| --- | --- |
+| `az` (logged in: `az login`) | create the AKS cluster / ACR |
+| `docker` (daemon running) | build & push the `gpu-node-mocker` image |
+| `kubectl` | talk to the cluster |
+| `helm` (v3+) | install the charts |
+| `python3`, `jq` | helper utilities used by the scripts |
+| `guidellm` *(optional)* | only for `--engine guidellm`; auto-installed via `pip` on demand |
+
+All component versions (Istio, KEDA, Gateway API, AKS K8s version) are pinned
+in [`versions.env`](../versions.env) and sourced automatically by the
+`run-e2e-local.sh` wrapper used below.
+
+---
+
+## Topology produced by this demo
+
+Each request follows the same path: the client hits the per-namespace Istio
+`Gateway`, whose HTTP filter chain runs **ext_authz** (API-key check against the
+cluster-wide `apikey-authz`) → **BBR** ext_proc (reads the body, injects
+`X-Gateway-Model-Name`) → the **EPP** ext_proc. The `HTTPRoute` matches on
+`X-Gateway-Model-Name` to pick the model's `InferencePool`, the EPP ext_proc
+selects one of that pool's replicas, and the Gateway then forwards the prompt to
+the chosen `vLLM(mock)` pod. KAITO, the KEDA scaler and the `gpu-node-mocker`
+provision and autoscale the pods off the request path.
+
+```mermaid
+flowchart TB
+  client(["Client<br/>loadgen.sh / guidellm"])
+
+  subgraph filt["Gateway filter services (cluster-scoped, shared)"]
+    direction LR
+    authz["apikey-authz<br/>(ext_authz)"]
+    bbr["Body-Based Router<br/>(ext_proc)"]
+  end
+
+  subgraph ctrl["Control plane (off request path)"]
+    direction LR
+    kaito["KAITO operator"]
+    keda["keda-kaito-scaler"]
+    mocker["gpu-node-mocker"]
+  end
+
+  subgraph nsa["namespace: demo-team-a (auth ON)"]
+    direction TB
+    gwa["Gateway demo-team-a-gw<br/>chain: ext_authz → BBR → EPP"]
+    subgraph a1["chat-phi"]
+      eppa1["EPP (ext_proc)"]
+      pa1["vLLM(mock) ×2"]
+      eppa1 -. selects .-> pa1
+    end
+    subgraph a2["code-ministral"]
+      eppa2["EPP (ext_proc)"]
+      pa2["vLLM(mock) ×1"]
+      eppa2 -. selects .-> pa2
+    end
+    gwa -. ext_proc .-> eppa1
+    gwa -. ext_proc .-> eppa2
+    gwa -->|"model=chat-phi"| pa1
+    gwa -->|"model=code-ministral"| pa2
+  end
+
+  subgraph nsb["namespace: demo-team-b (auth ON)"]
+    direction TB
+    gwb["Gateway demo-team-b-gw<br/>chain: ext_authz → BBR → EPP"]
+    subgraph b1["assistant-phi"]
+      eppb1["EPP (ext_proc)"]
+      pb1["vLLM(mock) ×2"]
+      eppb1 -. selects .-> pb1
+    end
+    subgraph b2["summarizer-ministral"]
+      eppb2["EPP (ext_proc)"]
+      pb2["vLLM(mock) ×1"]
+      eppb2 -. selects .-> pb2
+    end
+    gwb -. ext_proc .-> eppb1
+    gwb -. ext_proc .-> eppb2
+    gwb -->|"model=assistant-phi"| pb1
+    gwb -->|"model=summarizer-ministral"| pb2
+  end
+
+  client --> gwa
+  client --> gwb
+  gwa -. ext_authz .-> authz
+  gwa -. ext_proc .-> bbr
+  gwb -. ext_authz .-> authz
+  gwb -. ext_proc .-> bbr
+  ctrl -. provision &amp; autoscale .-> nsa
+  ctrl -. provision &amp; autoscale .-> nsb
+
+  classDef gw fill:#e3f2fd,stroke:#1976d2,color:#0d47a1;
+  classDef epp fill:#f3e5f5,stroke:#7b1fa2,color:#4a148c;
+  classDef pod fill:#e8f5e9,stroke:#388e3c,color:#1b5e20;
+  classDef svc fill:#fff3e0,stroke:#f57c00,color:#e65100;
+  class gwa,gwb gw;
+  class eppa1,eppa2,eppb1,eppb2 epp;
+  class pa1,pa2,pb1,pb2 pod;
+  class authz,bbr,kaito,keda,mocker svc;
+```
+
+| Namespace | ModelHarness | ModelDeployment | Preset | Replicas (min) | Autoscaling (max / threshold) |
+| --- | --- | --- | --- | --- | --- |
+| `demo-team-a` | auth **on** | `chat-phi` | `phi-4-mini-instruct` | **2** | 4 / 5 |
+| `demo-team-a` |  | `code-ministral` | `ministral-3-3b-instruct` | 1 | 3 / 5 |
+| `demo-team-b` | auth **on** | `assistant-phi` | `phi-4-mini-instruct` | **2** | 4 / 5 |
+| `demo-team-b` |  | `summarizer-ministral` | `ministral-3-3b-instruct` | 1 | 3 / 5 |
+
+This satisfies the demo's goals: **2 `modelharness`**, **2 `modeldeployment`
+each**, and **multiple deployments with `replicas > 1`**. Every deployment also
+has **KAITO autoscaling enabled** (`enableScaling=true`): the `keda-kaito-scaler`
+provisions a `ScaledObject` that scales each `InferenceSet` between its
+`replicas` baseline and `maxReplicas` once the per-replica request-queue depth
+crosses `scalingThreshold`.
+
+---
+
+## Part 1 — Create the AKS cluster and install cluster-scoped components
+
+All commands are run from the repository root.
+
+### 1.1 Pick names for the run
+
+These names are shared by `prepare-image.sh` (which derives the ACR name from
+`CLUSTER_NAME`) and `setup-cluster.sh` (which attaches that ACR), so export
+them once in your shell:
+
+```sh
+export RESOURCE_GROUP=ps-demo-rg
+export CLUSTER_NAME=ps-demo-aks
+export LOCATION=australiaeast
+export NODE_COUNT=3
+export NODE_VM_SIZE=Standard_D8s_v5
+```
+
+### 1.2 Create the resource group + ACR and build/push the mocker image
+
+[`prepare-image.sh`](../hack/e2e/scripts/prepare-image.sh) is idempotent: it
+creates the resource group and ACR (if missing) and builds + pushes the
+`gpu-node-mocker` image. Its **last stdout line** is `image=<acr-fqdn>/gpu-node-mocker:<tag>` —
+capture it for the install step:
+
+```sh
+export SHADOW_CONTROLLER_IMAGE="$(hack/e2e/scripts/prepare-image.sh | sed -n 's/^image=//p')"
+echo "Built image: ${SHADOW_CONTROLLER_IMAGE}"
+```
+
+### 1.3 Create the AKS cluster + cluster-prep components
+
+[`run-e2e-local.sh setup`](../hack/e2e/scripts/run-e2e-local.sh) sources
+[`versions.env`](../versions.env), then calls
+[`setup-cluster.sh`](../hack/e2e/scripts/setup-cluster.sh), which:
+
+- creates the AKS cluster (Azure CNI overlay + **Cilium** dataplane/policy),
+- fetches the kubeconfig and waits for nodes + Cilium to be Ready,
+- installs **KEDA**, the **Gateway API base CRDs**, and **Istio** (in parallel).
+
+```sh
+hack/e2e/scripts/run-e2e-local.sh setup
+```
+
+### 1.4 Install the remaining cluster-scoped components
+
+[`run-e2e-local.sh install`](../hack/e2e/scripts/run-e2e-local.sh) calls
+[`install-components.sh`](../hack/e2e/scripts/install-components.sh), which
+installs (in parallel): **KAITO** workspace operator, the **GAIE/GWIE CRDs**,
+the **gpu-node-mocker**, and the **productionstack** umbrella chart (BBR,
+`keda-kaito-scaler`, and the `llm-gateway-apikey` auth control plane).
+
+```sh
+# SHADOW_CONTROLLER_IMAGE from step 1.2 is required here.
+hack/e2e/scripts/run-e2e-local.sh install
+```
+
+### 1.5 Validate
+
+[`validate-components.sh`](../hack/e2e/scripts/validate-components.sh) asserts
+every control-plane component is healthy:
+
+```sh
+hack/e2e/scripts/run-e2e-local.sh validate
+```
+
+You should see ✅ lines for KAITO, gpu-node-mocker, istiod, BBR, KEDA,
+keda-kaito-scaler, and apikey-operator.
+
+> **Tip:** `setup` / `install` / `validate` are separate sub-commands so you
+> can re-run an individual phase. To run everything (including the Go e2e
+> suite and teardown) in one shot, use `hack/e2e/scripts/run-e2e-local.sh all`.
+
+---
+
+## Part 2 — Install two ModelHarness, each with two ModelDeployment
+
+Each workload namespace gets **one** `modelharness` release that provisions
+the shared resources every model in that namespace needs:
+
+- the per-namespace Istio `Gateway` `"<namespace>-gw"` that fronts the namespace,
+- the catch-all `EnvoyFilter` (`model-not-found-direct`) that returns an
+  OpenAI-compatible `404 model_not_found` straight from Envoy for any
+  unknown-model path,
+- the per-namespace `EnvoyFilter` that injects BBR's ext_proc into the
+  Gateway HCM,
+- the unified-error `local_reply` `EnvoyFilter` that maps fail-closed
+  BBR / ext_authz outages and any remaining `>= 500` reply onto a consistent
+  OpenAI-compatible error envelope,
+- (when `auth.enabled`) the `AuthorizationPolicy` + `APIKey` CR that wire the
+  Gateway into the cluster-wide `apikey-ext-authz` provider,
+- (when `networkPolicy.enabled`) a `CiliumNetworkPolicy` that locks down
+  East-West ingress to the namespace's inference workloads.
+
+Each namespace then hosts **two** `modeldeployment` releases that parent into
+that shared Gateway.
+
+### 2.1 `demo-team-a` (API-key auth enabled, one multi-replica model)
+
+`auth.enabled=true` makes the harness render the per-namespace
+`AuthorizationPolicy` + `APIKey` CR; the `apikey-operator` mints a
+`llm-api-key` Secret in the namespace that clients send as a bearer token.
+
+```sh
+# Per-namespace harness (Gateway demo-team-a-gw, BBR, catch-all 404, netpol, auth).
+helm upgrade --install modelharness charts/modelharness \
+  --namespace demo-team-a --create-namespace \
+  --set namespace=demo-team-a \
+  --set auth.enabled=true \
+  --wait --timeout=5m
+
+# Model #1 — phi, 2 replicas (multi-replica), autoscale 2→4.
+helm upgrade --install chat-phi charts/modeldeployment \
+  --namespace demo-team-a \
+  --set name=chat-phi \
+  --set namespace=demo-team-a \
+  --set model=phi-4-mini-instruct \
+  --set replicas=2 \
+  --set enableScaling=true \
+  --set maxReplicas=4 \
+  --set scalingThreshold=5 \
+  --set instanceType=Standard_NV36ads_A10_v5 \
+  --wait --timeout=10m
+
+# Model #2 — ministral, 1 replica, autoscale 1→3.
+helm upgrade --install code-ministral charts/modeldeployment \
+  --namespace demo-team-a \
+  --set name=code-ministral \
+  --set namespace=demo-team-a \
+  --set model=ministral-3-3b-instruct \
+  --set replicas=1 \
+  --set enableScaling=true \
+  --set maxReplicas=3 \
+  --set scalingThreshold=5 \
+  --set instanceType=Standard_NV36ads_A10_v5 \
+  --wait --timeout=10m
+```
+
+### 2.2 `demo-team-b` (API-key auth enabled, one multi-replica model)
+
+Same harness as `demo-team-a` — auth scope is per-namespace, so flipping
+`auth.enabled=true` here mints a `demo-team-b`-local `llm-api-key` Secret
+independent of `demo-team-a`'s.
+
+```sh
+helm upgrade --install modelharness charts/modelharness \
+  --namespace demo-team-b --create-namespace \
+  --set namespace=demo-team-b \
+  --set auth.enabled=true \
+  --wait --timeout=5m
+
+# Model #1 — phi, 2 replicas (multi-replica), autoscale 2→4.
+helm upgrade --install assistant-phi charts/modeldeployment \
+  --namespace demo-team-b \
+  --set name=assistant-phi \
+  --set namespace=demo-team-b \
+  --set model=phi-4-mini-instruct \
+  --set replicas=2 \
+  --set enableScaling=true \
+  --set maxReplicas=4 \
+  --set scalingThreshold=5 \
+  --set instanceType=Standard_NV36ads_A10_v5 \
+  --wait --timeout=10m
+
+# Model #2 — ministral, 1 replica, autoscale 1→3.
+helm upgrade --install summarizer-ministral charts/modeldeployment \
+  --namespace demo-team-b \
+  --set name=summarizer-ministral \
+  --set namespace=demo-team-b \
+  --set model=ministral-3-3b-instruct \
+  --set replicas=1 \
+  --set enableScaling=true \
+  --set maxReplicas=3 \
+  --set scalingThreshold=5 \
+  --set instanceType=Standard_NV36ads_A10_v5 \
+  --wait --timeout=10m
+```
+
+### 2.3 Wait for the inference pods
+
+`helm --wait` returns once the chart-owned Deployments (the EPP) are ready,
+but the InferenceSet's inference pods are reconciled by KAITO (and patched
+Running by the `gpu-node-mocker`). Wait for them explicitly:
+
+```sh
+for ns_model in \
+  "demo-team-a:chat-phi:2" "demo-team-a:code-ministral:1" \
+  "demo-team-b:assistant-phi:2" "demo-team-b:summarizer-ministral:1"; do
+  ns="${ns_model%%:*}"; rest="${ns_model#*:}"; name="${rest%%:*}"; want="${rest##*:}"
+  echo "── waiting for ${want} inference pod(s) of ${name} in ${ns} ──"
+  kubectl -n "${ns}" wait --for=condition=ready pod \
+    -l "inferenceset.kaito.sh/created-by=${name}" --timeout=10m
+done
+```
+
+Inspect what you built:
+
+```sh
+kubectl get modelharness,modeldeployment -A 2>/dev/null || true
+helm list -A | grep -E 'modelharness|chat-phi|code-ministral|assistant-phi|summarizer-ministral'
+kubectl get gateway,httproute,inferencepool,inferenceset -n demo-team-a
+kubectl get gateway,httproute,inferencepool,inferenceset -n demo-team-b
+```
+
+---
+
+## Part 3 — Send prompts at a target QPS
+
+> **Note:** `loadgen.sh` drives traffic from your local machine via
+> `kubectl port-forward`, so it needs a working kubeconfig for the cluster.
+> If you ran Parts 1–2 in this same shell you're already set; if you're on a
+> fresh machine/terminal, re-fetch it first:
+> `az aks get-credentials -g "${RESOURCE_GROUP}" -n "${CLUSTER_NAME}" --overwrite-existing`
+
+[`hack/loadgen.sh`](../hack/loadgen.sh) auto-discovers
+the model name and the per-namespace Gateway, starts (and cleans up) its own
+`kubectl port-forward`, auto-detects API-key auth, and drives traffic at a
+target QPS. See `--help` for the full option list.
+
+### 3.1 Built-in `curl` engine (default)
+
+```sh
+# Both namespaces have auth ON — the script auto-reads the llm-api-key Secret
+# and sends the bearer token + the <ns>.gw.kaito.sh Host header for you.
+
+# 5 QPS for 30s against the auto-discovered first model in demo-team-a (chat-phi).
+hack/loadgen.sh -n demo-team-a -q 5 -d 30
+
+# Target the second model explicitly, 3 QPS for 20s.
+hack/loadgen.sh -n demo-team-a -m code-ministral -q 3 -d 20
+
+hack/loadgen.sh -n demo-team-b -q 5 -d 30
+```
+
+The script prints a summary: requests sent, 2xx / 5xx / non-2xx / transport
+error counts, achieved QPS, and latency avg / p50 / p90 / p99.
+
+### 3.2 `guidellm` engine (TTFT / TPOT / throughput report)
+
+```sh
+# Installs guidellm via pip on first use; runs a constant-rate benchmark.
+hack/loadgen.sh -n demo-team-b -m assistant-phi -e guidellm \
+  --profile constant --rate 3 --max-seconds 30 \
+  --processor microsoft/Phi-4-mini-instruct \
+  --data 'prompt_tokens=256,output_tokens=64'
+```
+
+> `--processor` is the HuggingFace tokenizer id guidellm uses to synthesize
+> prompts; it must be a real HF repo id (the gateway `model` name is a routing
+> name, not an HF id). Use `microsoft/Phi-4-mini-instruct` for the phi models.
+
+---
+
+## Part 4 — Tear everything down
+
+Delete the workload releases/namespaces, then the whole cluster (the resource
+group deletion cascades the AKS cluster + ACR):
+
+```sh
+helm uninstall chat-phi code-ministral modelharness -n demo-team-a || true
+helm uninstall assistant-phi summarizer-ministral modelharness -n demo-team-b || true
+kubectl delete namespace demo-team-a demo-team-b --ignore-not-found
+
+# Deletes the resource group (cluster + ACR) asynchronously.
+RESOURCE_GROUP="${RESOURCE_GROUP:-ps-demo-rg}" hack/e2e/scripts/teardown-cluster.sh
+```
+
+---
+
+## Reference
+
+- [`charts/modelharness`](../charts/modelharness/README.md) — per-namespace shared resources.
+- [`charts/modeldeployment`](../charts/modeldeployment/README.md) — per-model GAIE artifacts.
+- [`charts/productionstack`](../charts/productionstack/README.md) — cluster-scoped components.
+- [`hack/e2e/scripts`](../hack/e2e/scripts) — cluster bring-up / install / validate / teardown.
+- [`.github/workflows/benchmark.yaml`](../.github/workflows/benchmark.yaml) — the guidellm benchmark this demo's `--engine guidellm` mode mirrors.

--- a/hack/loadgen.sh
+++ b/hack/loadgen.sh
@@ -1,0 +1,375 @@
+#!/usr/bin/env bash
+# ---------------------------------------------------------------------------
+# loadgen.sh — Drive OpenAI-style chat-completion traffic at a target QPS
+# against the modeldeployment(s) in a workload namespace provisioned by
+# charts/modelharness + charts/modeldeployment.
+#
+# The request path exercised is the full production path:
+#   localhost (port-forward) → Istio Gateway "<ns>-gw" → BBR ext_proc
+#   → EPP (InferencePool ext_proc) → vLLM (mock) inference pod.
+#
+# Two load engines are supported:
+#   * curl     (default) — a self-contained QPS-paced loop that records the
+#                          HTTP status code and end-to-end latency of every
+#                          request and prints a success/error + latency
+#                          summary (avg / p50 / p90 / p99). No extra deps.
+#   * guidellm           — delegates to the `guidellm` benchmark CLI for a
+#                          full TTFT / TPOT / throughput report (same tool
+#                          the .github/workflows/benchmark.yaml uses).
+#
+# The script auto-discovers the model name, the per-namespace Gateway, and
+# (when the namespace has API-key auth enabled) the bearer token from the
+# operator-minted `llm-api-key` Secret. It starts (and cleans up) its own
+# `kubectl port-forward` to the Gateway Service.
+#
+# ---------------------------------------------------------------------------
+# Usage:
+#   hack/loadgen.sh -n <namespace> [options]
+#
+# Common options:
+#   -n, --namespace NS     Workload namespace (required).
+#   -m, --model NAME       modeldeployment name == OpenAI `model` field.
+#                          Auto-discovered from the namespace when omitted.
+#   -q, --qps N            Target requests/sec for the curl engine (default 2).
+#   -d, --duration SEC     How long to send traffic, seconds (default 30).
+#   -c, --concurrency N    Max in-flight requests for the curl engine
+#                          (default: max(qps, 4)).
+#       --requests N       Stop after N requests instead of after --duration.
+#   -p, --prompt TEXT      Prompt content (default: a short fixed sentence).
+#       --max-tokens N     max_tokens in the request body (default 64).
+#   -e, --engine ENGINE    curl (default) | guidellm.
+#   -g, --gateway NAME     Gateway resource name (default "<ns>-gw").
+#       --api-key KEY      Bearer token override (else auto-read when auth on).
+#       --no-auth          Skip API-key auto-detection (send unauthenticated).
+#       --local-port PORT  Local port for the port-forward (default: random).
+#
+# guidellm-only options:
+#       --processor ID     HF tokenizer/processor id (default
+#                          microsoft/Phi-4-mini-instruct).
+#       --profile P        guidellm profile (default constant).
+#       --rate R           guidellm rate (default = --qps).
+#       --data SPEC        guidellm synthetic-data spec
+#                          (default prompt_tokens=256,output_tokens=64).
+#       --max-seconds SEC  guidellm per-benchmark cap (default = --duration).
+#       --out-dir DIR      Directory for guidellm JSON/CSV result files
+#                          (default: a fresh mktemp dir, printed on exit).
+#
+# Examples:
+#   # 5 QPS for 60s against the auto-discovered model in namespace `demo-a`:
+#   hack/loadgen.sh -n demo-a -q 5 -d 60
+#
+#   # Target a specific model and run a guidellm sweep:
+#   hack/loadgen.sh -n demo-a -m chat-phi -e guidellm \
+#       --profile sweep --max-seconds 30
+# ---------------------------------------------------------------------------
+set -euo pipefail
+
+# ── Defaults ───────────────────────────────────────────────────────────────
+NAMESPACE=""
+MODEL=""
+QPS="2"
+DURATION="30"
+CONCURRENCY=""
+MAX_REQUESTS=""
+PROMPT="Write a one-sentence hello to the production stack."
+MAX_TOKENS="64"
+ENGINE="curl"
+GATEWAY=""
+API_KEY=""
+AUTH_MODE="auto"   # auto | off
+LOCAL_PORT=""
+
+# guidellm-only
+PROCESSOR="microsoft/Phi-4-mini-instruct"
+GUIDELLM_PROFILE="constant"
+GUIDELLM_RATE=""
+GUIDELLM_DATA="prompt_tokens=256,output_tokens=64"
+GUIDELLM_MAX_SECONDS=""
+GUIDELLM_OUT_DIR=""
+
+APIKEY_SECRET_NAME="llm-api-key"
+APIKEY_SECRET_KEY="apiKey"
+
+die() { echo "❌ $*" >&2; exit 1; }
+info() { echo "▶︎ $*"; }
+
+usage() { sed -n '2,75p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'; exit "${1:-0}"; }
+
+# ── Parse args ──────────────────────────────────────────────────────────────
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -n|--namespace)   NAMESPACE="$2"; shift 2 ;;
+    -m|--model)       MODEL="$2"; shift 2 ;;
+    -q|--qps)         QPS="$2"; shift 2 ;;
+    -d|--duration)    DURATION="$2"; shift 2 ;;
+    -c|--concurrency) CONCURRENCY="$2"; shift 2 ;;
+    --requests)       MAX_REQUESTS="$2"; shift 2 ;;
+    -p|--prompt)      PROMPT="$2"; shift 2 ;;
+    --max-tokens)     MAX_TOKENS="$2"; shift 2 ;;
+    -e|--engine)      ENGINE="$2"; shift 2 ;;
+    -g|--gateway)     GATEWAY="$2"; shift 2 ;;
+    --api-key)        API_KEY="$2"; shift 2 ;;
+    --no-auth)        AUTH_MODE="off"; shift ;;
+    --local-port)     LOCAL_PORT="$2"; shift 2 ;;
+    --processor)      PROCESSOR="$2"; shift 2 ;;
+    --profile)        GUIDELLM_PROFILE="$2"; shift 2 ;;
+    --rate)           GUIDELLM_RATE="$2"; shift 2 ;;
+    --data)           GUIDELLM_DATA="$2"; shift 2 ;;
+    --max-seconds)    GUIDELLM_MAX_SECONDS="$2"; shift 2 ;;
+    --out-dir)        GUIDELLM_OUT_DIR="$2"; shift 2 ;;
+    -h|--help)        usage 0 ;;
+    *) die "Unknown argument: $1 (use --help)" ;;
+  esac
+done
+
+[[ -n "${NAMESPACE}" ]] || { echo "Missing required --namespace" >&2; usage 1; }
+case "${ENGINE}" in curl|guidellm) ;; *) die "Invalid --engine '${ENGINE}' (curl|guidellm)";; esac
+command -v kubectl >/dev/null || die "kubectl not found in PATH"
+
+# ── Verify namespace + discover model / gateway ─────────────────────────────
+kubectl get namespace "${NAMESPACE}" >/dev/null 2>&1 || die "namespace '${NAMESPACE}' not found"
+
+GATEWAY="${GATEWAY:-${NAMESPACE}-gw}"
+GATEWAY_SVC="${GATEWAY}-istio"
+
+if [[ -z "${MODEL}" ]]; then
+  info "Discovering model name from modeldeployment HTTPRoutes in ${NAMESPACE}..."
+  # Each modeldeployment HTTPRoute is stamped kaito.sh/owned-by=modeldeployment
+  # and kaito.sh/inferenceset=<model-name>. The model name is also the value
+  # sent in the OpenAI `model` field (matched as X-Gateway-Model-Name).
+  # (bash 3.2 has no mapfile — collect into a space-separated string.)
+  MODELS_RAW="$(kubectl get httproute -n "${NAMESPACE}" \
+    -l kaito.sh/owned-by=modeldeployment \
+    -o jsonpath='{range .items[*]}{.metadata.labels.kaito\.sh/inferenceset}{"\n"}{end}' 2>/dev/null \
+    | sed '/^$/d' | sort -u)"
+  if [[ -z "${MODELS_RAW}" ]]; then
+    # Fall back to InferenceSet names.
+    MODELS_RAW="$(kubectl get inferenceset -n "${NAMESPACE}" \
+      -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | sed '/^$/d' | sort -u)"
+  fi
+  [[ -n "${MODELS_RAW}" ]] || die "no modeldeployment found in '${NAMESPACE}' — pass --model"
+  MODEL="$(echo "${MODELS_RAW}" | head -1)"
+  MODEL_COUNT="$(echo "${MODELS_RAW}" | wc -l | tr -d ' ')"
+  if [[ "${MODEL_COUNT}" -gt 1 ]]; then
+    info "Found ${MODEL_COUNT} models ($(echo ${MODELS_RAW} | tr '\n' ' ')); defaulting to '${MODEL}'. Use --model to pick another."
+  fi
+fi
+info "Target model: ${MODEL}  (namespace=${NAMESPACE}, gateway=${GATEWAY})"
+
+kubectl get svc -n "${NAMESPACE}" "${GATEWAY_SVC}" >/dev/null 2>&1 \
+  || die "gateway service ${NAMESPACE}/${GATEWAY_SVC} not found (is modelharness installed?)"
+
+# ── Auth detection ──────────────────────────────────────────────────────────
+HOST_HEADER=""
+if [[ "${AUTH_MODE}" == "auto" && -z "${API_KEY}" ]]; then
+  if kubectl get secret -n "${NAMESPACE}" "${APIKEY_SECRET_NAME}" >/dev/null 2>&1; then
+    API_KEY="$(kubectl get secret -n "${NAMESPACE}" "${APIKEY_SECRET_NAME}" \
+      -o jsonpath="{.data.${APIKEY_SECRET_KEY}}" | base64 -d)"
+    info "API-key auth detected — using bearer token from Secret ${APIKEY_SECRET_NAME}"
+  fi
+fi
+if [[ -n "${API_KEY}" ]]; then
+  # The llm-gateway-apikey ext_authz filter resolves the APIKey CR namespace
+  # from the request Host subdomain "<ns>.gw.kaito.sh".
+  HOST_HEADER="${NAMESPACE}.gw.kaito.sh"
+fi
+
+# ── Port-forward to the gateway ─────────────────────────────────────────────
+if [[ -z "${LOCAL_PORT}" ]]; then
+  LOCAL_PORT="$(python3 -c 'import socket;s=socket.socket();s.bind(("127.0.0.1",0));print(s.getsockname()[1]);s.close()' 2>/dev/null || echo 18080)"
+fi
+PF_LOG="$(mktemp -t loadgen-pf.XXXXXX)"
+info "Starting port-forward svc/${GATEWAY_SVC} → localhost:${LOCAL_PORT}"
+kubectl -n "${NAMESPACE}" port-forward "svc/${GATEWAY_SVC}" "${LOCAL_PORT}:80" >"${PF_LOG}" 2>&1 &
+PF_PID=$!
+
+cleanup() {
+  [[ -n "${PF_PID:-}" ]] && kill "${PF_PID}" >/dev/null 2>&1 || true
+  [[ -n "${PF_LOG:-}" && -f "${PF_LOG}" ]] && rm -f "${PF_LOG}" || true
+  [[ -n "${REQ_LOG:-}" && -f "${REQ_LOG}" ]] && rm -f "${REQ_LOG}" || true
+}
+trap cleanup EXIT INT TERM
+
+# Wait for the local port to accept connections.
+for _ in $(seq 1 30); do
+  if (exec 3<>"/dev/tcp/127.0.0.1/${LOCAL_PORT}") 2>/dev/null; then exec 3>&- 3<&-; break; fi
+  if ! kill -0 "${PF_PID}" 2>/dev/null; then cat "${PF_LOG}" >&2; die "port-forward exited early"; fi
+  sleep 1
+done
+(exec 3<>"/dev/tcp/127.0.0.1/${LOCAL_PORT}") 2>/dev/null || { cat "${PF_LOG}" >&2; die "port-forward not ready"; }
+exec 3>&- 3<&- 2>/dev/null || true
+
+ENDPOINT="http://127.0.0.1:${LOCAL_PORT}"
+if [[ -n "${HOST_HEADER}" ]]; then
+  ENDPOINT="http://${HOST_HEADER}:${LOCAL_PORT}"   # resolves to 127.0.0.1 below
+fi
+
+# ── Smoke test ──────────────────────────────────────────────────────────────
+smoke_curl=(curl -sS -o /dev/null -w '%{http_code}' --max-time 60
+  --resolve "${HOST_HEADER:-127.0.0.1}:${LOCAL_PORT}:127.0.0.1"
+  -H 'Content-Type: application/json')
+[[ -n "${API_KEY}" ]] && smoke_curl+=(-H "Authorization: Bearer ${API_KEY}")
+smoke_body="{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":\"ping\"}],\"max_tokens\":8}"
+info "Smoke-testing ${ENDPOINT}/v1/chat/completions ..."
+smoke_code="$("${smoke_curl[@]}" -d "${smoke_body}" "${ENDPOINT}/v1/chat/completions" || echo 000)"
+if [[ "${smoke_code}" =~ ^2 ]]; then
+  echo "  ✅ smoke test OK (HTTP ${smoke_code})"
+else
+  echo "  ⚠️  smoke test returned HTTP ${smoke_code} — continuing anyway"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────
+# Engine: guidellm
+# ─────────────────────────────────────────────────────────────────────────
+if [[ "${ENGINE}" == "guidellm" ]]; then
+  # Resolve a guidellm binary. Prefer one already on PATH; otherwise install it
+  # into a dedicated virtualenv so we don't trip over PEP 668 ("externally
+  # managed") on Homebrew/Debian Python, and don't pollute the system env.
+  if command -v guidellm >/dev/null 2>&1; then
+    GUIDELLM_BIN="$(command -v guidellm)"
+  else
+    GUIDELLM_VENV="${GUIDELLM_VENV:-${HOME}/.cache/kaito-loadgen/guidellm-venv}"
+    GUIDELLM_BIN="${GUIDELLM_VENV}/bin/guidellm"
+    if [[ ! -x "${GUIDELLM_BIN}" ]]; then
+      info "guidellm not found — creating venv at ${GUIDELLM_VENV} and installing 'guidellm[recommended]'..."
+      python3 -m venv "${GUIDELLM_VENV}"
+      "${GUIDELLM_VENV}/bin/python" -m pip install --quiet --upgrade pip
+      "${GUIDELLM_VENV}/bin/python" -m pip install --quiet 'guidellm[recommended]'
+    fi
+    [[ -x "${GUIDELLM_BIN}" ]] || die "guidellm install failed (no executable at ${GUIDELLM_BIN})"
+  fi
+  GUIDELLM_RATE="${GUIDELLM_RATE:-${QPS}}"
+  GUIDELLM_MAX_SECONDS="${GUIDELLM_MAX_SECONDS:-${DURATION}}"
+  if [[ -n "${GUIDELLM_OUT_DIR}" ]]; then
+    OUT_DIR="${GUIDELLM_OUT_DIR}"; mkdir -p "${OUT_DIR}"
+  else
+    OUT_DIR="$(mktemp -d -t loadgen-guidellm.XXXXXX)"
+  fi
+  info "Running guidellm (profile=${GUIDELLM_PROFILE}, rate=${GUIDELLM_RATE}, max-seconds=${GUIDELLM_MAX_SECONDS})"
+  echo "    target=${ENDPOINT}  model=${MODEL}  processor=${PROCESSOR}  data=${GUIDELLM_DATA}"
+  bk="{\"verify\":false,\"validate_backend\":false"
+  [[ -n "${API_KEY}" ]] && bk="${bk},\"api_key\":\"${API_KEY}\""
+  bk="${bk}}"
+  "${GUIDELLM_BIN}" benchmark run \
+    --target "${ENDPOINT}" \
+    --model "${MODEL}" \
+    --processor "${PROCESSOR}" \
+    --backend-kwargs "${bk}" \
+    --profile "${GUIDELLM_PROFILE}" \
+    --rate "${GUIDELLM_RATE}" \
+    --max-seconds "${GUIDELLM_MAX_SECONDS}" \
+    --data "${GUIDELLM_DATA}" \
+    --output-dir "${OUT_DIR}" \
+    --outputs json --outputs csv \
+    --disable-console-interactive
+  echo ""
+  info "guidellm result files in ${OUT_DIR}:"
+  ls -1 "${OUT_DIR}" | sed 's/^/  /'
+  exit 0
+fi
+
+# ─────────────────────────────────────────────────────────────────────────
+# Engine: curl (QPS-paced loop)
+# ─────────────────────────────────────────────────────────────────────────
+# Validate numeric inputs.
+[[ "${QPS}" =~ ^[0-9]+([.][0-9]+)?$ ]] || die "--qps must be a number"
+[[ "${DURATION}" =~ ^[0-9]+$ ]] || die "--duration must be an integer (seconds)"
+if [[ -z "${CONCURRENCY}" ]]; then
+  CONCURRENCY="$(awk -v q="${QPS}" 'BEGIN{c=int(q+0.999); if(c<4)c=4; print c}')"
+fi
+
+REQ_LOG="$(mktemp -t loadgen-req.XXXXXX)"
+INTERVAL="$(awk -v q="${QPS}" 'BEGIN{printf "%.6f", 1.0/q}')"
+
+BODY="{\"model\":\"${MODEL}\",\"messages\":[{\"role\":\"user\",\"content\":$(printf '%s' "${PROMPT}" | python3 -c 'import json,sys;print(json.dumps(sys.stdin.read()))')}],\"max_tokens\":${MAX_TOKENS}}"
+
+# One request: append "<http_code> <time_total>" to the shared log.
+send_one() {
+  local code_time
+  local c=(curl -sS -o /dev/null -w '%{http_code} %{time_total}' --max-time 120
+    --resolve "${HOST_HEADER:-127.0.0.1}:${LOCAL_PORT}:127.0.0.1"
+    -H 'Content-Type: application/json')
+  [[ -n "${API_KEY}" ]] && c+=(-H "Authorization: Bearer ${API_KEY}")
+  code_time="$("${c[@]}" -d "${BODY}" "${ENDPOINT}/v1/chat/completions" 2>/dev/null || echo '000 0')"
+  echo "${code_time}" >>"${REQ_LOG}"
+}
+
+echo ""
+if [[ -n "${MAX_REQUESTS}" ]]; then
+  info "Sending traffic: qps=${QPS} (interval=${INTERVAL}s) concurrency=${CONCURRENCY} requests=${MAX_REQUESTS}"
+else
+  info "Sending traffic: qps=${QPS} (interval=${INTERVAL}s) concurrency=${CONCURRENCY} duration=${DURATION}s"
+fi
+echo "    endpoint=${ENDPOINT}/v1/chat/completions  model=${MODEL}  auth=$([[ -n "${API_KEY}" ]] && echo on || echo off)"
+
+# Use whole-second wall clock (portable across macOS/Linux; avoids date +%N).
+START_EPOCH="$(date +%s)"
+DEADLINE=$((START_EPOCH + DURATION))
+i=0
+REQ_PIDS=""   # track only request jobs (NOT the port-forward, which runs forever)
+while :; do
+  # Stop conditions.
+  if [[ -n "${MAX_REQUESTS}" ]]; then
+    [[ "${i}" -ge "${MAX_REQUESTS}" ]] && break
+  else
+    [[ "$(date +%s)" -ge "${DEADLINE}" ]] && break
+  fi
+
+  # Throttle concurrent background curls (bash 3.2: no `wait -n`).
+  # Count only live request PIDs so the long-running port-forward never blocks us.
+  while :; do
+    running=0; live_pids=""
+    for p in ${REQ_PIDS}; do
+      if kill -0 "${p}" 2>/dev/null; then running=$((running+1)); live_pids="${live_pids} ${p}"; fi
+    done
+    REQ_PIDS="${live_pids}"
+    [[ "${running}" -lt "${CONCURRENCY}" ]] && break
+    sleep 0.01
+  done
+
+  send_one &
+  REQ_PIDS="${REQ_PIDS} $!"
+  i=$((i+1))
+
+  # Pace to the target QPS with a fractional sleep between launches.
+  sleep "${INTERVAL}"
+done
+
+info "Waiting for in-flight requests to drain..."
+# Wait only on request jobs; a bare `wait` would also block on the port-forward.
+for p in ${REQ_PIDS}; do wait "${p}" 2>/dev/null || true; done
+END_EPOCH="$(date +%s)"
+ELAPSED=$((END_EPOCH - START_EPOCH)); [[ "${ELAPSED}" -lt 1 ]] && ELAPSED=1
+
+# ── Aggregate + report ──────────────────────────────────────────────────────
+echo ""
+echo "════════════════════════ loadgen.sh summary ════════════════════════"
+# Counts.
+awk -v elapsed="${ELAPSED}" '
+{
+  code=$1; total++;
+  if (code ~ /^2/) ok++;
+  else if (code ~ /^5/) e5++;
+  else if (code=="000") terr++;
+  else other++;
+}
+END{
+  printf "  requests sent      : %d\n", total+0;
+  printf "  2xx success        : %d\n", ok+0;
+  printf "  5xx errors         : %d\n", e5+0;
+  printf "  other non-2xx      : %d\n", other+0;
+  printf "  transport errors   : %d\n", terr+0;
+  if (elapsed+0>0) printf "  achieved QPS       : %.2f\n", (total+0)/elapsed;
+}' "${REQ_LOG}"
+# Latency percentiles from curl %{time_total} (portable: sort -n + awk index).
+awk '{print $2}' "${REQ_LOG}" | sort -n | awk '
+function pct(p,   idx){ idx=int(NR*p); if(idx<1)idx=1; if(idx>NR)idx=NR; return v[idx] }
+{ v[NR]=$1; sum+=$1 }
+END{
+  if (NR==0) exit;
+  printf "  latency avg        : %.3fs\n", sum/NR;
+  printf "  latency p50        : %.3fs\n", pct(0.50);
+  printf "  latency p90        : %.3fs\n", pct(0.90);
+  printf "  latency p99        : %.3fs\n", pct(0.99);
+}'
+echo "══════════════════════════════════════════════════════════════════════════"


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

1. add a doc `examples/multi-modelharness-deployment.md` for building a production-stack env from scratch manually. By the way, I've built a long-term production-stack env according to this tutorial.
2. add a script `hack/loadgen.sh` for llm workload benchmark testing in production-stack env.
3. use `hack/loadgen.sh` script to improve benchmark workflow.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
