### PR TITLE
make shadow-pod inference latency configurable

### DIFF
--- a/charts/gpu-node-mocker/templates/deployment.yaml
+++ b/charts/gpu-node-mocker/templates/deployment.yaml
@@ -34,6 +34,12 @@ spec:
             - --kv-cache-transfer-latency={{ .Values.shadowPod.kvCacheTransferLatency }}
             - --kv-cache-transfer-latency-std-dev={{ .Values.shadowPod.kvCacheTransferLatencyStdDev }}
             - --time-factor-under-load={{ .Values.shadowPod.timeFactorUnderLoad }}
+            - --latency-calculator={{ .Values.shadowPod.latencyCalculator }}
+            - --prefill-overhead={{ .Values.shadowPod.prefillOverhead }}
+            - --prefill-time-per-token={{ .Values.shadowPod.prefillTimePerToken }}
+            - --prefill-time-std-dev={{ .Values.shadowPod.prefillTimeStdDev }}
+            - --kv-cache-transfer-time-per-token={{ .Values.shadowPod.kvCacheTransferTimePerToken }}
+            - --kv-cache-transfer-time-std-dev={{ .Values.shadowPod.kvCacheTransferTimeStdDev }}
             - --lease-duration-seconds={{ .Values.leaseDurationSeconds }}
             - --lease-renew-interval-seconds={{ .Values.leaseRenewIntervalSeconds }}
             - --node-provisioner={{ .Values.nodeProvisioner }}

--- a/charts/gpu-node-mocker/templates/deployment.yaml
+++ b/charts/gpu-node-mocker/templates/deployment.yaml
@@ -27,6 +27,13 @@ spec:
             - --health-probe-bind-address=:8081
             - --shadow-pod-image={{ .Values.shadowPod.image }}
             - --uds-tokenizer-image={{ .Values.shadowPod.udsTokenizerImage }}
+            - --time-to-first-token={{ .Values.shadowPod.timeToFirstToken }}
+            - --inter-token-latency={{ .Values.shadowPod.interTokenLatency }}
+            - --time-to-first-token-std-dev={{ .Values.shadowPod.timeToFirstTokenStdDev }}
+            - --inter-token-latency-std-dev={{ .Values.shadowPod.interTokenLatencyStdDev }}
+            - --kv-cache-transfer-latency={{ .Values.shadowPod.kvCacheTransferLatency }}
+            - --kv-cache-transfer-latency-std-dev={{ .Values.shadowPod.kvCacheTransferLatencyStdDev }}
+            - --time-factor-under-load={{ .Values.shadowPod.timeFactorUnderLoad }}
             - --lease-duration-seconds={{ .Values.leaseDurationSeconds }}
             - --lease-renew-interval-seconds={{ .Values.leaseRenewIntervalSeconds }}
             - --node-provisioner={{ .Values.nodeProvisioner }}

--- a/charts/gpu-node-mocker/values.yaml
+++ b/charts/gpu-node-mocker/values.yaml
@@ -14,6 +14,17 @@ image:
 shadowPod:
   image: ghcr.io/llm-d/llm-d-inference-sim:v0.8.1
   udsTokenizerImage: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.6.0
+  # Inference simulator "constant" latency calculator knobs. Defaults mirror
+  # an 8B-class model on H100 under balanced load (Profile 1 in
+  # llm-d-inference-sim/docs/latency-profiles.md). Override to mimic other
+  # model/hardware combinations.
+  timeToFirstToken: 100ms
+  interTokenLatency: 30ms
+  timeToFirstTokenStdDev: 20ms
+  interTokenLatencyStdDev: 2ms
+  kvCacheTransferLatency: 2ms
+  kvCacheTransferLatencyStdDev: 400us
+  timeFactorUnderLoad: "2.0"
 
 # nodeProvisioner selects which KAITO node provisioner to mock.
 # Must match KAITO's --node-provisioner value: azure-gpu-provisioner or karpenter.

--- a/charts/gpu-node-mocker/values.yaml
+++ b/charts/gpu-node-mocker/values.yaml
@@ -19,12 +19,21 @@ shadowPod:
   # llm-d-inference-sim/docs/latency-profiles.md). Override to mimic other
   # model/hardware combinations.
   timeToFirstToken: 100ms
-  interTokenLatency: 30ms
+  interTokenLatency: 12ms
   timeToFirstTokenStdDev: 20ms
   interTokenLatencyStdDev: 2ms
   kvCacheTransferLatency: 2ms
   kvCacheTransferLatencyStdDev: 400us
   timeFactorUnderLoad: "2.0"
+  # latencyCalculator selects the simulator latency model: "constant" (default,
+  # TTFT is a fixed value) or "per-token" (TTFT scales with prompt length via
+  # the prefill* knobs below). The per-token defaults also follow Profile 1.
+  latencyCalculator: constant
+  prefillOverhead: 30ms
+  prefillTimePerToken: 250us
+  prefillTimeStdDev: 5ms
+  kvCacheTransferTimePerToken: 3us
+  kvCacheTransferTimeStdDev: 200us
 
 # nodeProvisioner selects which KAITO node provisioner to mock.
 # Must match KAITO's --node-provisioner value: azure-gpu-provisioner or karpenter.

--- a/cmd/gpu-node-mocker/main.go
+++ b/cmd/gpu-node-mocker/main.go
@@ -65,6 +65,13 @@ func main() {
 		probeAddr             string
 		shadowPodImage        string
 		udsTokenizerImage     string
+		timeToFirstToken      string
+		interTokenLatency     string
+		ttftStdDev            string
+		itlStdDev             string
+		kvCacheTransfer       string
+		kvCacheTransferStdDev string
+		timeFactorUnderLoad   string
 		leaseDurationSec      int
 		leaseRenewIntervalSec int
 		nodeProvisioner       string
@@ -82,6 +89,20 @@ func main() {
 		"Container image for the inference simulator running in shadow pods.")
 	flag.StringVar(&udsTokenizerImage, "uds-tokenizer-image", controllers.DefaultUDSTokenizerImage,
 		"Container image for the UDS tokenizer sidecar in shadow pods.")
+	flag.StringVar(&timeToFirstToken, "time-to-first-token", controllers.DefaultTimeToFirstToken,
+		"Inference simulator time-to-first-token latency (e.g. 100ms). See llm-d-inference-sim latency-profiles.md.")
+	flag.StringVar(&interTokenLatency, "inter-token-latency", controllers.DefaultInterTokenLatency,
+		"Inference simulator inter-token latency (e.g. 30ms). See llm-d-inference-sim latency-profiles.md.")
+	flag.StringVar(&ttftStdDev, "time-to-first-token-std-dev", controllers.DefaultTimeToFirstTokenStdDev,
+		"Std-dev jitter for time-to-first-token (e.g. 20ms).")
+	flag.StringVar(&itlStdDev, "inter-token-latency-std-dev", controllers.DefaultInterTokenLatencyStdDev,
+		"Std-dev jitter for inter-token latency (e.g. 2ms).")
+	flag.StringVar(&kvCacheTransfer, "kv-cache-transfer-latency", controllers.DefaultKVCacheTransferLatency,
+		"Constant KV-cache transfer overhead (e.g. 2ms).")
+	flag.StringVar(&kvCacheTransferStdDev, "kv-cache-transfer-latency-std-dev", controllers.DefaultKVCacheTransferStdDev,
+		"Std-dev jitter for KV-cache transfer latency (e.g. 400us).")
+	flag.StringVar(&timeFactorUnderLoad, "time-factor-under-load", controllers.DefaultTimeFactorUnderLoad,
+		"Latency multiplier as concurrency approaches max-num-seqs (e.g. 2.0).")
 	flag.IntVar(&leaseDurationSec, "lease-duration-seconds", 40,
 		"Duration in seconds for fake node lease.")
 	flag.IntVar(&leaseRenewIntervalSec, "lease-renew-interval-seconds", 10,
@@ -113,10 +134,17 @@ func main() {
 	}
 
 	cfg := controllers.Config{
-		ShadowPodImage:        shadowPodImage,
-		UDSTokenizerImage:     udsTokenizerImage,
-		LeaseDurationSec:      int32(leaseDurationSec),
-		LeaseRenewIntervalSec: leaseRenewIntervalSec,
+		ShadowPodImage:          shadowPodImage,
+		UDSTokenizerImage:       udsTokenizerImage,
+		TimeToFirstToken:        timeToFirstToken,
+		InterTokenLatency:       interTokenLatency,
+		TimeToFirstTokenStdDev:  ttftStdDev,
+		InterTokenLatencyStdDev: itlStdDev,
+		KVCacheTransferLatency:  kvCacheTransfer,
+		KVCacheTransferStdDev:   kvCacheTransferStdDev,
+		TimeFactorUnderLoad:     timeFactorUnderLoad,
+		LeaseDurationSec:        int32(leaseDurationSec),
+		LeaseRenewIntervalSec:   leaseRenewIntervalSec,
 		NodeClass: controllers.NodeClassRef{
 			Group:    nodeClassGroup,
 			Version:  nodeClassVersion,

--- a/cmd/gpu-node-mocker/main.go
+++ b/cmd/gpu-node-mocker/main.go
@@ -61,24 +61,30 @@ func init() {
 
 func main() {
 	var (
-		metricsAddr           string
-		probeAddr             string
-		shadowPodImage        string
-		udsTokenizerImage     string
-		timeToFirstToken      string
-		interTokenLatency     string
-		ttftStdDev            string
-		itlStdDev             string
-		kvCacheTransfer       string
-		kvCacheTransferStdDev string
-		timeFactorUnderLoad   string
-		leaseDurationSec      int
-		leaseRenewIntervalSec int
-		nodeProvisioner       string
-		nodeClassGroup        string
-		nodeClassVersion      string
-		nodeClassKind         string
-		nodeClassResource     string
+		metricsAddr            string
+		probeAddr              string
+		shadowPodImage         string
+		udsTokenizerImage      string
+		timeToFirstToken       string
+		interTokenLatency      string
+		ttftStdDev             string
+		itlStdDev              string
+		kvCacheTransfer        string
+		kvCacheTransferStdDev  string
+		timeFactorUnderLoad    string
+		latencyCalculator      string
+		prefillOverhead        string
+		prefillTimePerToken    string
+		prefillTimeStdDev      string
+		kvTransferTimePerToken string
+		kvTransferTimeStdDev   string
+		leaseDurationSec       int
+		leaseRenewIntervalSec  int
+		nodeProvisioner        string
+		nodeClassGroup         string
+		nodeClassVersion       string
+		nodeClassKind          string
+		nodeClassResource      string
 	)
 
 	defaultNodeClass := controllers.DefaultNodeClassRef()
@@ -103,6 +109,19 @@ func main() {
 		"Std-dev jitter for KV-cache transfer latency (e.g. 400us).")
 	flag.StringVar(&timeFactorUnderLoad, "time-factor-under-load", controllers.DefaultTimeFactorUnderLoad,
 		"Latency multiplier as concurrency approaches max-num-seqs (e.g. 2.0).")
+	flag.StringVar(&latencyCalculator, "latency-calculator", controllers.DefaultLatencyCalculator,
+		fmt.Sprintf("Inference simulator latency model (%q or %q).",
+			controllers.LatencyCalculatorConstant, controllers.LatencyCalculatorPerToken))
+	flag.StringVar(&prefillOverhead, "prefill-overhead", controllers.DefaultPrefillOverhead,
+		"per-token calculator: fixed prefill overhead (e.g. 30ms).")
+	flag.StringVar(&prefillTimePerToken, "prefill-time-per-token", controllers.DefaultPrefillTimePerToken,
+		"per-token calculator: prefill cost per prompt token (e.g. 250us).")
+	flag.StringVar(&prefillTimeStdDev, "prefill-time-std-dev", controllers.DefaultPrefillTimeStdDev,
+		"per-token calculator: std-dev jitter for prefill time (e.g. 5ms).")
+	flag.StringVar(&kvTransferTimePerToken, "kv-cache-transfer-time-per-token", controllers.DefaultKVCacheTransferTimePerToken,
+		"per-token calculator: KV-cache transfer cost per token (e.g. 3us).")
+	flag.StringVar(&kvTransferTimeStdDev, "kv-cache-transfer-time-std-dev", controllers.DefaultKVCacheTransferTimeStdDev,
+		"per-token calculator: std-dev jitter for KV-cache transfer time (e.g. 200us).")
 	flag.IntVar(&leaseDurationSec, "lease-duration-seconds", 40,
 		"Duration in seconds for fake node lease.")
 	flag.IntVar(&leaseRenewIntervalSec, "lease-renew-interval-seconds", 10,
@@ -132,19 +151,31 @@ func main() {
 		setupLog.Error(nil, "--lease-duration-seconds must be > 0")
 		os.Exit(1)
 	}
+	if latencyCalculator != controllers.LatencyCalculatorConstant &&
+		latencyCalculator != controllers.LatencyCalculatorPerToken {
+		setupLog.Error(nil, "--latency-calculator must be \"constant\" or \"per-token\"",
+			"value", latencyCalculator)
+		os.Exit(1)
+	}
 
 	cfg := controllers.Config{
-		ShadowPodImage:          shadowPodImage,
-		UDSTokenizerImage:       udsTokenizerImage,
-		TimeToFirstToken:        timeToFirstToken,
-		InterTokenLatency:       interTokenLatency,
-		TimeToFirstTokenStdDev:  ttftStdDev,
-		InterTokenLatencyStdDev: itlStdDev,
-		KVCacheTransferLatency:  kvCacheTransfer,
-		KVCacheTransferStdDev:   kvCacheTransferStdDev,
-		TimeFactorUnderLoad:     timeFactorUnderLoad,
-		LeaseDurationSec:        int32(leaseDurationSec),
-		LeaseRenewIntervalSec:   leaseRenewIntervalSec,
+		ShadowPodImage:              shadowPodImage,
+		UDSTokenizerImage:           udsTokenizerImage,
+		TimeToFirstToken:            timeToFirstToken,
+		InterTokenLatency:           interTokenLatency,
+		TimeToFirstTokenStdDev:      ttftStdDev,
+		InterTokenLatencyStdDev:     itlStdDev,
+		KVCacheTransferLatency:      kvCacheTransfer,
+		KVCacheTransferStdDev:       kvCacheTransferStdDev,
+		TimeFactorUnderLoad:         timeFactorUnderLoad,
+		LatencyCalculator:           latencyCalculator,
+		PrefillOverhead:             prefillOverhead,
+		PrefillTimePerToken:         prefillTimePerToken,
+		PrefillTimeStdDev:           prefillTimeStdDev,
+		KVCacheTransferTimePerToken: kvTransferTimePerToken,
+		KVCacheTransferTimeStdDev:   kvTransferTimeStdDev,
+		LeaseDurationSec:            int32(leaseDurationSec),
+		LeaseRenewIntervalSec:       leaseRenewIntervalSec,
 		NodeClass: controllers.NodeClassRef{
 			Group:    nodeClassGroup,
 			Version:  nodeClassVersion,

--- a/pkg/gpu-node-mocker/README.md
+++ b/pkg/gpu-node-mocker/README.md
@@ -61,27 +61,57 @@
 
 ## Inference latency profile
 
-The shadow pod runs `llm-d-inference-sim`, configured via its `constant` latency
-calculator so mocked endpoints behave closer to real vLLM serving instead of
-responding instantly. The defaults mirror **Profile 1 — 8B-class model on H100,
+The shadow pod runs `llm-d-inference-sim`, configured with a latency calculator
+so mocked endpoints behave closer to real vLLM serving instead of responding
+instantly. `shadowPod.latencyCalculator` selects the model — `constant` (default)
+or `per-token` — and the defaults mirror **Profile 1 — 8B-class model on H100,
 balanced load** from the upstream [latency-profiles.md](https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/latency-profiles.md).
+
+### Common settings (both calculators)
+
+| Setting | Helm value (`shadowPod.*`) | Flag | Default |
+| --- | --- | --- | --- |
+| Latency calculator | `latencyCalculator` | `--latency-calculator` | `constant` |
+| Inter-token latency | `interTokenLatency` | `--inter-token-latency` | `12ms` |
+| Inter-token std-dev | `interTokenLatencyStdDev` | `--inter-token-latency-std-dev` | `2ms` |
+| Time factor under load | `timeFactorUnderLoad` | `--time-factor-under-load` | `2.0` |
+
+### `constant` calculator (TTFT is a fixed value)
 
 | Setting | Helm value (`shadowPod.*`) | Flag | Default |
 | --- | --- | --- | --- |
 | Time to first token | `timeToFirstToken` | `--time-to-first-token` | `100ms` |
-| Inter-token latency | `interTokenLatency` | `--inter-token-latency` | `30ms` |
 | TTFT std-dev | `timeToFirstTokenStdDev` | `--time-to-first-token-std-dev` | `20ms` |
-| Inter-token std-dev | `interTokenLatencyStdDev` | `--inter-token-latency-std-dev` | `2ms` |
 | KV-cache transfer latency | `kvCacheTransferLatency` | `--kv-cache-transfer-latency` | `2ms` |
 | KV-cache transfer std-dev | `kvCacheTransferLatencyStdDev` | `--kv-cache-transfer-latency-std-dev` | `400us` |
-| Time factor under load | `timeFactorUnderLoad` | `--time-factor-under-load` | `2.0` |
 
-Override per-deployment to mimic other model/hardware combinations, e.g. a 70B
-TP=8 throughput profile:
+### `per-token` calculator (TTFT scales with prompt length)
+
+| Setting | Helm value (`shadowPod.*`) | Flag | Default |
+| --- | --- | --- | --- |
+| Prefill overhead | `prefillOverhead` | `--prefill-overhead` | `30ms` |
+| Prefill time per token | `prefillTimePerToken` | `--prefill-time-per-token` | `250us` |
+| Prefill time std-dev | `prefillTimeStdDev` | `--prefill-time-std-dev` | `5ms` |
+| KV-cache transfer time per token | `kvCacheTransferTimePerToken` | `--kv-cache-transfer-time-per-token` | `3us` |
+| KV-cache transfer time std-dev | `kvCacheTransferTimeStdDev` | `--kv-cache-transfer-time-std-dev` | `200us` |
+
+Only the fields for the selected calculator are written into the simulator
+config. Override per-deployment to mimic other model/hardware combinations, e.g.
+a 70B TP=8 throughput profile on the `constant` calculator:
 
 ```yaml
 shadowPod:
+  latencyCalculator: constant
   timeToFirstToken: 200ms
   interTokenLatency: 25ms
   timeFactorUnderLoad: "3.0"
+```
+
+Or switch to the `per-token` calculator so TTFT reflects prompt length:
+
+```yaml
+shadowPod:
+  latencyCalculator: per-token
+  prefillOverhead: 30ms
+  prefillTimePerToken: 250us
 ```

--- a/pkg/gpu-node-mocker/README.md
+++ b/pkg/gpu-node-mocker/README.md
@@ -58,3 +58,30 @@
 - **Creates a shadow pod** for each inference pod that's Pending on a fake node — the shadow pod runs the `llm-mocker` image on a real AKS node and gets a real CNI IP.
 - **Patches the inference pod's status** — copies the shadow pod's IP into the inference pod's `status.podIP`, sets `phase=Running`, `conditions[Ready]=True`, and builds fake `containerStatuses`. This makes KAITO think the inference pod is running.
 - **Annotates the inference pod** with `kaito.sh/shadow-pod-ref` pointing to the shadow pod, so future reconciles can correlate them.
+
+## Inference latency profile
+
+The shadow pod runs `llm-d-inference-sim`, configured via its `constant` latency
+calculator so mocked endpoints behave closer to real vLLM serving instead of
+responding instantly. The defaults mirror **Profile 1 — 8B-class model on H100,
+balanced load** from the upstream [latency-profiles.md](https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/latency-profiles.md).
+
+| Setting | Helm value (`shadowPod.*`) | Flag | Default |
+| --- | --- | --- | --- |
+| Time to first token | `timeToFirstToken` | `--time-to-first-token` | `100ms` |
+| Inter-token latency | `interTokenLatency` | `--inter-token-latency` | `30ms` |
+| TTFT std-dev | `timeToFirstTokenStdDev` | `--time-to-first-token-std-dev` | `20ms` |
+| Inter-token std-dev | `interTokenLatencyStdDev` | `--inter-token-latency-std-dev` | `2ms` |
+| KV-cache transfer latency | `kvCacheTransferLatency` | `--kv-cache-transfer-latency` | `2ms` |
+| KV-cache transfer std-dev | `kvCacheTransferLatencyStdDev` | `--kv-cache-transfer-latency-std-dev` | `400us` |
+| Time factor under load | `timeFactorUnderLoad` | `--time-factor-under-load` | `2.0` |
+
+Override per-deployment to mimic other model/hardware combinations, e.g. a 70B
+TP=8 throughput profile:
+
+```yaml
+shadowPod:
+  timeToFirstToken: 200ms
+  interTokenLatency: 25ms
+  timeFactorUnderLoad: "3.0"
+```

--- a/pkg/gpu-node-mocker/controllers/config.go
+++ b/pkg/gpu-node-mocker/controllers/config.go
@@ -95,7 +95,7 @@ const (
 	// in llm-d-inference-sim/docs/latency-profiles.md). Override per-deployment
 	// to mimic other model/hardware combinations.
 	DefaultTimeToFirstToken  = "100ms"
-	DefaultInterTokenLatency = "30ms"
+	DefaultInterTokenLatency = "12ms"
 
 	// Default*StdDev add jitter so the simulator does not emit flat latencies.
 	// DefaultTimeFactorUnderLoad scales latency as concurrency approaches
@@ -106,6 +106,23 @@ const (
 	DefaultKVCacheTransferLatency  = "2ms"
 	DefaultKVCacheTransferStdDev   = "400us"
 	DefaultTimeFactorUnderLoad     = "2.0"
+
+	// LatencyCalculatorConstant / LatencyCalculatorPerToken are the two
+	// llm-d-inference-sim latency models. "constant" derives TTFT from a fixed
+	// value; "per-token" derives it from prompt length via prefill overhead +
+	// per-token cost. See llm-d-inference-sim/docs/latency-profiles.md.
+	LatencyCalculatorConstant = "constant"
+	LatencyCalculatorPerToken = "per-token"
+	DefaultLatencyCalculator  = LatencyCalculatorConstant
+
+	// Default per-token calculator knobs (Profile 1: 8B/H100). PrefillOverhead
+	// is the fixed prefill cost; PrefillTimePerToken scales with prompt length;
+	// KVCacheTransferTimePerToken is the per-token cache transfer cost.
+	DefaultPrefillOverhead             = "30ms"
+	DefaultPrefillTimePerToken         = "250us"
+	DefaultPrefillTimeStdDev           = "5ms"
+	DefaultKVCacheTransferTimePerToken = "3us"
+	DefaultKVCacheTransferTimeStdDev   = "200us"
 
 	// InferenceSimPort is the default port for the inference simulator.
 	InferenceSimPort = 8001
@@ -198,6 +215,20 @@ type Config struct {
 	KVCacheTransferLatency  string
 	KVCacheTransferStdDev   string
 	TimeFactorUnderLoad     string
+
+	// LatencyCalculator selects the simulator latency model: "constant"
+	// (default) or "per-token". The per-token model derives TTFT from prompt
+	// length and uses the Prefill*/KVCacheTransferTime* knobs below instead of
+	// TimeToFirstToken / KVCacheTransferLatency.
+	LatencyCalculator string
+
+	// Per-token calculator knobs. Used only when LatencyCalculator is
+	// "per-token". See llm-d-inference-sim/docs/latency-profiles.md.
+	PrefillOverhead             string
+	PrefillTimePerToken         string
+	PrefillTimeStdDev           string
+	KVCacheTransferTimePerToken string
+	KVCacheTransferTimeStdDev   string
 
 	// LeaseDurationSec is the Lease.spec.leaseDurationSeconds written to the
 	// kube-node-lease Lease for each fake node.

--- a/pkg/gpu-node-mocker/controllers/config.go
+++ b/pkg/gpu-node-mocker/controllers/config.go
@@ -89,6 +89,24 @@ const (
 	// DefaultUDSTokenizerImage is the default UDS tokenizer sidecar image.
 	DefaultUDSTokenizerImage = "ghcr.io/llm-d/llm-d-uds-tokenizer:v0.6.0"
 
+	// DefaultTimeToFirstToken / DefaultInterTokenLatency are the simulator
+	// latency knobs passed to llm-d-inference-sim's "constant" calculator. The
+	// defaults mirror an 8B-class model on H100 under balanced load (Profile 1
+	// in llm-d-inference-sim/docs/latency-profiles.md). Override per-deployment
+	// to mimic other model/hardware combinations.
+	DefaultTimeToFirstToken  = "100ms"
+	DefaultInterTokenLatency = "30ms"
+
+	// Default*StdDev add jitter so the simulator does not emit flat latencies.
+	// DefaultTimeFactorUnderLoad scales latency as concurrency approaches
+	// max-num-seqs. DefaultKVCacheTransferLatency models the constant
+	// prefill-cache transfer overhead. Values follow Profile 1.
+	DefaultTimeToFirstTokenStdDev  = "20ms"
+	DefaultInterTokenLatencyStdDev = "2ms"
+	DefaultKVCacheTransferLatency  = "2ms"
+	DefaultKVCacheTransferStdDev   = "400us"
+	DefaultTimeFactorUnderLoad     = "2.0"
+
 	// InferenceSimPort is the default port for the inference simulator.
 	InferenceSimPort = 8001
 
@@ -164,6 +182,22 @@ type Config struct {
 
 	// UDSTokenizerImage is the UDS tokenizer sidecar image.
 	UDSTokenizerImage string
+
+	// TimeToFirstToken / InterTokenLatency tune the llm-d-inference-sim
+	// "constant" latency calculator (values include a unit suffix, e.g.
+	// "100ms"). See llm-d-inference-sim/docs/latency-profiles.md.
+	TimeToFirstToken  string
+	InterTokenLatency string
+
+	// Latency jitter and load-scaling knobs for the "constant" calculator.
+	// StdDev values add jitter; TimeFactorUnderLoad scales latency as
+	// concurrency approaches max-num-seqs; KVCacheTransfer* model prefill-cache
+	// transfer overhead. See llm-d-inference-sim/docs/latency-profiles.md.
+	TimeToFirstTokenStdDev  string
+	InterTokenLatencyStdDev string
+	KVCacheTransferLatency  string
+	KVCacheTransferStdDev   string
+	TimeFactorUnderLoad     string
 
 	// LeaseDurationSec is the Lease.spec.leaseDurationSeconds written to the
 	// kube-node-lease Lease for each fake node.

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
@@ -476,6 +476,14 @@ func makePodCondition(t corev1.PodConditionType, s corev1.ConditionStatus, reaso
 	}
 }
 
+// valueOrDefault returns v if it is non-empty, otherwise def.
+func valueOrDefault(v, def string) string {
+	if v == "" {
+		return def
+	}
+	return v
+}
+
 // ensureSimConfigMap creates the inference simulator ConfigMap if it does not exist.
 // The config enables KV cache but does not set any threshold so cache_threshold
 // is never triggered. The port is set to match the original pod's serving port.
@@ -489,33 +497,52 @@ func (r *ShadowPodReconciler) ensureSimConfigMap(ctx context.Context, namespace,
 		return nil
 	}
 
-	ttft := r.Config.TimeToFirstToken
-	if ttft == "" {
-		ttft = DefaultTimeToFirstToken
-	}
 	itl := r.Config.InterTokenLatency
 	if itl == "" {
 		itl = DefaultInterTokenLatency
-	}
-	ttftStdDev := r.Config.TimeToFirstTokenStdDev
-	if ttftStdDev == "" {
-		ttftStdDev = DefaultTimeToFirstTokenStdDev
 	}
 	itlStdDev := r.Config.InterTokenLatencyStdDev
 	if itlStdDev == "" {
 		itlStdDev = DefaultInterTokenLatencyStdDev
 	}
-	kvTransfer := r.Config.KVCacheTransferLatency
-	if kvTransfer == "" {
-		kvTransfer = DefaultKVCacheTransferLatency
-	}
-	kvTransferStdDev := r.Config.KVCacheTransferStdDev
-	if kvTransferStdDev == "" {
-		kvTransferStdDev = DefaultKVCacheTransferStdDev
-	}
 	timeFactor := r.Config.TimeFactorUnderLoad
 	if timeFactor == "" {
 		timeFactor = DefaultTimeFactorUnderLoad
+	}
+	calculator := r.Config.LatencyCalculator
+	if calculator == "" {
+		calculator = DefaultLatencyCalculator
+	}
+
+	// Fields common to both calculators.
+	latencyYAML := fmt.Sprintf(`latency-calculator: %s
+inter-token-latency: %s
+inter-token-latency-std-dev: %s
+time-factor-under-load: %s
+`, calculator, itl, itlStdDev, timeFactor)
+
+	if calculator == LatencyCalculatorPerToken {
+		prefillOverhead := valueOrDefault(r.Config.PrefillOverhead, DefaultPrefillOverhead)
+		prefillPerToken := valueOrDefault(r.Config.PrefillTimePerToken, DefaultPrefillTimePerToken)
+		prefillStdDev := valueOrDefault(r.Config.PrefillTimeStdDev, DefaultPrefillTimeStdDev)
+		kvPerToken := valueOrDefault(r.Config.KVCacheTransferTimePerToken, DefaultKVCacheTransferTimePerToken)
+		kvTimeStdDev := valueOrDefault(r.Config.KVCacheTransferTimeStdDev, DefaultKVCacheTransferTimeStdDev)
+		latencyYAML += fmt.Sprintf(`prefill-overhead: %s
+prefill-time-per-token: %s
+prefill-time-std-dev: %s
+kv-cache-transfer-time-per-token: %s
+kv-cache-transfer-time-std-dev: %s
+`, prefillOverhead, prefillPerToken, prefillStdDev, kvPerToken, kvTimeStdDev)
+	} else {
+		ttft := valueOrDefault(r.Config.TimeToFirstToken, DefaultTimeToFirstToken)
+		ttftStdDev := valueOrDefault(r.Config.TimeToFirstTokenStdDev, DefaultTimeToFirstTokenStdDev)
+		kvTransfer := valueOrDefault(r.Config.KVCacheTransferLatency, DefaultKVCacheTransferLatency)
+		kvTransferStdDev := valueOrDefault(r.Config.KVCacheTransferStdDev, DefaultKVCacheTransferStdDev)
+		latencyYAML += fmt.Sprintf(`time-to-first-token: %s
+time-to-first-token-std-dev: %s
+kv-cache-transfer-latency: %s
+kv-cache-transfer-latency-std-dev: %s
+`, ttft, ttftStdDev, kvTransfer, kvTransferStdDev)
 	}
 
 	configYAML := fmt.Sprintf(`port: %d
@@ -528,14 +555,7 @@ max-model-len: 32768
 enable-kvcache: true
 kv-cache-size: 4096
 block-size: 16
-time-to-first-token: %s
-time-to-first-token-std-dev: %s
-inter-token-latency: %s
-inter-token-latency-std-dev: %s
-kv-cache-transfer-latency: %s
-kv-cache-transfer-latency-std-dev: %s
-time-factor-under-load: %s
-`, port, modelName, servedModelName, ttft, ttftStdDev, itl, itlStdDev, kvTransfer, kvTransferStdDev, timeFactor)
+%s`, port, modelName, servedModelName, latencyYAML)
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
@@ -489,6 +489,35 @@ func (r *ShadowPodReconciler) ensureSimConfigMap(ctx context.Context, namespace,
 		return nil
 	}
 
+	ttft := r.Config.TimeToFirstToken
+	if ttft == "" {
+		ttft = DefaultTimeToFirstToken
+	}
+	itl := r.Config.InterTokenLatency
+	if itl == "" {
+		itl = DefaultInterTokenLatency
+	}
+	ttftStdDev := r.Config.TimeToFirstTokenStdDev
+	if ttftStdDev == "" {
+		ttftStdDev = DefaultTimeToFirstTokenStdDev
+	}
+	itlStdDev := r.Config.InterTokenLatencyStdDev
+	if itlStdDev == "" {
+		itlStdDev = DefaultInterTokenLatencyStdDev
+	}
+	kvTransfer := r.Config.KVCacheTransferLatency
+	if kvTransfer == "" {
+		kvTransfer = DefaultKVCacheTransferLatency
+	}
+	kvTransferStdDev := r.Config.KVCacheTransferStdDev
+	if kvTransferStdDev == "" {
+		kvTransferStdDev = DefaultKVCacheTransferStdDev
+	}
+	timeFactor := r.Config.TimeFactorUnderLoad
+	if timeFactor == "" {
+		timeFactor = DefaultTimeFactorUnderLoad
+	}
+
 	configYAML := fmt.Sprintf(`port: %d
 model: "%s"
 served-model-name:
@@ -499,9 +528,14 @@ max-model-len: 32768
 enable-kvcache: true
 kv-cache-size: 4096
 block-size: 16
-time-to-first-token: 100ms
-inter-token-latency: 30ms
-`, port, modelName, servedModelName)
+time-to-first-token: %s
+time-to-first-token-std-dev: %s
+inter-token-latency: %s
+inter-token-latency-std-dev: %s
+kv-cache-transfer-latency: %s
+kv-cache-transfer-latency-std-dev: %s
+time-factor-under-load: %s
+`, port, modelName, servedModelName, ttft, ttftStdDev, itl, itlStdDev, kvTransfer, kvTransferStdDev, timeFactor)
 
 	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
@@ -906,10 +906,11 @@ func TestEnsureSimConfigMap(t *testing.T) {
 	if strings.Contains(configYAML, "threshold") {
 		t.Errorf("config should not contain threshold: %s", configYAML)
 	}
-	// Empty Config latency fields ⇒ Profile 1 defaults applied.
+	// Empty Config latency fields ⇒ Profile 1 constant-calculator defaults.
 	for _, want := range []string{
+		"latency-calculator: constant",
 		"time-to-first-token: 100ms",
-		"inter-token-latency: 30ms",
+		"inter-token-latency: 12ms",
 		"time-to-first-token-std-dev: 20ms",
 		"inter-token-latency-std-dev: 2ms",
 		"kv-cache-transfer-latency: 2ms",
@@ -919,6 +920,10 @@ func TestEnsureSimConfigMap(t *testing.T) {
 		if !strings.Contains(configYAML, want) {
 			t.Errorf("missing default %q in config: %s", want, configYAML)
 		}
+	}
+	// Constant calculator must not emit per-token-only fields.
+	if strings.Contains(configYAML, "prefill-overhead") {
+		t.Errorf("constant calculator should not emit prefill fields: %s", configYAML)
 	}
 
 	// Idempotent: calling again should not error
@@ -964,6 +969,52 @@ func TestEnsureSimConfigMap_LatencyOverrides(t *testing.T) {
 	} {
 		if !strings.Contains(configYAML, want) {
 			t.Errorf("missing override %q in config: %s", want, configYAML)
+		}
+	}
+}
+
+func TestEnsureSimConfigMap_PerTokenCalculator(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+	cfg := testConfig()
+	cfg.LatencyCalculator = LatencyCalculatorPerToken
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+	r := &ShadowPodReconciler{Client: cl, Config: cfg}
+
+	ownerRef := metav1.OwnerReference{APIVersion: "v1", Kind: "Pod", Name: "falcon-0", UID: "test-uid", Controller: ptr.To(true)}
+	if err := r.ensureSimConfigMap(ctx, "default", "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000, ownerRef); err != nil {
+		t.Fatalf("ensureSimConfigMap: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: "shadow-default-falcon-0-config", Namespace: "default"}, cm); err != nil {
+		t.Fatalf("configmap not found: %v", err)
+	}
+	configYAML := cm.Data["config.yaml"]
+	// Per-token calculator: common + per-token defaults (Profile 1) applied.
+	for _, want := range []string{
+		"latency-calculator: per-token",
+		"inter-token-latency: 12ms",
+		"prefill-overhead: 30ms",
+		"prefill-time-per-token: 250us",
+		"prefill-time-std-dev: 5ms",
+		"kv-cache-transfer-time-per-token: 3us",
+		"kv-cache-transfer-time-std-dev: 200us",
+		"time-factor-under-load: 2.0",
+	} {
+		if !strings.Contains(configYAML, want) {
+			t.Errorf("missing per-token field %q in config: %s", want, configYAML)
+		}
+	}
+	// Per-token calculator must not emit constant-only fields.
+	for _, unwanted := range []string{
+		"time-to-first-token:",
+		"kv-cache-transfer-latency:",
+	} {
+		if strings.Contains(configYAML, unwanted) {
+			t.Errorf("per-token calculator should not emit %q: %s", unwanted, configYAML)
 		}
 	}
 }

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
@@ -906,9 +906,64 @@ func TestEnsureSimConfigMap(t *testing.T) {
 	if strings.Contains(configYAML, "threshold") {
 		t.Errorf("config should not contain threshold: %s", configYAML)
 	}
+	// Empty Config latency fields ⇒ Profile 1 defaults applied.
+	for _, want := range []string{
+		"time-to-first-token: 100ms",
+		"inter-token-latency: 30ms",
+		"time-to-first-token-std-dev: 20ms",
+		"inter-token-latency-std-dev: 2ms",
+		"kv-cache-transfer-latency: 2ms",
+		"kv-cache-transfer-latency-std-dev: 400us",
+		"time-factor-under-load: 2.0",
+	} {
+		if !strings.Contains(configYAML, want) {
+			t.Errorf("missing default %q in config: %s", want, configYAML)
+		}
+	}
 
 	// Idempotent: calling again should not error
 	if err := r.ensureSimConfigMap(ctx, "default", "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000, ownerRef); err != nil {
 		t.Fatalf("second call should be idempotent: %v", err)
+	}
+}
+
+func TestEnsureSimConfigMap_LatencyOverrides(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+	cfg := testConfig()
+	cfg.TimeToFirstToken = "200ms"
+	cfg.InterTokenLatency = "25ms"
+	cfg.TimeToFirstTokenStdDev = "40ms"
+	cfg.InterTokenLatencyStdDev = "4ms"
+	cfg.KVCacheTransferLatency = "8ms"
+	cfg.KVCacheTransferStdDev = "500us"
+	cfg.TimeFactorUnderLoad = "3.0"
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+	r := &ShadowPodReconciler{Client: cl, Config: cfg}
+
+	ownerRef := metav1.OwnerReference{APIVersion: "v1", Kind: "Pod", Name: "falcon-0", UID: "test-uid", Controller: ptr.To(true)}
+	if err := r.ensureSimConfigMap(ctx, "default", "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000, ownerRef); err != nil {
+		t.Fatalf("ensureSimConfigMap: %v", err)
+	}
+
+	cm := &corev1.ConfigMap{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: "shadow-default-falcon-0-config", Namespace: "default"}, cm); err != nil {
+		t.Fatalf("configmap not found: %v", err)
+	}
+	configYAML := cm.Data["config.yaml"]
+	for _, want := range []string{
+		"time-to-first-token: 200ms",
+		"inter-token-latency: 25ms",
+		"time-to-first-token-std-dev: 40ms",
+		"inter-token-latency-std-dev: 4ms",
+		"kv-cache-transfer-latency: 8ms",
+		"kv-cache-transfer-latency-std-dev: 500us",
+		"time-factor-under-load: 3.0",
+	} {
+		if !strings.Contains(configYAML, want) {
+			t.Errorf("missing override %q in config: %s", want, configYAML)
+		}
 	}
 }


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->
The shadow pod runs llm-d-inference-sim to fake an inference workload, but currently has no realistic default latency configuration. This PR adopts sensible default latency profiles so mocked endpoints behave closer to real vLLM serving.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
https://github.com/kaito-project/production-stack/issues/124

**Notes for Reviewers**:
