### PR TITLE
Add pass fail results to coverage report

### DIFF
--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -94,6 +94,7 @@ jobs:
           go run ./hack/e2e/report \
             --label-filter 'Karpenter' \
             --workflow 'E2E tests (nightly, full suite)' \
+            --results ginkgo-report.json \
             --output-md e2e-coverage-report.md \
             --output-html e2e-coverage-report.html
           echo '## Karpenter Nightly Coverage' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -96,6 +96,7 @@ jobs:
           go run ./hack/e2e/report \
             --label-filter '!Nightly' \
             --workflow 'E2E tests' \
+            --results ginkgo-report.json \
             --output-md e2e-coverage-report.md \
             --output-html e2e-coverage-report.html
           cat e2e-coverage-report.md >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ docker-buildx: ## Multi-arch build (and optionally push) the gpu-node-mocker ima
 E2E_LABEL ?=
 E2E_PARALLEL ?= 2
 E2E_TIMEOUT  ?= 60m
+E2E_JSON_REPORT ?= ginkgo-report.json
 
 .PHONY: test-e2e
 test-e2e: ## Run e2e tests against a live cluster (requires KUBECONFIG).
@@ -127,6 +128,9 @@ test-e2e: ## Run e2e tests against a live cluster (requires KUBECONFIG).
 		--procs=$(E2E_PARALLEL) \
 		--timeout=$(E2E_TIMEOUT) \
 		-v \
+		--output-dir=$(CURDIR) \
+		--json-report=$(E2E_JSON_REPORT) \
+		--keep-going \
 		$(if $(E2E_LABEL),--label-filter="$(E2E_LABEL)",) \
 		./test/e2e/...
 

--- a/hack/e2e/report/main.go
+++ b/hack/e2e/report/main.go
@@ -35,6 +35,7 @@ type Block struct {
 	Title           string
 	Labels          []string // labels declared directly on this block
 	EffectiveLabels []string // Labels plus labels inherited from ancestor Describe/Context blocks
+	Status          string   // It blocks only: "passed", "failed", "skipped", "pending", or "" when unknown
 }
 
 // TestFile collects all parsed blocks from a single *_test.go file.
@@ -49,6 +50,7 @@ func main() {
 	outputMD := flag.String("output-md", "e2e-coverage-report.md", "path for Markdown output")
 	outputHTML := flag.String("output-html", "e2e-coverage-report.html", "path for HTML output")
 	workflow := flag.String("workflow", "", "GitHub Actions workflow name")
+	results := flag.String("results", "", "path to a Ginkgo JSON report (ginkgo --json-report) used to annotate specs with pass/fail status")
 	flag.Parse()
 
 	repoRoot, err := findRepoRoot()
@@ -61,7 +63,14 @@ func main() {
 	labelMap := parseLabelConstants(filepath.Join(e2eDir, "utils", "ginkgo.go"))
 	files := parseTestFiles(e2eDir, labelMap)
 
+	specResults, err := parseResults(*results)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "results: %v\n", err)
+		os.Exit(1)
+	}
+
 	data := buildReportData(files, *workflow, *labelFilter)
+	applyResults(data, specResults)
 
 	if err := writeMarkdown(data, *outputMD); err != nil {
 		fmt.Fprintf(os.Stderr, "markdown: %v\n", err)

--- a/hack/e2e/report/report.go
+++ b/hack/e2e/report/report.go
@@ -40,6 +40,14 @@ type ReportData struct {
 	TotalFiles  int
 	TotalIts    int
 
+	// HasResults is true when a Ginkgo JSON report was supplied, enabling the
+	// pass/fail/skip summary and per-spec status annotations.
+	HasResults   bool
+	TotalPassed  int
+	TotalFailed  int
+	TotalSkipped int
+	TotalPending int
+
 	Files         []TestFile
 	BarChart      []BarEntry
 	ConicGradient string
@@ -321,9 +329,61 @@ func buildReportData(files []TestFile, workflow, labelFilter string) *ReportData
 	return data
 }
 
+// applyResults annotates each It block in data.Files with its recorded
+// outcome and tallies the pass/fail/skip totals. results maps a spec's leaf
+// text (the It title) to its status. When results is empty, data is left
+// unchanged and the report renders as a source-only coverage report.
+func applyResults(data *ReportData, results map[string]string) {
+	if len(results) == 0 {
+		return
+	}
+	data.HasResults = true
+	for fi := range data.Files {
+		for bi := range data.Files[fi].Blocks {
+			b := &data.Files[fi].Blocks[bi]
+			if b.Type != "It" {
+				continue
+			}
+			// Specs that ran but produced no matching result are treated as
+			// skipped rather than silently counted as passing.
+			status, ok := results[b.Title]
+			if !ok {
+				status = StatusSkipped
+			}
+			b.Status = status
+			switch status {
+			case StatusPassed:
+				data.TotalPassed++
+			case StatusFailed:
+				data.TotalFailed++
+			case StatusPending:
+				data.TotalPending++
+			default:
+				data.TotalSkipped++
+			}
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Markdown generation
 // ---------------------------------------------------------------------------
+
+// statusIcon maps a spec outcome to its report emoji. An empty status (no
+// results supplied) falls back to 🟢 so source-only coverage reports render as
+// before.
+func statusIcon(status string) string {
+	switch status {
+	case StatusFailed:
+		return "🔴"
+	case StatusSkipped:
+		return "⚪"
+	case StatusPending:
+		return "🟡"
+	default:
+		return "🟢"
+	}
+}
 
 func writeMarkdown(data *ReportData, path string) error {
 	f, err := os.Create(path)
@@ -348,6 +408,14 @@ func writeMarkdown(data *ReportData, path string) error {
 	p("|--------|------:|")
 	p("| 📄 Test Files | **%d** |", data.TotalFiles)
 	p("| 🧪 Test Cases | **%d** |", data.TotalIts)
+	if data.HasResults {
+		p("| 🟢 Passed | **%d** |", data.TotalPassed)
+		p("| 🔴 Failed | **%d** |", data.TotalFailed)
+		p("| ⚪ Skipped | **%d** |", data.TotalSkipped)
+		if data.TotalPending > 0 {
+			p("| 🟡 Pending | **%d** |", data.TotalPending)
+		}
+	}
 	p("")
 	p("---")
 	p("")
@@ -410,7 +478,7 @@ func writeMarkdown(data *ReportData, path string) error {
 				p("**◦ %s**%s", b.Title, badges)
 				p("")
 			case "It":
-				p("- 🟢 %s%s", b.Title, badges)
+				p("- %s %s%s", statusIcon(b.Status), b.Title, badges)
 			}
 		}
 		p("")
@@ -432,6 +500,18 @@ func writeMarkdown(data *ReportData, path string) error {
 func writeHTML(data *ReportData, path string) error {
 	funcMap := template.FuncMap{
 		"lower": strings.ToLower,
+		"statusColor": func(status string) string {
+			switch status {
+			case StatusFailed:
+				return "var(--rd)"
+			case StatusSkipped:
+				return "var(--mt)"
+			case StatusPending:
+				return "var(--yl)"
+			default:
+				return "var(--gn)"
+			}
+		},
 	}
 	tmpl, err := template.New("report").Funcs(funcMap).Parse(htmlTemplateStr)
 	if err != nil {

--- a/hack/e2e/report/report_test.go
+++ b/hack/e2e/report/report_test.go
@@ -250,6 +250,165 @@ func TestWriteHTML_EmptyFiles(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Results annotation
+// ---------------------------------------------------------------------------
+
+func TestApplyResults_AnnotatesAndCounts(t *testing.T) {
+	data := buildReportData(sampleFiles(), "", "(all)")
+	// sampleFiles has Its: "test 1", "test 2" (alpha), "test A" (beta).
+	applyResults(data, map[string]string{
+		"test 1": StatusPassed,
+		"test 2": StatusFailed,
+		// "test A" has no result → should be counted as skipped.
+	})
+
+	if !data.HasResults {
+		t.Fatal("expected HasResults=true")
+	}
+	if data.TotalPassed != 1 {
+		t.Errorf("expected 1 passed, got %d", data.TotalPassed)
+	}
+	if data.TotalFailed != 1 {
+		t.Errorf("expected 1 failed, got %d", data.TotalFailed)
+	}
+	if data.TotalSkipped != 1 {
+		t.Errorf("expected 1 skipped, got %d", data.TotalSkipped)
+	}
+
+	// Verify per-spec statuses were assigned on the block copies.
+	statuses := map[string]string{}
+	for _, f := range data.Files {
+		for _, b := range f.Blocks {
+			if b.Type == "It" {
+				statuses[b.Title] = b.Status
+			}
+		}
+	}
+	if statuses["test 1"] != StatusPassed {
+		t.Errorf("expected test 1 passed, got %q", statuses["test 1"])
+	}
+	if statuses["test 2"] != StatusFailed {
+		t.Errorf("expected test 2 failed, got %q", statuses["test 2"])
+	}
+	if statuses["test A"] != StatusSkipped {
+		t.Errorf("expected test A skipped, got %q", statuses["test A"])
+	}
+}
+
+func TestApplyResults_EmptyIsNoOp(t *testing.T) {
+	data := buildReportData(sampleFiles(), "", "(all)")
+	applyResults(data, nil)
+
+	if data.HasResults {
+		t.Error("expected HasResults=false when no results supplied")
+	}
+	if data.TotalPassed+data.TotalFailed+data.TotalSkipped != 0 {
+		t.Error("expected zero status tallies when no results supplied")
+	}
+}
+
+func TestWriteMarkdown_WithResults(t *testing.T) {
+	data := buildReportData(sampleFiles(), "E2E tests", "(all)")
+	applyResults(data, map[string]string{
+		"test 1": StatusPassed,
+		"test 2": StatusFailed,
+		"test A": StatusPassed,
+	})
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.md")
+	if err := writeMarkdown(data, path); err != nil {
+		t.Fatalf("writeMarkdown: %v", err)
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	md := string(content)
+
+	checks := []string{
+		"🟢 Passed | **2**",
+		"🔴 Failed | **1**",
+		"🔴 test 2", // failing spec rendered with red icon
+		"🟢 test 1",
+	}
+	for _, want := range checks {
+		if !strings.Contains(md, want) {
+			t.Errorf("markdown missing %q", want)
+		}
+	}
+}
+
+func TestParseResults_MissingFileIsEmpty(t *testing.T) {
+	results, err := parseResults(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected empty results, got %v", results)
+	}
+}
+
+func TestParseResults_EmptyPathIsEmpty(t *testing.T) {
+	results, err := parseResults("")
+	if err != nil {
+		t.Fatalf("expected no error for empty path, got %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected empty results, got %v", results)
+	}
+}
+
+func TestParseResults_ParsesGinkgoJSON(t *testing.T) {
+	// Minimal Ginkgo JSON report. SpecState marshals as a lowercase string
+	// (see github.com/onsi/ginkgo/v2/types.SpecState.MarshalJSON). LeafNodeText
+	// is the matching key; for a duplicate leaf the worst status wins.
+	jsonReport := `[
+      {
+        "SpecReports": [
+          {"LeafNodeText": "spec passes", "State": "passed"},
+          {"LeafNodeText": "spec fails", "State": "failed"},
+          {"LeafNodeText": "spec skipped", "State": "skipped"},
+          {"LeafNodeText": "spec timed out", "State": "timedout"},
+          {"LeafNodeText": "dup", "State": "passed"},
+          {"LeafNodeText": "dup", "State": "failed"},
+          {"LeafNodeText": "", "State": "passed"}
+        ]
+      }
+    ]`
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ginkgo-report.json")
+	if err := os.WriteFile(path, []byte(jsonReport), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := parseResults(path)
+	if err != nil {
+		t.Fatalf("parseResults: %v", err)
+	}
+	if results["spec passes"] != StatusPassed {
+		t.Errorf("expected spec passes=passed, got %q", results["spec passes"])
+	}
+	if results["spec fails"] != StatusFailed {
+		t.Errorf("expected spec fails=failed, got %q", results["spec fails"])
+	}
+	if results["spec skipped"] != StatusSkipped {
+		t.Errorf("expected spec skipped=skipped, got %q", results["spec skipped"])
+	}
+	if results["spec timed out"] != StatusFailed {
+		t.Errorf("expected spec timed out=failed, got %q", results["spec timed out"])
+	}
+	// Worst status wins for duplicate leaf text.
+	if results["dup"] != StatusFailed {
+		t.Errorf("expected dup=failed (worst wins), got %q", results["dup"])
+	}
+	// Empty leaf text (setup/teardown nodes) must be ignored.
+	if _, ok := results[""]; ok {
+		t.Error("expected empty leaf text to be ignored")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Label filter evaluation
 // ---------------------------------------------------------------------------
 

--- a/hack/e2e/report/results.go
+++ b/hack/e2e/report/results.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The KAITO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/onsi/ginkgo/v2/types"
+)
+
+// Spec status values used throughout the report. They mirror the lowercase
+// strings produced by Ginkgo's types.SpecState.String().
+const (
+	StatusPassed  = "passed"
+	StatusFailed  = "failed"
+	StatusSkipped = "skipped"
+	StatusPending = "pending"
+)
+
+// statusRank orders statuses from best to worst so that, when two specs share
+// the same leaf text, the worst outcome wins (a failure is never hidden by a
+// passing namesake).
+var statusRank = map[string]int{
+	StatusPending: 0,
+	StatusSkipped: 1,
+	StatusPassed:  2,
+	StatusFailed:  3,
+}
+
+// parseResults reads one or more Ginkgo JSON reports (as written by
+// `ginkgo --json-report`) and returns a map from spec leaf text (the It title)
+// to its outcome. When the same leaf text appears more than once, the worst
+// outcome is kept. A missing path returns an empty map with no error so the
+// report can still be generated as a source-only coverage report.
+func parseResults(path string) (map[string]string, error) {
+	if path == "" {
+		return nil, nil
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read results: %w", err)
+	}
+
+	var reports []types.Report
+	if err := json.Unmarshal(raw, &reports); err != nil {
+		return nil, fmt.Errorf("parse results JSON: %w", err)
+	}
+
+	results := make(map[string]string)
+	for _, r := range reports {
+		for _, spec := range r.SpecReports {
+			// Ignore setup/teardown nodes; only report on actual It specs.
+			if spec.LeafNodeText == "" {
+				continue
+			}
+			status := normalizeStatus(spec.State)
+			if status == "" {
+				continue
+			}
+			key := spec.LeafNodeText
+			if prev, ok := results[key]; !ok || statusRank[status] > statusRank[prev] {
+				results[key] = status
+			}
+		}
+	}
+	return results, nil
+}
+
+// normalizeStatus collapses Ginkgo's spec states into the four buckets the
+// report displays. Timed-out/aborted/panicked/interrupted specs are treated as
+// failures.
+func normalizeStatus(state types.SpecState) string {
+	switch {
+	case state.Is(types.SpecStatePassed):
+		return StatusPassed
+	case state.Is(types.SpecStatePending):
+		return StatusPending
+	case state.Is(types.SpecStateSkipped):
+		return StatusSkipped
+	case state.Is(types.SpecStateFailureStates):
+		return StatusFailed
+	default:
+		return ""
+	}
+}

--- a/hack/e2e/report/template.html
+++ b/hack/e2e/report/template.html
@@ -87,6 +87,12 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,san
 <div class="cr">
   <div class="cd"><div class="ic">📄</div><div class="v">{{.TotalFiles}}</div><div class="l">Test Files</div></div>
   <div class="cd"><div class="ic">🧪</div><div class="v">{{.TotalIts}}</div><div class="l">Test Cases</div></div>
+  {{- if .HasResults}}
+  <div class="cd"><div class="ic">🟢</div><div class="v" style="color:var(--gn)">{{.TotalPassed}}</div><div class="l">Passed</div></div>
+  <div class="cd"><div class="ic">🔴</div><div class="v" style="color:var(--rd)">{{.TotalFailed}}</div><div class="l">Failed</div></div>
+  {{- if .TotalSkipped}}<div class="cd"><div class="ic">⚪</div><div class="v" style="color:var(--mt)">{{.TotalSkipped}}</div><div class="l">Skipped</div></div>{{end}}
+  {{- if .TotalPending}}<div class="cd"><div class="ic">🟡</div><div class="v" style="color:var(--yl)">{{.TotalPending}}</div><div class="l">Pending</div></div>{{end}}
+  {{- end}}
 </div>
 
 <div class="br">
@@ -142,7 +148,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,san
     {{- range $file.Blocks}}
       {{- if eq .Type "Describe"}}<div class="dh">▸ {{.Title}} {{range .Labels}}<span class="tg t-{{lower .}}">{{.}}</span>{{end}}</div>
       {{- else if eq .Type "Context"}}<div class="cx">◦ {{.Title}} {{range .Labels}}<span class="tg t-{{lower .}}">{{.}}</span>{{end}}</div>
-      {{- else if eq .Type "It"}}<div class="ti"><span class="dt"></span>{{.Title}} {{range .Labels}}<span class="tg t-{{lower .}}">{{.}}</span>{{end}}</div>
+      {{- else if eq .Type "It"}}<div class="ti"><span class="dt" style="background:{{statusColor .Status}}"></span>{{.Title}} {{range .Labels}}<span class="tg t-{{lower .}}">{{.}}</span>{{end}}</div>
       {{- end}}
     {{- end}}
   </div>


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->
Add pass fail results to coverage report.

Generated summary report: https://github.com/kaito-project/production-stack/actions/runs/28631947876?pr=134

html report:

<img width="1236" height="1275" alt="image" src="https://github.com/user-attachments/assets/5b15816c-d743-4889-92ae-580022306cf5" />

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
