### PR TITLE
Support workspace shadow pod

### DIFF
--- a/pkg/gpu-node-mocker/controllers/config.go
+++ b/pkg/gpu-node-mocker/controllers/config.go
@@ -67,15 +67,9 @@ const (
 	// ShadowPodLabelKey marks shadow pods so we can watch only those.
 	ShadowPodLabelKey = "kaito.sh/shadow-pod-for"
 
-	// ShadowPodInferenceSetLabelKey records the InferenceSet (modeldeployment)
-	// that the shadow pod mirrors. Intentionally distinct from the upstream
-	// `inferenceset.kaito.sh/created-by` label to avoid the InferencePool
-	// selector accidentally treating shadow pods as real inference endpoints.
-	ShadowPodInferenceSetLabelKey = "kaito.sh/shadow-pod-inferenceset"
-
 	// InferenceSetCreatedByLabelKey is the upstream KAITO label that the
-	// InferenceSet controller stamps on its child pods. We read (but never
-	// re-stamp) this value to populate ShadowPodInferenceSetLabelKey.
+	// InferenceSet controller stamps on its child pods. The Phase-2 pod
+	// predicate reads it to recognize InferenceSet (modeldeployment) pods.
 	InferenceSetCreatedByLabelKey = "inferenceset.kaito.sh/created-by"
 
 	// OwnedByLabelKey / OwnedByLabelValue is the stable, value-free label

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
@@ -213,14 +213,16 @@ func (r *ShadowPodReconciler) ensureShadowPod(ctx context.Context, original *cor
 		LabelManagedBy:    ControllerName,
 		ShadowPodLabelKey: shadowPodLabel,
 		// Stamp the production-stack ownership label so the modelharness
-		// `allow-inference-traffic` NetworkPolicy positively selects this
-		// shadow pod. Without it, EPP traffic forwarded to the (patched)
-		// inference-pod IP — which is actually the shadow pod's IP —
-		// would be dropped by `default-deny-ingress`.
+		// `inference-pods-ingress` CiliumNetworkPolicy positively selects
+		// this shadow pod. That policy's endpointSelector matches
+		// `kaito.sh/owned-by: modeldeployment`; a selected endpoint enters
+		// Cilium's default-deny ingress and only same-namespace (plus
+		// `allowedIngressNamespaces`) traffic is permitted. Stamping this
+		// label brings the shadow pod under the same East-West isolation as
+		// real inference pods while still allowing EPP — which forwards to
+		// the (patched) inference-pod IP that is actually the shadow pod's
+		// IP — to reach it from within the namespace.
 		OwnedByLabelKey: OwnedByLabelValue,
-	}
-	if v, ok := original.Labels[InferenceSetCreatedByLabelKey]; ok && v != "" {
-		labels[ShadowPodInferenceSetLabelKey] = v
 	}
 
 	udsTokenizerImage := r.Config.UDSTokenizerImage
@@ -437,8 +439,13 @@ func isPendingOnFakeNode(obj client.Object) bool {
 	if !ok {
 		return false
 	}
-	// Only process pods created by KAITO InferenceSets
-	if _, hasLabel := pod.Labels["inferenceset.kaito.sh/created-by"]; !hasLabel {
+	// Only process pods created by KAITO. Two provisioning paths exist:
+	//   - InferenceSet (modeldeployment) pods carry `inferenceset.kaito.sh/created-by`.
+	//   - Workspace pods (KAITO StatefulSet) carry `kaito.sh/workspace`.
+	// Both end up Pending on a fake node and need a shadow pod.
+	_, hasInferenceSet := pod.Labels[InferenceSetCreatedByLabelKey]
+	_, hasWorkspace := pod.Labels[LabelKaitoWorkspace]
+	if !hasInferenceSet && !hasWorkspace {
 		return false
 	}
 	return pod.Spec.NodeName != "" &&

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
@@ -37,6 +37,10 @@ func TestIsPendingOnFakeNode(t *testing.T) {
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"inferenceset.kaito.sh/created-by": "falcon"}},
 			Spec:       corev1.PodSpec{NodeName: "fake-ws1"}, Status: corev1.PodStatus{Phase: corev1.PodPending},
 		}, true},
+		{"valid workspace pod", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"kaito.sh/workspace": "workspace-phi"}},
+			Spec:       corev1.PodSpec{NodeName: "fake-ws1"}, Status: corev1.PodStatus{Phase: corev1.PodPending},
+		}, true},
 		{"running", &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"inferenceset.kaito.sh/created-by": "falcon"}},
 			Spec:       corev1.PodSpec{NodeName: "fake-ws1"}, Status: corev1.PodStatus{Phase: corev1.PodRunning},
@@ -206,9 +210,6 @@ func TestEnsureShadowPod_Creates(t *testing.T) {
 	if shadow.Labels[ShadowPodLabelKey] != "default.falcon-0" {
 		t.Errorf("shadow label = %q", shadow.Labels[ShadowPodLabelKey])
 	}
-	if shadow.Labels[ShadowPodInferenceSetLabelKey] != "falcon-7b-instruct" {
-		t.Errorf("shadow inferenceset label = %q", shadow.Labels[ShadowPodInferenceSetLabelKey])
-	}
 	// Regression guard for issue #83: the modelharness NetworkPolicies
 	// positively select on `kaito.sh/owned-by: modeldeployment`. Without
 	// this label, EPP traffic forwarded to the (patched) inference-pod
@@ -283,6 +284,47 @@ func TestEnsureShadowPod_ReturnsExisting(t *testing.T) {
 	}
 	if shadow.Labels["existing"] != "true" {
 		t.Error("should return existing shadow pod")
+	}
+}
+
+func TestEnsureShadowPod_WorkspacePodCreatesShadow(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+	cfg := testConfig()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	// Workspace (StatefulSet) pod: carries kaito.sh/workspace, NOT the
+	// InferenceSet created-by label.
+	original := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "workspace-phi-0",
+			Namespace: "default",
+			Labels:    map[string]string{"kaito.sh/workspace": "workspace-phi"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName: "fake-ws1",
+			Containers: []corev1.Container{{
+				Name:  "model",
+				Image: "kaito/phi:latest",
+				Args:  []string{"--model", "microsoft/phi-4-mini-instruct", "--port", "5000"},
+				Ports: []corev1.ContainerPort{{ContainerPort: 5000}},
+			}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodPending},
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns, original).Build()
+	r := &ShadowPodReconciler{Client: cl, Config: cfg}
+
+	shadow, err := r.ensureShadowPod(ctx, original, "shadow-default-workspace-phi-0")
+	if err != nil {
+		t.Fatalf("ensureShadowPod: %v", err)
+	}
+	// A Workspace (StatefulSet) pod must still produce a shadow pod carrying
+	// the ownership label so modelharness NetworkPolicies select it.
+	if shadow.Labels[OwnedByLabelKey] != OwnedByLabelValue {
+		t.Errorf("shadow owned-by label = %q, want %q",
+			shadow.Labels[OwnedByLabelKey], OwnedByLabelValue)
 	}
 }
 

--- a/test/e2e/gpu_mocker_test.go
+++ b/test/e2e/gpu_mocker_test.go
@@ -25,6 +25,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -296,6 +297,138 @@ var _ = Describe("GPU Mocker E2E", Ordered, func() {
 					Expect(containerNames).To(ContainElement("uds-tokenizer"),
 						"shadow pod %q should have uds-tokenizer container", pod.Name)
 				}
+			})
+
+			It("should create a shadow pod for a KAITO Workspace (StatefulSet) pod", func() {
+				clientset, err := utils.GetK8sClientset()
+				Expect(err).NotTo(HaveOccurred())
+
+				ctx := context.Background()
+
+				// The gpu-mocker case deploys InferenceSet (modeldeployment)
+				// pods, which already provisioned at least one Ready fake node.
+				// KAITO Workspace pods (owned by a StatefulSet, labelled
+				// kaito.sh/workspace) take a different provisioning path but
+				// must still get a shadow pod. Synthesize a Workspace-style pod
+				// bound to one of THIS case's fake nodes and assert the
+				// gpu-node-mocker mirrors it just like an InferenceSet pod.
+				//
+				// Scoping the target to a fake node that hosts a pod in
+				// caseNamespace keeps cases running in parallel isolated.
+				deploymentName := caseDeployments[0].Name
+				origPods, err := clientset.CoreV1().Pods(caseNamespace).List(ctx, metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("inferenceset.kaito.sh/created-by=%s", deploymentName),
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(origPods.Items).NotTo(BeEmpty(),
+					"need at least one original pod in %s for deployment %q", caseNamespace, deploymentName)
+
+				var fakeNodeName string
+				for _, p := range origPods.Items {
+					if strings.HasPrefix(p.Spec.NodeName, "fake-") {
+						fakeNodeName = p.Spec.NodeName
+						break
+					}
+				}
+				Expect(fakeNodeName).NotTo(BeEmpty(),
+					"no original pod for %q is scheduled on a fake- node yet", deploymentName)
+
+				const wsName = "e2e-workspace-shadow"
+				wsPodName := wsName + "-0"
+
+				wsPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      wsPodName,
+						Namespace: caseNamespace,
+						// KAITO Workspace StatefulSet pods carry this label
+						// instead of inferenceset.kaito.sh/created-by.
+						Labels: map[string]string{"kaito.sh/workspace": wsName},
+					},
+					Spec: corev1.PodSpec{
+						// Bind directly to the fake node (no kubelet runs there)
+						// so the pod stays Pending — exactly the state the
+						// ShadowPodReconciler mirrors. A blanket toleration
+						// clears the fake node's sku=gpu taint.
+						NodeName:    fakeNodeName,
+						Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+						Containers: []corev1.Container{{
+							Name:  "model",
+							Image: "mcr.microsoft.com/oss/kubernetes/pause:3.6",
+							Args: []string{
+								"--model", "microsoft/phi-4-mini-instruct",
+								"--served-model-name", "phi-4-mini-instruct",
+							},
+							Ports: []corev1.ContainerPort{{ContainerPort: 5000}},
+						}},
+					},
+				}
+
+				By(fmt.Sprintf("creating synthetic Workspace pod %s/%s bound to fake node %q",
+					caseNamespace, wsPodName, fakeNodeName))
+				_, err = clientset.CoreV1().Pods(caseNamespace).Create(ctx, wsPod, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Deleting the original pod cascades the shadow pod and its
+				// ConfigMap via native Kubernetes GC (OwnerReference).
+				DeferCleanup(func() {
+					_ = clientset.CoreV1().Pods(caseNamespace).Delete(
+						context.Background(), wsPodName, metav1.DeleteOptions{})
+				})
+
+				shadowName := "shadow-" + caseNamespace + "-" + wsPodName
+
+				By(fmt.Sprintf("waiting for shadow pod %q to be created and Running", shadowName))
+				Eventually(func() error {
+					shadow, err := clientset.CoreV1().Pods(caseNamespace).Get(ctx, shadowName, metav1.GetOptions{})
+					if err != nil {
+						return fmt.Errorf("get shadow pod %q: %w", shadowName, err)
+					}
+					if shadow.Labels["kaito.sh/managed-by"] != "gpu-mocker" {
+						return fmt.Errorf("shadow pod %q missing managed-by label", shadowName)
+					}
+					if _, ok := shadow.Labels["kaito.sh/shadow-pod-for"]; !ok {
+						return fmt.Errorf("shadow pod %q missing shadow-pod-for label", shadowName)
+					}
+					// The ownership label drives modelharness NetworkPolicy
+					// selection and must be present on Workspace shadow pods too.
+					if shadow.Labels["kaito.sh/owned-by"] != "modeldeployment" {
+						return fmt.Errorf("shadow pod %q missing owned-by label", shadowName)
+					}
+					var ownedByWsPod bool
+					for _, ref := range shadow.OwnerReferences {
+						if ref.Kind == "Pod" && ref.Name == wsPodName {
+							ownedByWsPod = true
+							break
+						}
+					}
+					if !ownedByWsPod {
+						return fmt.Errorf("shadow pod %q should be owned by Workspace pod %q", shadowName, wsPodName)
+					}
+					if shadow.Status.Phase != corev1.PodRunning || shadow.Status.PodIP == "" {
+						return fmt.Errorf("shadow pod %q not Running yet (phase=%s)", shadowName, shadow.Status.Phase)
+					}
+					return nil
+				}, 3*time.Minute, 10*time.Second).Should(Succeed(),
+					"gpu-node-mocker should create a Running shadow pod for the Workspace pod")
+
+				By("verifying the original Workspace pod is patched to Running with the shadow pod IP")
+				Eventually(func() error {
+					orig, err := clientset.CoreV1().Pods(caseNamespace).Get(ctx, wsPodName, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					if orig.Status.Phase != corev1.PodRunning {
+						return fmt.Errorf("workspace pod %q phase = %s, want Running", wsPodName, orig.Status.Phase)
+					}
+					if orig.Status.PodIP == "" {
+						return fmt.Errorf("workspace pod %q has no podIP", wsPodName)
+					}
+					if _, ok := orig.Annotations["kaito.sh/shadow-pod-ref"]; !ok {
+						return fmt.Errorf("workspace pod %q missing shadow-pod-ref annotation", wsPodName)
+					}
+					return nil
+				}, 2*time.Minute, 10*time.Second).Should(Succeed(),
+					"original Workspace pod should be patched to Running with the shadow pod IP")
 			})
 		})
 


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

The Phase-2 shadow pod predicate only recognized InferenceSet(modeldeployment) pods via the inferenceset.kaito.sh/created-by label, so KAITO Workspace (StatefulSet) pods stayed Pending on fake nodes without a shadow pod. Accept either the InferenceSet or the kaito.sh/workspace label so Workspace pods get shadow pods too.

Also drop the unused ShadowPodInferenceSetLabelKey label, which was written but never read; NetworkPolicy selection is driven solely by kaito.sh/owned-by: modeldeployment.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
