### PR TITLE
chart(productionstack): bundle gpu-node-mocker as optional subchart

### DIFF
--- a/charts/gpu-node-mocker/templates/_helpers.tpl
+++ b/charts/gpu-node-mocker/templates/_helpers.tpl
@@ -2,8 +2,23 @@
 gpu-node-mocker
 {{- end }}
 
+{{/*
+Fixed object name. Pinned to "gpu-node-mocker" (rather than .Release.Name) so
+the chart is safe to consume as a subchart of the productionstack umbrella —
+the auto-generated ClusterRole hardcodes this name, and a release-name-based
+fullname would mismatch the ClusterRoleBinding's roleRef.
+*/}}
 {{- define "gpu-node-mocker.fullname" -}}
-{{ .Release.Name }}
+gpu-node-mocker
+{{- end }}
+
+{{/*
+Install namespace for namespaced resources. Defaults to the release namespace;
+override via `namespaceOverride` when installed as a subchart so the mocker
+can be pinned to a namespace independent of the umbrella release.
+*/}}
+{{- define "gpu-node-mocker.namespace" -}}
+{{- default .Release.Namespace .Values.namespaceOverride -}}
 {{- end }}
 
 {{- define "gpu-node-mocker.labels" -}}

--- a/charts/gpu-node-mocker/templates/clusterrolebinding.yaml
+++ b/charts/gpu-node-mocker/templates/clusterrolebinding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "gpu-node-mocker.fullname" . }}
-    namespace: {{ .Release.Namespace }}
+    namespace: {{ include "gpu-node-mocker.namespace" . }}

--- a/charts/gpu-node-mocker/templates/deployment.yaml
+++ b/charts/gpu-node-mocker/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "gpu-node-mocker.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "gpu-node-mocker.namespace" . }}
   labels:
     {{- include "gpu-node-mocker.labels" . | nindent 4 }}
     app.kubernetes.io/component: controller

--- a/charts/gpu-node-mocker/templates/serviceaccount.yaml
+++ b/charts/gpu-node-mocker/templates/serviceaccount.yaml
@@ -2,6 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "gpu-node-mocker.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "gpu-node-mocker.namespace" . }}
   labels:
     {{- include "gpu-node-mocker.labels" . | nindent 4 }}

--- a/charts/gpu-node-mocker/values.yaml
+++ b/charts/gpu-node-mocker/values.yaml
@@ -1,3 +1,10 @@
+# Install namespace for namespaced resources (Deployment, ServiceAccount,
+# RoleBinding subject). Empty string ⇒ inherit the Helm release namespace
+# (standard Helm behavior). Used when consumed as a subchart of the
+# productionstack umbrella so the mocker can live in a dedicated namespace
+# (e.g. kaito-system) independent of the umbrella release namespace.
+namespaceOverride: ""
+
 image:
   # REQUIRED: set via --set image.repository=<your-acr>.azurecr.io/gpu-node-mocker
   repository: ""

--- a/charts/productionstack/Chart.lock
+++ b/charts/productionstack/Chart.lock
@@ -5,8 +5,11 @@ dependencies:
 - name: keda-kaito-scaler
   repository: ""
   version: 0.5.1
+- name: gpu-node-mocker
+  repository: file://../gpu-node-mocker
+  version: 0.2.1
 - name: llm-gateway-apikey
   repository: oci://mcr.microsoft.com/aks/kaito/helm
   version: 0.0.11-alpha
-digest: sha256:9cbc31e446d9ac8e19f5dff91ca60b2b5ad3e495b3d67e73b981f034d2bd2ce4
-generated: "2026-06-17T15:36:54.34743639+10:00"
+digest: sha256:0e09236751860f8ff6cf6338976b5c34a4cdb3e416fa7e5ef58d80a6b1656683
+generated: "2026-06-26T10:08:16.398427+10:00"

--- a/charts/productionstack/Chart.yaml
+++ b/charts/productionstack/Chart.yaml
@@ -46,6 +46,21 @@ dependencies:
     version: 0.5.1
     tags:
       - autoscaling
+  # In-tree gpu-node-mocker chart. Sourced via a `file://` repository
+  # so the standalone chart at `charts/gpu-node-mocker` remains the
+  # single source of truth (still published independently to OCI / gh-
+  # pages); `helm dependency update charts/productionstack` packages
+  # it and vendors the tarball into `charts/productionstack/charts/`.
+  # Gated behind `gpu-node-mocker.enabled` because the mocker requires
+  # an `image.repository` and is only relevant for E2E / dev clusters
+  # that don't have a real GPU node provisioner.
+  - name: gpu-node-mocker
+    version: 0.2.1
+    repository: file://../gpu-node-mocker
+    condition: gpu-node-mocker.enabled
+    tags:
+      - node-provisioner
+      - mocker
   # Upstream API-key ext_authz chart, pulled from the kaito-project OCI
   # registry at `helm dependency update` time (no in-tree fork). Values
   # are passed through under the upstream chart name `llm-gateway-apikey`

--- a/charts/productionstack/templates/NOTES.txt
+++ b/charts/productionstack/templates/NOTES.txt
@@ -7,6 +7,10 @@ Enabled cluster-level components:
 {{- if index .Values "keda-kaito-scaler" "enabled" }}
   - keda-kaito-scaler (KEDA external scaler for vLLM / InferenceSet)
 {{- end }}
+{{- if index .Values "gpu-node-mocker" "enabled" }}
+  - gpu-node-mocker (mock GPU node provisioner for E2E / dev clusters,
+    --node-provisioner={{ index .Values "gpu-node-mocker" "nodeProvisioner" | default "karpenter" }})
+{{- end }}
 {{- if index .Values "llm-gateway-apikey" "enabled" }}
   - llm-gateway-apikey (APIKey CRD + apikey-operator + apikey-authz gRPC
     Service in `{{ index .Values "llm-gateway-apikey" "namespaceOverride" | default .Release.Namespace }}`).

--- a/charts/productionstack/values.yaml
+++ b/charts/productionstack/values.yaml
@@ -61,6 +61,23 @@ keda-kaito-scaler:
   # inherit the umbrella release namespace instead.
   namespaceOverride: keda
 
+# GPU Node Mocker — fakes a Karpenter / azure-gpu-provisioner node
+# provisioner for E2E and dev clusters that don't have real GPU
+# capacity. Disabled by default because it requires an image push
+# (`image.repository` has no sensible default) and is irrelevant on
+# clusters that already run a real provisioner. Enable with:
+#   --set gpu-node-mocker.enabled=true \
+#   --set gpu-node-mocker.image.repository=<your-acr>/gpu-node-mocker \
+#   --set gpu-node-mocker.image.tag=<tag>
+# See charts/gpu-node-mocker/values.yaml for the full value reference.
+gpu-node-mocker:
+  enabled: false
+  # Inherit the umbrella release namespace (kaito-system by default).
+  # The mocker's ClusterRole is cluster-scoped and named
+  # `gpu-node-mocker`, so at most one instance can exist per cluster
+  # regardless of namespace.
+  namespaceOverride: ""
+
 # LLM Gateway Auth — API-key ext_authz for the inference Gateway.
 # Pulled from the upstream `oci://mcr.microsoft.com/aks/kaito/helm`
 # registry as a Helm dependency (no in-tree fork); run


### PR DESCRIPTION


**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

Add gpu-node-mocker as a file:// Helm dependency of the productionstack umbrella, gated on gpu-node-mocker.enabled (default false). The standalone chart at charts/gpu-node-mocker remains the single source of truth and continues to publish independently.

Pin gpu-node-mocker.fullname to the literal "gpu-node-mocker" so the ClusterRoleBinding's roleRef matches the hardcoded ClusterRole name regardless of release name (previously only worked when installed as release "gpu-node-mocker"), and add a namespaceOverride knob matching the other subcharts.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
