### PR TITLE
feat(gpu-node-mocker): filter NodeClaims by nodeClassRef in karpenter mode

### DIFF
--- a/pkg/gpu-node-mocker/controllers/node_claim_controller.go
+++ b/pkg/gpu-node-mocker/controllers/node_claim_controller.go
@@ -31,9 +31,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	karpenterv1 "sigs.k8s.io/karpenter/pkg/apis/v1"
 )
 
@@ -57,6 +59,16 @@ type NodeClaimReconciler struct {
 	client.Client
 	Config Config
 
+	// NodeClassFilter, if non-nil, restricts the reconciler to NodeClaims
+	// whose spec.nodeClassRef matches the given Group+Kind. This lets the
+	// mocker coexist with a real karpenter provider in the same cluster: real
+	// karpenter creates NodeClaims pointing at its own NodeClass
+	// (e.g. karpenter.azure.com/AKSNodeClass) which this filter drops, while
+	// KAITO's NodePool template points at the mock NodeClass and those
+	// NodeClaims are handled here. When nil, all NodeClaims are reconciled
+	// (used by the azure-gpu-provisioner mode where no other provisioner runs).
+	NodeClassFilter *NodeClassRef
+
 	// mu protects cancelFuncs.
 	mu          sync.Mutex
 	cancelFuncs map[string]context.CancelFunc // key = node name
@@ -65,10 +77,35 @@ type NodeClaimReconciler struct {
 // SetupWithManager registers the controller and initialises internal state.
 func (r *NodeClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.cancelFuncs = make(map[string]context.CancelFunc)
-	return ctrl.NewControllerManagedBy(mgr).
-		For(&karpenterv1.NodeClaim{}).
-		Owns(&corev1.Node{}).
-		Complete(r)
+	b := ctrl.NewControllerManagedBy(mgr)
+	if r.NodeClassFilter != nil {
+		nodeClassPred := predicate.NewPredicateFuncs(func(obj client.Object) bool {
+			nc, ok := obj.(*karpenterv1.NodeClaim)
+			if !ok {
+				return false
+			}
+			return r.matchesNodeClassFilter(nc)
+		})
+		b = b.For(&karpenterv1.NodeClaim{}, builder.WithPredicates(nodeClassPred))
+	} else {
+		b = b.For(&karpenterv1.NodeClaim{})
+	}
+	return b.Owns(&corev1.Node{}).Complete(r)
+}
+
+// matchesNodeClassFilter reports whether nc.Spec.NodeClassRef matches the
+// configured NodeClassFilter (matched by Group+Kind; Name is intentionally not
+// compared so multiple NodeClass instances of the same kind are all handled).
+// Returns true when no filter is configured.
+func (r *NodeClaimReconciler) matchesNodeClassFilter(nc *karpenterv1.NodeClaim) bool {
+	if r.NodeClassFilter == nil {
+		return true
+	}
+	ref := nc.Spec.NodeClassRef
+	if ref == nil {
+		return false
+	}
+	return ref.Group == r.NodeClassFilter.Group && ref.Kind == r.NodeClassFilter.Kind
 }
 
 // +kubebuilder:rbac:groups=karpenter.sh,resources=nodeclaims,verbs=get;list;watch;update
@@ -86,6 +123,15 @@ func (r *NodeClaimReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, fmt.Errorf("get NodeClaim: %w", err)
+	}
+
+	// Skip NodeClaims that reference a NodeClass owned by another provisioner
+	// (e.g. a real karpenter install running alongside the mocker). The watch
+	// predicate already filters these out; this is defense-in-depth in case the
+	// reconciler is invoked through a path that bypasses the predicate
+	// (e.g. owned-object events).
+	if !r.matchesNodeClassFilter(nc) {
+		return ctrl.Result{}, nil
 	}
 
 	if !nc.DeletionTimestamp.IsZero() {

--- a/pkg/gpu-node-mocker/controllers/node_claim_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/node_claim_controller_test.go
@@ -768,3 +768,80 @@ func TestReconcile_DeletionPath_StopsLeaseRenewer(t *testing.T) {
 		t.Error("cancelFunc should be removed from map")
 	}
 }
+
+func TestMatchesNodeClassFilter(t *testing.T) {
+	mockRef := DefaultNodeClassRef()
+	withRef := func(group, kind string) *karpenterv1.NodeClaim {
+		nc := newNodeClaim("ws-x")
+		nc.Spec.NodeClassRef = &karpenterv1.NodeClassReference{
+			Group: group, Kind: kind, Name: "any",
+		}
+		return nc
+	}
+
+	tests := []struct {
+		name   string
+		filter *NodeClassRef
+		nc     *karpenterv1.NodeClaim
+		want   bool
+	}{
+		{"nil filter matches anything", nil, withRef("karpenter.azure.com", "AKSNodeClass"), true},
+		{"nil filter matches nil ref", nil, newNodeClaim("ws-y"), true},
+		{"matches mock NodeClass", &mockRef, withRef(MockNodeClassGroup, MockNodeClassKind), true},
+		{"rejects other group", &mockRef, withRef("karpenter.azure.com", MockNodeClassKind), false},
+		{"rejects other kind", &mockRef, withRef(MockNodeClassGroup, "AKSNodeClass"), false},
+		{"rejects nil nodeClassRef", &mockRef, newNodeClaim("ws-z"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := &NodeClaimReconciler{NodeClassFilter: tt.filter}
+			if got := r.matchesNodeClassFilter(tt.nc); got != tt.want {
+				t.Errorf("matchesNodeClassFilter = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestReconcile_SkipsNonMatchingNodeClass(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+
+	// NodeClaim references a NodeClass owned by a different provisioner (real
+	// karpenter's AKSNodeClass) — the mocker must not touch it.
+	nc := newNodeClaim("ws-foreign")
+	nc.Spec.NodeClassRef = &karpenterv1.NodeClassReference{
+		Group: "karpenter.azure.com",
+		Kind:  "AKSNodeClass",
+		Name:  "default",
+	}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(nc).Build()
+	mockRef := DefaultNodeClassRef()
+	r := &NodeClaimReconciler{
+		Client:          cl,
+		Config:          testConfig(),
+		NodeClassFilter: &mockRef,
+		cancelFuncs:     make(map[string]context.CancelFunc),
+	}
+
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "ws-foreign"}}); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	// No fake node, no lease, and no finalizer should be added.
+	if err := cl.Get(ctx, types.NamespacedName{Name: "fake-ws-foreign"}, &corev1.Node{}); err == nil {
+		t.Error("fake node should not be created for foreign NodeClass")
+	}
+	if err := cl.Get(ctx, types.NamespacedName{Namespace: "kube-node-lease", Name: "fake-ws-foreign"}, &coordinationv1.Lease{}); err == nil {
+		t.Error("lease should not be created for foreign NodeClass")
+	}
+	got := &karpenterv1.NodeClaim{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: "ws-foreign"}, got); err != nil {
+		t.Fatalf("get NodeClaim: %v", err)
+	}
+	for _, f := range got.Finalizers {
+		if f == fakeNodeFinalizer {
+			t.Error("finalizer should not be added to foreign NodeClass NodeClaim")
+		}
+	}
+}

--- a/pkg/gpu-node-mocker/controllers/provisioner.go
+++ b/pkg/gpu-node-mocker/controllers/provisioner.go
@@ -149,9 +149,14 @@ func (m *KarpenterMocker) SetupWithManager(mgr ctrl.Manager) error {
 		return fmt.Errorf("unable to create NodePool controller: %w", err)
 	}
 	// Phase 1b: NodeClaim -> fake Node (shared with gpu-provisioner mode).
+	// Filter on the configured mock NodeClass so a real karpenter provider
+	// running in the same cluster can manage its own NodeClaims (e.g. those
+	// referencing karpenter.azure.com/AKSNodeClass) without interference.
+	nodeClass := m.Config.NodeClass
 	if err := (&NodeClaimReconciler{
-		Client: mgr.GetClient(),
-		Config: m.Config,
+		Client:          mgr.GetClient(),
+		Config:          m.Config,
+		NodeClassFilter: &nodeClass,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("unable to create NodeClaim controller: %w", err)
 	}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->


Add an optional NodeClassFilter to NodeClaimReconciler that drops NodeClaims whose spec.nodeClassRef does not match the configured mock NodeClass (matched by Group+Kind). KarpenterMocker now sets the filter so a real karpenter provider running in the same cluster can manage its own AKSNodeClass-backed NodeClaims without interference. GPUProvisionerMocker keeps the previous behavior (no filter).

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
