### PR TITLE
gpu-node-mocker: reap any pod stuck Terminating on a fake node

### DIFF
--- a/pkg/gpu-node-mocker/controllers/pod_reaper_controller.go
+++ b/pkg/gpu-node-mocker/controllers/pod_reaper_controller.go
@@ -111,21 +111,16 @@ func (r *FakeNodePodReaper) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	return ctrl.Result{}, nil
 }
 
-// isTerminatingOnFakeNode reports whether the pod is a KAITO inference pod that
-// is bound to a fake node and has been marked for deletion. It uses the same
-// KAITO-label gate as isPendingOnFakeNode so the reaper only touches pods this
-// controller is responsible for.
+// isTerminatingOnFakeNode reports whether the pod is bound to a fake node
+// (spec.nodeName starts with "fake-") and has been marked for deletion. Any
+// such pod — a KAITO inference pod or an unrelated DaemonSet/Job pod that
+// happened to be scheduled onto a fake node — hangs in Terminating forever
+// because the fake node has no kubelet to finalize deletion. Force-deleting it
+// is exactly the job the absent kubelet would have performed, so no KAITO-label
+// gate is applied here.
 func isTerminatingOnFakeNode(obj client.Object) bool {
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
-		return false
-	}
-	// Only process pods created by KAITO. Two provisioning paths exist:
-	//   - InferenceSet (modeldeployment) pods carry `inferenceset.kaito.sh/created-by`.
-	//   - Workspace pods (KAITO StatefulSet) carry `kaito.sh/workspace`.
-	_, hasInferenceSet := pod.Labels[InferenceSetCreatedByLabelKey]
-	_, hasWorkspace := pod.Labels[LabelKaitoWorkspace]
-	if !hasInferenceSet && !hasWorkspace {
 		return false
 	}
 	return pod.DeletionTimestamp != nil &&

--- a/pkg/gpu-node-mocker/controllers/pod_reaper_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/pod_reaper_controller_test.go
@@ -59,23 +59,23 @@ func TestIsTerminatingOnFakeNode(t *testing.T) {
 			},
 			Spec: corev1.PodSpec{NodeName: "aks-node1"},
 		}, false},
-		{"no kaito label", &corev1.Pod{
+		{"non-kaito pod on fake node is reaped", &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:            map[string]string{"app": "nginx"},
 				DeletionTimestamp: &del,
 			},
 			Spec: corev1.PodSpec{NodeName: "fake-ws1"},
-		}, false},
+		}, true},
 		{"no node", &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels:            map[string]string{InferenceSetCreatedByLabelKey: "falcon"},
 				DeletionTimestamp: &del,
 			},
 		}, false},
-		{"nil labels", &corev1.Pod{
+		{"nil labels on fake node is reaped", &corev1.Pod{
 			ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &del},
 			Spec:       corev1.PodSpec{NodeName: "fake-ws1"},
-		}, false},
+		}, true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

FakeNodePodReaper previously gated on a KAITO label (inferenceset.kaito.sh/ created-by or kaito.sh/workspace), so unrelated pods that landed on a fake node were never reaped. In practice azuresecuritylinuxagent stale-pod-cleanup Job pods scheduled onto fake nodes and piled up in Terminating forever, because a fake node has no kubelet to finalize deletion.

Drop the KAITO-label gate: reap ANY pod bound to a fake node (spec.nodeName has the "fake-" prefix) once its grace period elapses. This is safe because no pod can actually run on a kubelet-less fake node, so force-deleting it just performs the finalization the absent kubelet would have.

Fake-node detection stays on the "fake-" name prefix (kept simple).

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

Fixes #125 

**Notes for Reviewers**:
