### PR TITLE
feat(gpu-node-mocker): reap KAITO pods stuck Terminating on fake nodes

### DIFF
--- a/pkg/gpu-node-mocker/controllers/pod_reaper_controller.go
+++ b/pkg/gpu-node-mocker/controllers/pod_reaper_controller.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 The KAITO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/utils/ptr"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+// FakeNodePodReaper acts as the missing kubelet for pod *deletion* on fake nodes.
+//
+// Fake nodes created by Phase 1 have no real kubelet. Kubernetes pod deletion is
+// two-phase: the API server stamps metadata.deletionTimestamp, then the node's
+// kubelet stops the containers and issues the final removal. On a fake node the
+// second phase never happens, so a KAITO inference pod that is deleted (e.g.
+// during a StatefulSet/Workspace rollout) hangs in Terminating forever. Because
+// it still holds the fake node's single nvidia.com/gpu, the replacement pod can
+// never schedule → Pending deadlock.
+//
+// This reconciler completes the deletion the fake kubelet would have performed:
+// once the pod's graceful-termination deadline has elapsed it force-deletes the
+// pod (grace period 0). The shadow pod and its ConfigMap are garbage-collected
+// via their OwnerReference to the original pod, so no extra cleanup is required.
+//
+// It is the deletion-side counterpart of ShadowPodReconciler (which mirrors the
+// kubelet's start-up job of driving Pending pods on fake nodes to Running).
+type FakeNodePodReaper struct {
+	client.Client
+}
+
+// SetupWithManager registers the reaper with a single Pod watch filtered to
+// KAITO inference pods that are bound to a fake node and marked for deletion.
+func (r *FakeNodePodReaper) SetupWithManager(mgr ctrl.Manager) error {
+	terminatingOnFakeNode := predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return isTerminatingOnFakeNode(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return isTerminatingOnFakeNode(e.ObjectNew) },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		Named("fake-node-pod-reaper").
+		For(&corev1.Pod{}, builder.WithPredicates(terminatingOnFakeNode)).
+		Complete(r)
+}
+
+// +kubebuilder:rbac:groups="",resources=pods,verbs=get;list;watch;delete
+
+func (r *FakeNodePodReaper) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
+	log := log.FromContext(ctx).WithValues("pod", req.NamespacedName)
+
+	pod := &corev1.Pod{}
+	if err := r.Get(ctx, req.NamespacedName, pod); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("get pod: %w", err)
+	}
+
+	if !isTerminatingOnFakeNode(pod) {
+		return ctrl.Result{}, nil
+	}
+
+	// Respect the graceful-termination window. metadata.deletionTimestamp is the
+	// deadline the API server already computed as
+	// (deletion-request time + terminationGracePeriodSeconds). If it has not yet
+	// passed, requeue for the remaining time instead of force-deleting early.
+	deadline := pod.DeletionTimestamp.Time
+	if remaining := time.Until(deadline); remaining > 0 {
+		log.Info("pod terminating on fake node; waiting for grace period to elapse",
+			"node", pod.Spec.NodeName, "remaining", remaining.String())
+		return ctrl.Result{RequeueAfter: remaining}, nil
+	}
+
+	// Grace period elapsed — complete the deletion the fake node's (absent)
+	// kubelet would have performed.
+	if err := r.Delete(ctx, pod, &client.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))}); err != nil {
+		if errors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("force delete terminating pod: %w", err)
+	}
+
+	log.Info("force-deleted pod stuck Terminating on fake node", "node", pod.Spec.NodeName)
+	return ctrl.Result{}, nil
+}
+
+// isTerminatingOnFakeNode reports whether the pod is a KAITO inference pod that
+// is bound to a fake node and has been marked for deletion. It uses the same
+// KAITO-label gate as isPendingOnFakeNode so the reaper only touches pods this
+// controller is responsible for.
+func isTerminatingOnFakeNode(obj client.Object) bool {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return false
+	}
+	// Only process pods created by KAITO. Two provisioning paths exist:
+	//   - InferenceSet (modeldeployment) pods carry `inferenceset.kaito.sh/created-by`.
+	//   - Workspace pods (KAITO StatefulSet) carry `kaito.sh/workspace`.
+	_, hasInferenceSet := pod.Labels[InferenceSetCreatedByLabelKey]
+	_, hasWorkspace := pod.Labels[LabelKaitoWorkspace]
+	if !hasInferenceSet && !hasWorkspace {
+		return false
+	}
+	return pod.DeletionTimestamp != nil &&
+		pod.Spec.NodeName != "" &&
+		strings.HasPrefix(pod.Spec.NodeName, "fake-")
+}

--- a/pkg/gpu-node-mocker/controllers/pod_reaper_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/pod_reaper_controller_test.go
@@ -1,0 +1,236 @@
+// Copyright (c) KAITO authors.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controllers
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+)
+
+func TestIsTerminatingOnFakeNode(t *testing.T) {
+	del := metav1.NewTime(time.Now())
+	tests := []struct {
+		name string
+		pod  *corev1.Pod
+		want bool
+	}{
+		{"valid inferenceset", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:            map[string]string{InferenceSetCreatedByLabelKey: "falcon"},
+				DeletionTimestamp: &del,
+			},
+			Spec: corev1.PodSpec{NodeName: "fake-ws1"},
+		}, true},
+		{"valid workspace", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:            map[string]string{LabelKaitoWorkspace: "workspace-phi"},
+				DeletionTimestamp: &del,
+			},
+			Spec: corev1.PodSpec{NodeName: "fake-ws1"},
+		}, true},
+		{"not terminating", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{InferenceSetCreatedByLabelKey: "falcon"}},
+			Spec:       corev1.PodSpec{NodeName: "fake-ws1"},
+		}, false},
+		{"real node", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:            map[string]string{InferenceSetCreatedByLabelKey: "falcon"},
+				DeletionTimestamp: &del,
+			},
+			Spec: corev1.PodSpec{NodeName: "aks-node1"},
+		}, false},
+		{"no kaito label", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:            map[string]string{"app": "nginx"},
+				DeletionTimestamp: &del,
+			},
+			Spec: corev1.PodSpec{NodeName: "fake-ws1"},
+		}, false},
+		{"no node", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels:            map[string]string{InferenceSetCreatedByLabelKey: "falcon"},
+				DeletionTimestamp: &del,
+			},
+		}, false},
+		{"nil labels", &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &del},
+			Spec:       corev1.PodSpec{NodeName: "fake-ws1"},
+		}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isTerminatingOnFakeNode(tt.pod); got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// newTerminatingPodOnFakeNode builds a KAITO inference pod that is bound to a
+// fake node and marked for deletion. A finalizer is required because the fake
+// client refuses to persist an object that has a deletionTimestamp but no
+// finalizers.
+func newTerminatingPodOnFakeNode(name, ns, node string, deletionTS time.Time) *corev1.Pod {
+	dt := metav1.NewTime(deletionTS)
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:                       name,
+			Namespace:                  ns,
+			Labels:                     map[string]string{InferenceSetCreatedByLabelKey: "falcon-7b-instruct"},
+			DeletionTimestamp:          &dt,
+			DeletionGracePeriodSeconds: ptrInt64(30),
+			Finalizers:                 []string{"kaito.sh/test-hold"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   node,
+			Containers: []corev1.Container{{Name: "model", Image: "kaito/falcon:latest"}},
+		},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+}
+
+func ptrInt64(v int64) *int64 { return &v }
+
+func TestFakeNodePodReaper_ForceDeletesAfterGrace(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+
+	// deletionTimestamp already in the past → grace period elapsed.
+	pod := newTerminatingPodOnFakeNode("falcon-0", "default", "fake-ws1", time.Now().Add(-time.Minute))
+
+	var deleteCalled bool
+	var gotGrace *int64
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				deleteCalled = true
+				do := &client.DeleteOptions{}
+				for _, o := range opts {
+					o.ApplyToDelete(do)
+				}
+				gotGrace = do.GracePeriodSeconds
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &FakeNodePodReaper{Client: cl}
+	res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "falcon-0", Namespace: "default"}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("expected no requeue after grace elapsed, got %v", res.RequeueAfter)
+	}
+	if !deleteCalled {
+		t.Fatal("expected pod to be force-deleted")
+	}
+	if gotGrace == nil || *gotGrace != 0 {
+		t.Errorf("expected force delete with grace period 0, got %v", gotGrace)
+	}
+}
+
+func TestFakeNodePodReaper_RequeuesDuringGrace(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+
+	// deletionTimestamp in the future → still within the graceful window.
+	pod := newTerminatingPodOnFakeNode("falcon-0", "default", "fake-ws1", time.Now().Add(30*time.Second))
+
+	var deleteCalled bool
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				deleteCalled = true
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &FakeNodePodReaper{Client: cl}
+	res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "falcon-0", Namespace: "default"}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.RequeueAfter <= 0 {
+		t.Errorf("expected requeue during grace window, got %v", res.RequeueAfter)
+	}
+	if deleteCalled {
+		t.Error("pod must not be deleted before grace period elapses")
+	}
+}
+
+func TestFakeNodePodReaper_IgnoresNonTerminating(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "falcon-0",
+			Namespace: "default",
+			Labels:    map[string]string{InferenceSetCreatedByLabelKey: "falcon"},
+		},
+		Spec:   corev1.PodSpec{NodeName: "fake-ws1", Containers: []corev1.Container{{Name: "c", Image: "i"}}},
+		Status: corev1.PodStatus{Phase: corev1.PodRunning},
+	}
+
+	var deleteCalled bool
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(pod).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Delete: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+				deleteCalled = true
+				return c.Delete(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	r := &FakeNodePodReaper{Client: cl}
+	res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "falcon-0", Namespace: "default"}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.RequeueAfter != 0 || deleteCalled {
+		t.Errorf("non-terminating pod must be ignored, requeue=%v deleteCalled=%v", res.RequeueAfter, deleteCalled)
+	}
+}
+
+func TestFakeNodePodReaper_NotFound(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	r := &FakeNodePodReaper{Client: cl}
+	res, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "gone", Namespace: "default"}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	if res.RequeueAfter != 0 {
+		t.Errorf("expected empty result, got %v", res.RequeueAfter)
+	}
+}

--- a/pkg/gpu-node-mocker/controllers/register.go
+++ b/pkg/gpu-node-mocker/controllers/register.go
@@ -39,5 +39,15 @@ func NewControllers(mgr ctrl.Manager, cfg Config, mocker ProvisionerMocker) erro
 		return fmt.Errorf("unable to create ShadowPod controller: %w", err)
 	}
 
+	// FakeNodePodReaper is the deletion-side counterpart of the ShadowPod
+	// controller: it force-deletes KAITO inference pods that are stuck
+	// Terminating on fake nodes (which have no kubelet to finalize deletion),
+	// freeing the fake node's GPU for the replacement pod.
+	if err := (&FakeNodePodReaper{
+		Client: mgr.GetClient(),
+	}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("unable to create FakeNodePodReaper controller: %w", err)
+	}
+
 	return nil
 }

--- a/test/e2e/gpu_mocker_test.go
+++ b/test/e2e/gpu_mocker_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/utils/ptr"
 
 	"github.com/kaito-project/production-stack/test/e2e/utils"
 )
@@ -457,6 +458,126 @@ var _ = Describe("GPU Mocker E2E", Ordered, func() {
 							"pod %q should have shadow-pod-ref annotation", pod.Name)
 					}
 				}
+			})
+		})
+
+		Context("Terminating pod reaping", func() {
+			It("should force-delete a KAITO pod stuck Terminating on a fake node", func() {
+				clientset, err := utils.GetK8sClientset()
+				Expect(err).NotTo(HaveOccurred())
+
+				ctx := context.Background()
+
+				// A pod bound to a fake node has no real kubelet to finalize
+				// deletion. A normal delete sets metadata.deletionTimestamp and
+				// then waits forever for the (absent) kubelet, so the pod hangs
+				// in Terminating while still holding the fake node's single
+				// nvidia.com/gpu — blocking the replacement pod (Pending
+				// deadlock). The FakeNodePodReaper stands in for the missing
+				// kubelet: once the grace period elapses it force-deletes the
+				// pod. Reaching NotFound on a fake-node pod is therefore proof
+				// the reaper ran — without it the pod would hang indefinitely.
+				//
+				// Scope the target to a fake node hosting a pod in caseNamespace
+				// so cases running in parallel stay isolated.
+				deploymentName := caseDeployments[0].Name
+				origPods, err := clientset.CoreV1().Pods(caseNamespace).List(ctx, metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("inferenceset.kaito.sh/created-by=%s", deploymentName),
+				})
+				Expect(err).NotTo(HaveOccurred())
+				Expect(origPods.Items).NotTo(BeEmpty(),
+					"need at least one original pod in %s for deployment %q", caseNamespace, deploymentName)
+
+				var fakeNodeName string
+				for _, p := range origPods.Items {
+					if strings.HasPrefix(p.Spec.NodeName, "fake-") {
+						fakeNodeName = p.Spec.NodeName
+						break
+					}
+				}
+				Expect(fakeNodeName).NotTo(BeEmpty(),
+					"no original pod for %q is scheduled on a fake- node yet", deploymentName)
+
+				const wsName = "e2e-reaper-terminating"
+				wsPodName := wsName + "-0"
+				gracePeriod := int64(30)
+
+				wsPod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      wsPodName,
+						Namespace: caseNamespace,
+						// KAITO Workspace StatefulSet pods carry this label; the
+						// reaper gates on it (or inferenceset.kaito.sh/created-by).
+						Labels: map[string]string{"kaito.sh/workspace": wsName},
+					},
+					Spec: corev1.PodSpec{
+						// Bind directly to the fake node (no kubelet runs there).
+						NodeName:    fakeNodeName,
+						Tolerations: []corev1.Toleration{{Operator: corev1.TolerationOpExists}},
+						Containers: []corev1.Container{{
+							Name:  "model",
+							Image: "mcr.microsoft.com/oss/kubernetes/pause:3.6",
+							Args: []string{
+								"--model", "microsoft/phi-4-mini-instruct",
+								"--served-model-name", "phi-4-mini-instruct",
+							},
+							Ports: []corev1.ContainerPort{{ContainerPort: 5000}},
+						}},
+					},
+				}
+
+				By(fmt.Sprintf("creating synthetic Workspace pod %s/%s bound to fake node %q",
+					caseNamespace, wsPodName, fakeNodeName))
+				_, err = clientset.CoreV1().Pods(caseNamespace).Create(ctx, wsPod, metav1.CreateOptions{})
+				Expect(err).NotTo(HaveOccurred())
+
+				// Safety net if the reaper does not act or an assertion fails
+				// midway: force-remove the pod so it never leaks into other specs.
+				DeferCleanup(func() {
+					_ = clientset.CoreV1().Pods(caseNamespace).Delete(
+						context.Background(), wsPodName,
+						metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))})
+				})
+
+				// Let the ShadowPodReconciler drive the pod to Running, mirroring
+				// a live KAITO inference pod occupying the fake node's GPU.
+				By("waiting for the pod to be patched to Running by the shadow controller")
+				Eventually(func() error {
+					p, err := clientset.CoreV1().Pods(caseNamespace).Get(ctx, wsPodName, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					if p.Status.Phase != corev1.PodRunning {
+						return fmt.Errorf("pod %q phase = %s, want Running", wsPodName, p.Status.Phase)
+					}
+					return nil
+				}, 3*time.Minute, 10*time.Second).Should(Succeed(),
+					"synthetic Workspace pod should be patched to Running before deletion")
+
+				By(fmt.Sprintf("deleting the pod with a %ds grace period", gracePeriod))
+				err = clientset.CoreV1().Pods(caseNamespace).Delete(ctx, wsPodName,
+					metav1.DeleteOptions{GracePeriodSeconds: &gracePeriod})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("verifying the pod first hangs in Terminating (deletionTimestamp set, still present)")
+				Eventually(func() error {
+					p, err := clientset.CoreV1().Pods(caseNamespace).Get(ctx, wsPodName, metav1.GetOptions{})
+					if err != nil {
+						return fmt.Errorf("pod not yet observed Terminating: %w", err)
+					}
+					if p.DeletionTimestamp == nil {
+						return fmt.Errorf("pod %q has no deletionTimestamp yet", wsPodName)
+					}
+					return nil
+				}, 15*time.Second, 1*time.Second).Should(Succeed(),
+					"pod should enter Terminating on the fake node before the grace period elapses")
+
+				By("waiting for the FakeNodePodReaper to force-delete the pod after the grace period")
+				Eventually(func() bool {
+					_, err := clientset.CoreV1().Pods(caseNamespace).Get(ctx, wsPodName, metav1.GetOptions{})
+					return errors.IsNotFound(err)
+				}, 2*time.Minute, 5*time.Second).Should(BeTrue(),
+					"FakeNodePodReaper should force-delete the pod stuck Terminating on fake node %q", fakeNodeName)
 			})
 		})
 	})


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

Fake nodes have no kubelet to finalize the second phase of pod deletion, so a KAITO inference pod deleted during a StatefulSet/Workspace rollout hangs in Terminating forever while still holding the fake node's single nvidia.com/gpu. The replacement pod can then never schedule (Insufficient nvidia.com/gpu), producing a Pending deadlock.

Add FakeNodePodReaper, the deletion-side counterpart of ShadowPodReconciler. It watches KAITO inference pods bound to fake nodes with a deletionTimestamp, respects the graceful-termination deadline (metadata.deletionTimestamp), and once elapsed force-deletes the pod (grace period 0) to complete the removal the absent kubelet would have performed. Shadow pod and ConfigMap are GC'd via their OwnerReference to the original pod.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
