### PR TITLE
Configure shadow pod latency via model size profiles

### DIFF
--- a/charts/gpu-node-mocker/templates/deployment.yaml
+++ b/charts/gpu-node-mocker/templates/deployment.yaml
@@ -27,19 +27,45 @@ spec:
             - --health-probe-bind-address=:8081
             - --shadow-pod-image={{ .Values.shadowPod.image }}
             - --uds-tokenizer-image={{ .Values.shadowPod.udsTokenizerImage }}
-            - --time-to-first-token={{ .Values.shadowPod.timeToFirstToken }}
-            - --inter-token-latency={{ .Values.shadowPod.interTokenLatency }}
-            - --time-to-first-token-std-dev={{ .Values.shadowPod.timeToFirstTokenStdDev }}
-            - --inter-token-latency-std-dev={{ .Values.shadowPod.interTokenLatencyStdDev }}
-            - --kv-cache-transfer-latency={{ .Values.shadowPod.kvCacheTransferLatency }}
-            - --kv-cache-transfer-latency-std-dev={{ .Values.shadowPod.kvCacheTransferLatencyStdDev }}
-            - --time-factor-under-load={{ .Values.shadowPod.timeFactorUnderLoad }}
-            - --latency-calculator={{ .Values.shadowPod.latencyCalculator }}
-            - --prefill-overhead={{ .Values.shadowPod.prefillOverhead }}
-            - --prefill-time-per-token={{ .Values.shadowPod.prefillTimePerToken }}
-            - --prefill-time-std-dev={{ .Values.shadowPod.prefillTimeStdDev }}
-            - --kv-cache-transfer-time-per-token={{ .Values.shadowPod.kvCacheTransferTimePerToken }}
-            - --kv-cache-transfer-time-std-dev={{ .Values.shadowPod.kvCacheTransferTimeStdDev }}
+            {{- with .Values.shadowPod.timeToFirstToken }}
+            - --time-to-first-token={{ . }}
+            {{- end }}
+            {{- with .Values.shadowPod.interTokenLatency }}
+            - --inter-token-latency={{ . }}
+            {{- end }}
+            {{- with .Values.shadowPod.timeToFirstTokenStdDev }}
+            - --time-to-first-token-std-dev={{ . }}
+            {{- end }}
+            {{- with .Values.shadowPod.interTokenLatencyStdDev }}
+            - --inter-token-latency-std-dev={{ . }}
+            {{- end }}
+            {{- with .Values.shadowPod.kvCacheTransferLatency }}
+            - --kv-cache-transfer-latency={{ . }}
+            {{- end }}
+            {{- with .Values.shadowPod.kvCacheTransferLatencyStdDev }}
+            - --kv-cache-transfer-latency-std-dev={{ . }}
+            {{- end }}
+            {{- with .Values.shadowPod.timeFactorUnderLoad }}
+            - --time-factor-under-load={{ . }}
+            {{- end }}
+            {{- with .Values.shadowPod.latencyCalculator }}
+            - --latency-calculator={{ . }}
+            {{- end }}
+            {{- with .Values.shadowPod.prefillOverhead }}
+            - --prefill-overhead={{ . }}
+            {{- end }}
+            {{- with .Values.shadowPod.prefillTimePerToken }}
+            - --prefill-time-per-token={{ . }}
+            {{- end }}
+            {{- with .Values.shadowPod.prefillTimeStdDev }}
+            - --prefill-time-std-dev={{ . }}
+            {{- end }}
+            {{- with .Values.shadowPod.kvCacheTransferTimePerToken }}
+            - --kv-cache-transfer-time-per-token={{ . }}
+            {{- end }}
+            {{- with .Values.shadowPod.kvCacheTransferTimeStdDev }}
+            - --kv-cache-transfer-time-std-dev={{ . }}
+            {{- end }}
             - --lease-duration-seconds={{ .Values.leaseDurationSeconds }}
             - --lease-renew-interval-seconds={{ .Values.leaseRenewIntervalSeconds }}
             - --node-provisioner={{ .Values.nodeProvisioner }}

--- a/charts/gpu-node-mocker/values.yaml
+++ b/charts/gpu-node-mocker/values.yaml
@@ -16,11 +16,10 @@ shadowPod:
   udsTokenizerImage: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.6.0
   # Latency knobs are resolved per-InferenceSet from a latency profile. By
   # default the profile is auto-selected from the served model size
-  # (<5B ⇒ small-l40s, 7-8B ⇒ 8b-h100, 13B ⇒ 13b, 30-34B ⇒ 30b-tp2,
-  # 70B ⇒ 70b-tp8, ≥150B ⇒ 405b-tp8; see
-  # llm-d-inference-sim/docs/latency-profiles.md). An InferenceSet can override
+  # (<5B ⇒ small-l40s, 5–25B ⇒ 8b-h100, ≥25B ⇒ 70b-tp8; see
+  # llm-d-inference-sim/manifests/latency-profiles). An InferenceSet can override
   # the profile and calculator via pod-template annotations:
-  #   kaito.sh/latency-profile: auto | small-l40s | 8b-h100 | 13b | 30b-tp2 | 70b-tp8 | 405b-tp8
+  #   kaito.sh/latency-profile: auto | small-l40s | 8b-h100 | 70b-tp8
   #   kaito.sh/latency-calculator: per-token | constant
   #
   # The values below are OPERATOR-WIDE DEFAULTS: set one to provide the baseline

--- a/charts/gpu-node-mocker/values.yaml
+++ b/charts/gpu-node-mocker/values.yaml
@@ -23,9 +23,11 @@ shadowPod:
   #   kaito.sh/latency-profile: auto | small-l40s | 8b-h100 | 13b | 30b-tp2 | 70b-tp8 | 405b-tp8
   #   kaito.sh/latency-calculator: per-token | constant
   #
-  # The values below are OPERATOR-WIDE OVERRIDES: set one to force that knob for
-  # every shadow pod regardless of the selected profile. Leave empty ("") to let
-  # the profile drive the value (recommended).
+  # The values below are OPERATOR-WIDE DEFAULTS: set one to provide the baseline
+  # for that knob. The selected latency profile OVERRIDES a default whenever the
+  # profile defines that knob; a default only applies when the profile leaves it
+  # empty. Leave a value empty ("") to have no default and rely solely on the
+  # profile (recommended).
   timeToFirstToken: ""
   interTokenLatency: ""
   timeToFirstTokenStdDev: ""

--- a/charts/gpu-node-mocker/values.yaml
+++ b/charts/gpu-node-mocker/values.yaml
@@ -14,26 +14,34 @@ image:
 shadowPod:
   image: ghcr.io/llm-d/llm-d-inference-sim:v0.8.1
   udsTokenizerImage: ghcr.io/llm-d/llm-d-uds-tokenizer:v0.6.0
-  # Inference simulator "constant" latency calculator knobs. Defaults mirror
-  # an 8B-class model on H100 under balanced load (Profile 1 in
-  # llm-d-inference-sim/docs/latency-profiles.md). Override to mimic other
-  # model/hardware combinations.
-  timeToFirstToken: 100ms
-  interTokenLatency: 12ms
-  timeToFirstTokenStdDev: 20ms
-  interTokenLatencyStdDev: 2ms
-  kvCacheTransferLatency: 2ms
-  kvCacheTransferLatencyStdDev: 400us
-  timeFactorUnderLoad: "2.0"
-  # latencyCalculator selects the simulator latency model: "constant" (default,
-  # TTFT is a fixed value) or "per-token" (TTFT scales with prompt length via
-  # the prefill* knobs below). The per-token defaults also follow Profile 1.
-  latencyCalculator: constant
-  prefillOverhead: 30ms
-  prefillTimePerToken: 250us
-  prefillTimeStdDev: 5ms
-  kvCacheTransferTimePerToken: 3us
-  kvCacheTransferTimeStdDev: 200us
+  # Latency knobs are resolved per-InferenceSet from a latency profile. By
+  # default the profile is auto-selected from the served model size
+  # (<5B ⇒ small-l40s, 7-8B ⇒ 8b-h100, 13B ⇒ 13b, 30-34B ⇒ 30b-tp2,
+  # 70B ⇒ 70b-tp8, ≥150B ⇒ 405b-tp8; see
+  # llm-d-inference-sim/docs/latency-profiles.md). An InferenceSet can override
+  # the profile and calculator via pod-template annotations:
+  #   kaito.sh/latency-profile: auto | small-l40s | 8b-h100 | 13b | 30b-tp2 | 70b-tp8 | 405b-tp8
+  #   kaito.sh/latency-calculator: per-token | constant
+  #
+  # The values below are OPERATOR-WIDE OVERRIDES: set one to force that knob for
+  # every shadow pod regardless of the selected profile. Leave empty ("") to let
+  # the profile drive the value (recommended).
+  timeToFirstToken: ""
+  interTokenLatency: ""
+  timeToFirstTokenStdDev: ""
+  interTokenLatencyStdDev: ""
+  kvCacheTransferLatency: ""
+  kvCacheTransferLatencyStdDev: ""
+  timeFactorUnderLoad: ""
+  # latencyCalculator is the operator-wide default calculator ("per-token" or
+  # "constant") used when a pod has no kaito.sh/latency-calculator annotation.
+  # Empty ⇒ "per-token".
+  latencyCalculator: ""
+  prefillOverhead: ""
+  prefillTimePerToken: ""
+  prefillTimeStdDev: ""
+  kvCacheTransferTimePerToken: ""
+  kvCacheTransferTimeStdDev: ""
 
 # nodeProvisioner selects which KAITO node provisioner to mock.
 # Must match KAITO's --node-provisioner value: azure-gpu-provisioner or karpenter.

--- a/cmd/gpu-node-mocker/main.go
+++ b/cmd/gpu-node-mocker/main.go
@@ -95,33 +95,34 @@ func main() {
 		"Container image for the inference simulator running in shadow pods.")
 	flag.StringVar(&udsTokenizerImage, "uds-tokenizer-image", controllers.DefaultUDSTokenizerImage,
 		"Container image for the UDS tokenizer sidecar in shadow pods.")
-	flag.StringVar(&timeToFirstToken, "time-to-first-token", controllers.DefaultTimeToFirstToken,
-		"Inference simulator time-to-first-token latency (e.g. 100ms). See llm-d-inference-sim latency-profiles.md.")
-	flag.StringVar(&interTokenLatency, "inter-token-latency", controllers.DefaultInterTokenLatency,
-		"Inference simulator inter-token latency (e.g. 30ms). See llm-d-inference-sim latency-profiles.md.")
-	flag.StringVar(&ttftStdDev, "time-to-first-token-std-dev", controllers.DefaultTimeToFirstTokenStdDev,
-		"Std-dev jitter for time-to-first-token (e.g. 20ms).")
-	flag.StringVar(&itlStdDev, "inter-token-latency-std-dev", controllers.DefaultInterTokenLatencyStdDev,
-		"Std-dev jitter for inter-token latency (e.g. 2ms).")
-	flag.StringVar(&kvCacheTransfer, "kv-cache-transfer-latency", controllers.DefaultKVCacheTransferLatency,
-		"Constant KV-cache transfer overhead (e.g. 2ms).")
-	flag.StringVar(&kvCacheTransferStdDev, "kv-cache-transfer-latency-std-dev", controllers.DefaultKVCacheTransferStdDev,
-		"Std-dev jitter for KV-cache transfer latency (e.g. 400us).")
-	flag.StringVar(&timeFactorUnderLoad, "time-factor-under-load", controllers.DefaultTimeFactorUnderLoad,
-		"Latency multiplier as concurrency approaches max-num-seqs (e.g. 2.0).")
-	flag.StringVar(&latencyCalculator, "latency-calculator", controllers.DefaultLatencyCalculator,
-		fmt.Sprintf("Inference simulator latency model (%q or %q).",
-			controllers.LatencyCalculatorConstant, controllers.LatencyCalculatorPerToken))
-	flag.StringVar(&prefillOverhead, "prefill-overhead", controllers.DefaultPrefillOverhead,
-		"per-token calculator: fixed prefill overhead (e.g. 30ms).")
-	flag.StringVar(&prefillTimePerToken, "prefill-time-per-token", controllers.DefaultPrefillTimePerToken,
-		"per-token calculator: prefill cost per prompt token (e.g. 250us).")
-	flag.StringVar(&prefillTimeStdDev, "prefill-time-std-dev", controllers.DefaultPrefillTimeStdDev,
-		"per-token calculator: std-dev jitter for prefill time (e.g. 5ms).")
-	flag.StringVar(&kvTransferTimePerToken, "kv-cache-transfer-time-per-token", controllers.DefaultKVCacheTransferTimePerToken,
-		"per-token calculator: KV-cache transfer cost per token (e.g. 3us).")
-	flag.StringVar(&kvTransferTimeStdDev, "kv-cache-transfer-time-std-dev", controllers.DefaultKVCacheTransferTimeStdDev,
-		"per-token calculator: std-dev jitter for KV-cache transfer time (e.g. 200us).")
+	flag.StringVar(&timeToFirstToken, "time-to-first-token", "",
+		"Override the selected latency profile's time-to-first-token (e.g. 100ms). Empty ⇒ use the profile value. See llm-d-inference-sim latency-profiles.md.")
+	flag.StringVar(&interTokenLatency, "inter-token-latency", "",
+		"Override the selected latency profile's inter-token latency (e.g. 30ms). Empty ⇒ use the profile value. See llm-d-inference-sim latency-profiles.md.")
+	flag.StringVar(&ttftStdDev, "time-to-first-token-std-dev", "",
+		"Override the selected latency profile's std-dev jitter for time-to-first-token (e.g. 20ms). Empty ⇒ use the profile value.")
+	flag.StringVar(&itlStdDev, "inter-token-latency-std-dev", "",
+		"Override the selected latency profile's std-dev jitter for inter-token latency (e.g. 2ms). Empty ⇒ use the profile value.")
+	flag.StringVar(&kvCacheTransfer, "kv-cache-transfer-latency", "",
+		"Override the selected latency profile's constant KV-cache transfer overhead (e.g. 2ms). Empty ⇒ use the profile value.")
+	flag.StringVar(&kvCacheTransferStdDev, "kv-cache-transfer-latency-std-dev", "",
+		"Override the selected latency profile's std-dev jitter for KV-cache transfer latency (e.g. 400us). Empty ⇒ use the profile value.")
+	flag.StringVar(&timeFactorUnderLoad, "time-factor-under-load", "",
+		"Override the selected latency profile's latency multiplier as concurrency approaches max-num-seqs (e.g. 2.0). Empty ⇒ use the profile value.")
+	flag.StringVar(&latencyCalculator, "latency-calculator", "",
+		fmt.Sprintf("Operator-wide default latency model (%q or %q) when a pod has no %q annotation. Empty ⇒ %q.",
+			controllers.LatencyCalculatorConstant, controllers.LatencyCalculatorPerToken,
+			controllers.AnnotationLatencyCalculator, controllers.DefaultLatencyCalculator))
+	flag.StringVar(&prefillOverhead, "prefill-overhead", "",
+		"per-token calculator: override the profile's fixed prefill overhead (e.g. 30ms). Empty ⇒ use the profile value.")
+	flag.StringVar(&prefillTimePerToken, "prefill-time-per-token", "",
+		"per-token calculator: override the profile's prefill cost per prompt token (e.g. 250us). Empty ⇒ use the profile value.")
+	flag.StringVar(&prefillTimeStdDev, "prefill-time-std-dev", "",
+		"per-token calculator: override the profile's std-dev jitter for prefill time (e.g. 5ms). Empty ⇒ use the profile value.")
+	flag.StringVar(&kvTransferTimePerToken, "kv-cache-transfer-time-per-token", "",
+		"per-token calculator: override the profile's KV-cache transfer cost per token (e.g. 3us). Empty ⇒ use the profile value.")
+	flag.StringVar(&kvTransferTimeStdDev, "kv-cache-transfer-time-std-dev", "",
+		"per-token calculator: override the profile's std-dev jitter for KV-cache transfer time (e.g. 200us). Empty ⇒ use the profile value.")
 	flag.IntVar(&leaseDurationSec, "lease-duration-seconds", 40,
 		"Duration in seconds for fake node lease.")
 	flag.IntVar(&leaseRenewIntervalSec, "lease-renew-interval-seconds", 10,
@@ -151,9 +152,10 @@ func main() {
 		setupLog.Error(nil, "--lease-duration-seconds must be > 0")
 		os.Exit(1)
 	}
-	if latencyCalculator != controllers.LatencyCalculatorConstant &&
+	if latencyCalculator != "" &&
+		latencyCalculator != controllers.LatencyCalculatorConstant &&
 		latencyCalculator != controllers.LatencyCalculatorPerToken {
-		setupLog.Error(nil, "--latency-calculator must be \"constant\" or \"per-token\"",
+		setupLog.Error(nil, "--latency-calculator must be \"constant\", \"per-token\", or empty",
 			"value", latencyCalculator)
 		os.Exit(1)
 	}

--- a/cmd/gpu-node-mocker/main.go
+++ b/cmd/gpu-node-mocker/main.go
@@ -159,6 +159,9 @@ func main() {
 			"value", latencyCalculator)
 		os.Exit(1)
 	}
+	if latencyCalculator == "" {
+		latencyCalculator = controllers.DefaultLatencyCalculator
+	}
 
 	cfg := controllers.Config{
 		ShadowPodImage:              shadowPodImage,

--- a/pkg/gpu-node-mocker/README.md
+++ b/pkg/gpu-node-mocker/README.md
@@ -68,17 +68,15 @@ instantly.
 ### Profiles (selected per InferenceSet)
 
 Each shadow pod's baseline latency comes from a **latency profile** that mirrors
-one of the "Suggested Default Profiles" / reference-table rows in the upstream
-[latency-profiles.md](https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/latency-profiles.md):
+one of the three upstream profiles in
+[manifests/latency-profiles](https://github.com/llm-d/llm-d-inference-sim/tree/main/manifests/latency-profiles)
+(each ships as a separate constant-calculator and per-token-calculator manifest):
 
 | Profile | Mirrors | Selected for (auto) | TTFT / ITL |
 | --- | --- | --- | --- |
 | `small-l40s` | Small model (1–3B) on L40S, low-latency edge | size `< 5B` | 110ms / 15ms |
-| `8b-h100` | 8B-class model on H100, balanced load | `5B ≤ size < 10B` (and fallback when size can't be parsed) | 100ms / 12ms |
-| `13b` | 13B model, H100-class balanced load | `10B ≤ size < 20B` | 180ms / 22ms |
-| `30b-tp2` | 30–34B model on 2×H100 (TP=2) | `20B ≤ size < 50B` | 250ms / 30ms |
-| `70b-tp8` | 70B model on 8×H100 (TP=8), throughput-optimized | `50B ≤ size < 150B` | 200ms / 25ms |
-| `405b-tp8` | 405B model on 8×H100 (TP=8) | size `≥ 150B` | 900ms / 80ms |
+| `8b-h100` | 8B-class model on H100, balanced load | `5B ≤ size < 25B` (and fallback when size can't be parsed) | 100ms / 12ms |
+| `70b-tp8` | 70B model on 8×H100 (TP=8), throughput-optimized | size `≥ 25B` | 200ms / 25ms |
 
 By default the profile is chosen **automatically from the served model size**
 parsed out of the model name (e.g. `...-8B...` ⇒ 8 billion parameters). An
@@ -86,7 +84,7 @@ InferenceSet can override the selection through pod-template annotations:
 
 | Annotation | Values | Default |
 | --- | --- | --- |
-| `kaito.sh/latency-profile` | `auto`, `small-l40s`, `8b-h100`, `13b`, `30b-tp2`, `70b-tp8`, `405b-tp8` | `auto` (pick by model size) |
+| `kaito.sh/latency-profile` | `auto`, `small-l40s`, `8b-h100`, `70b-tp8` | `auto` (pick by model size) |
 | `kaito.sh/latency-calculator` | `per-token`, `constant` | `per-token` |
 
 ```yaml

--- a/pkg/gpu-node-mocker/README.md
+++ b/pkg/gpu-node-mocker/README.md
@@ -63,41 +63,94 @@
 
 The shadow pod runs `llm-d-inference-sim`, configured with a latency calculator
 so mocked endpoints behave closer to real vLLM serving instead of responding
-instantly. `shadowPod.latencyCalculator` selects the model — `constant` (default)
-or `per-token` — and the defaults mirror **Profile 1 — 8B-class model on H100,
-balanced load** from the upstream [latency-profiles.md](https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/latency-profiles.md).
+instantly.
+
+### Profiles (selected per InferenceSet)
+
+Each shadow pod's baseline latency comes from a **latency profile** that mirrors
+one of the "Suggested Default Profiles" / reference-table rows in the upstream
+[latency-profiles.md](https://github.com/llm-d/llm-d-inference-sim/blob/main/docs/latency-profiles.md):
+
+| Profile | Mirrors | Selected for (auto) | TTFT / ITL |
+| --- | --- | --- | --- |
+| `small-l40s` | Small model (1–3B) on L40S, low-latency edge | size `< 5B` | 110ms / 15ms |
+| `8b-h100` | 8B-class model on H100, balanced load | `5B ≤ size < 10B` (and fallback when size can't be parsed) | 100ms / 12ms |
+| `13b` | 13B model, H100-class balanced load | `10B ≤ size < 20B` | 180ms / 22ms |
+| `30b-tp2` | 30–34B model on 2×H100 (TP=2) | `20B ≤ size < 50B` | 250ms / 30ms |
+| `70b-tp8` | 70B model on 8×H100 (TP=8), throughput-optimized | `50B ≤ size < 150B` | 200ms / 25ms |
+| `405b-tp8` | 405B model on 8×H100 (TP=8) | size `≥ 150B` | 900ms / 80ms |
+
+By default the profile is chosen **automatically from the served model size**
+parsed out of the model name (e.g. `...-8B...` ⇒ 8 billion parameters). An
+InferenceSet can override the selection through pod-template annotations:
+
+| Annotation | Values | Default |
+| --- | --- | --- |
+| `kaito.sh/latency-profile` | `auto`, `small-l40s`, `8b-h100`, `13b`, `30b-tp2`, `70b-tp8`, `405b-tp8` | `auto` (pick by model size) |
+| `kaito.sh/latency-calculator` | `per-token`, `constant` | `per-token` |
+
+```yaml
+# InferenceSet / modeldeployment pod template
+metadata:
+  annotations:
+    kaito.sh/latency-profile: 70b-tp8
+    kaito.sh/latency-calculator: per-token
+```
+
+Unknown annotation values fall back to the default (`auto` /
+`per-token`) and an unrecognized `kaito.sh/latency-calculator` value is logged as
+a warning. `kaito.sh/latency-calculator` selects the model — `per-token`
+(default, TTFT scales with prompt length) or `constant` (TTFT is a fixed value).
+Only the fields for the selected calculator are written into the simulator
+config.
+
+### Operator-wide overrides (Helm values / flags)
+
+The Helm values and CLI flags below are **operator-wide overrides**: each is
+empty by default so the selected profile drives the value. Set one to force that
+knob for every shadow pod regardless of profile. `latencyCalculator` /
+`--latency-calculator` sets the default calculator used when a pod has no
+`kaito.sh/latency-calculator` annotation (empty ⇒ `per-token`).
 
 ### Common settings (both calculators)
 
 | Setting | Helm value (`shadowPod.*`) | Flag | Default |
 | --- | --- | --- | --- |
-| Latency calculator | `latencyCalculator` | `--latency-calculator` | `constant` |
-| Inter-token latency | `interTokenLatency` | `--inter-token-latency` | `12ms` |
-| Inter-token std-dev | `interTokenLatencyStdDev` | `--inter-token-latency-std-dev` | `2ms` |
-| Time factor under load | `timeFactorUnderLoad` | `--time-factor-under-load` | `2.0` |
+| Latency calculator | `latencyCalculator` | `--latency-calculator` | profile / `per-token` |
+| Inter-token latency | `interTokenLatency` | `--inter-token-latency` | profile value |
+| Inter-token std-dev | `interTokenLatencyStdDev` | `--inter-token-latency-std-dev` | profile value |
+| Time factor under load | `timeFactorUnderLoad` | `--time-factor-under-load` | profile value |
 
 ### `constant` calculator (TTFT is a fixed value)
 
 | Setting | Helm value (`shadowPod.*`) | Flag | Default |
 | --- | --- | --- | --- |
-| Time to first token | `timeToFirstToken` | `--time-to-first-token` | `100ms` |
-| TTFT std-dev | `timeToFirstTokenStdDev` | `--time-to-first-token-std-dev` | `20ms` |
-| KV-cache transfer latency | `kvCacheTransferLatency` | `--kv-cache-transfer-latency` | `2ms` |
-| KV-cache transfer std-dev | `kvCacheTransferLatencyStdDev` | `--kv-cache-transfer-latency-std-dev` | `400us` |
+| Time to first token | `timeToFirstToken` | `--time-to-first-token` | profile value |
+| TTFT std-dev | `timeToFirstTokenStdDev` | `--time-to-first-token-std-dev` | profile value |
+| KV-cache transfer latency | `kvCacheTransferLatency` | `--kv-cache-transfer-latency` | profile value |
+| KV-cache transfer std-dev | `kvCacheTransferLatencyStdDev` | `--kv-cache-transfer-latency-std-dev` | profile value |
 
 ### `per-token` calculator (TTFT scales with prompt length)
 
 | Setting | Helm value (`shadowPod.*`) | Flag | Default |
 | --- | --- | --- | --- |
-| Prefill overhead | `prefillOverhead` | `--prefill-overhead` | `30ms` |
-| Prefill time per token | `prefillTimePerToken` | `--prefill-time-per-token` | `250us` |
-| Prefill time std-dev | `prefillTimeStdDev` | `--prefill-time-std-dev` | `5ms` |
-| KV-cache transfer time per token | `kvCacheTransferTimePerToken` | `--kv-cache-transfer-time-per-token` | `3us` |
-| KV-cache transfer time std-dev | `kvCacheTransferTimeStdDev` | `--kv-cache-transfer-time-std-dev` | `200us` |
+| Prefill overhead | `prefillOverhead` | `--prefill-overhead` | profile value |
+| Prefill time per token | `prefillTimePerToken` | `--prefill-time-per-token` | profile value |
+| Prefill time std-dev | `prefillTimeStdDev` | `--prefill-time-std-dev` | profile value |
+| KV-cache transfer time per token | `kvCacheTransferTimePerToken` | `--kv-cache-transfer-time-per-token` | profile value |
+| KV-cache transfer time std-dev | `kvCacheTransferTimeStdDev` | `--kv-cache-transfer-time-std-dev` | profile value |
 
-Only the fields for the selected calculator are written into the simulator
-config. Override per-deployment to mimic other model/hardware combinations, e.g.
-a 70B TP=8 throughput profile on the `constant` calculator:
+Override per-deployment to mimic other model/hardware combinations, e.g. force a
+70B TP=8 throughput profile via annotation:
+
+```yaml
+# InferenceSet pod template
+metadata:
+  annotations:
+    kaito.sh/latency-profile: 70b-tp8
+```
+
+Or pin individual knobs operator-wide (applies to every shadow pod):
 
 ```yaml
 shadowPod:
@@ -105,13 +158,4 @@ shadowPod:
   timeToFirstToken: 200ms
   interTokenLatency: 25ms
   timeFactorUnderLoad: "3.0"
-```
-
-Or switch to the `per-token` calculator so TTFT reflects prompt length:
-
-```yaml
-shadowPod:
-  latencyCalculator: per-token
-  prefillOverhead: 30ms
-  prefillTimePerToken: 250us
 ```

--- a/pkg/gpu-node-mocker/controllers/config.go
+++ b/pkg/gpu-node-mocker/controllers/config.go
@@ -59,6 +59,19 @@ const (
 	// which shadow pod mirrors it, enabling idempotent reconciliation.
 	AnnotationShadowPodRef = "kaito.sh/shadow-pod-ref"
 
+	// AnnotationLatencyProfile lets an InferenceSet (via its pod template)
+	// select the llm-d-inference-sim latency profile for its shadow pods.
+	// Recognized values are "auto" (default — pick a profile from the model
+	// size parsed out of the served model name) or one of the named profiles
+	// ("small-l40s", "8b-h100", "13b", "30b-tp2", "70b-tp8", "405b-tp8").
+	// Unknown values fall back to "auto".
+	AnnotationLatencyProfile = "kaito.sh/latency-profile"
+
+	// AnnotationLatencyCalculator lets an InferenceSet select the simulator
+	// latency model per deployment: "per-token" (default) or "constant".
+	// Unknown values fall back to the operator-wide default and are logged.
+	AnnotationLatencyCalculator = "kaito.sh/latency-calculator"
+
 	// FakeProviderIDPrefix is intentionally un-parseable by the Azure CCM so
 	// InstanceExistsByProviderID returns an error and the CCM skips the node
 	// rather than deleting it.
@@ -89,40 +102,17 @@ const (
 	// DefaultUDSTokenizerImage is the default UDS tokenizer sidecar image.
 	DefaultUDSTokenizerImage = "ghcr.io/llm-d/llm-d-uds-tokenizer:v0.6.0"
 
-	// DefaultTimeToFirstToken / DefaultInterTokenLatency are the simulator
-	// latency knobs passed to llm-d-inference-sim's "constant" calculator. The
-	// defaults mirror an 8B-class model on H100 under balanced load (Profile 1
-	// in llm-d-inference-sim/docs/latency-profiles.md). Override per-deployment
-	// to mimic other model/hardware combinations.
-	DefaultTimeToFirstToken  = "100ms"
-	DefaultInterTokenLatency = "12ms"
-
-	// Default*StdDev add jitter so the simulator does not emit flat latencies.
-	// DefaultTimeFactorUnderLoad scales latency as concurrency approaches
-	// max-num-seqs. DefaultKVCacheTransferLatency models the constant
-	// prefill-cache transfer overhead. Values follow Profile 1.
-	DefaultTimeToFirstTokenStdDev  = "20ms"
-	DefaultInterTokenLatencyStdDev = "2ms"
-	DefaultKVCacheTransferLatency  = "2ms"
-	DefaultKVCacheTransferStdDev   = "400us"
-	DefaultTimeFactorUnderLoad     = "2.0"
-
 	// LatencyCalculatorConstant / LatencyCalculatorPerToken are the two
 	// llm-d-inference-sim latency models. "constant" derives TTFT from a fixed
 	// value; "per-token" derives it from prompt length via prefill overhead +
 	// per-token cost. See llm-d-inference-sim/docs/latency-profiles.md.
+	//
+	// Individual latency knob defaults are not defined here: when a Config knob
+	// is empty the value comes from the model-size latency profile selected in
+	// ensureSimConfigMap (see latency_profiles.go).
 	LatencyCalculatorConstant = "constant"
 	LatencyCalculatorPerToken = "per-token"
-	DefaultLatencyCalculator  = LatencyCalculatorConstant
-
-	// Default per-token calculator knobs (Profile 1: 8B/H100). PrefillOverhead
-	// is the fixed prefill cost; PrefillTimePerToken scales with prompt length;
-	// KVCacheTransferTimePerToken is the per-token cache transfer cost.
-	DefaultPrefillOverhead             = "30ms"
-	DefaultPrefillTimePerToken         = "250us"
-	DefaultPrefillTimeStdDev           = "5ms"
-	DefaultKVCacheTransferTimePerToken = "3us"
-	DefaultKVCacheTransferTimeStdDev   = "200us"
+	DefaultLatencyCalculator  = LatencyCalculatorPerToken
 
 	// InferenceSimPort is the default port for the inference simulator.
 	InferenceSimPort = 8001
@@ -216,8 +206,8 @@ type Config struct {
 	KVCacheTransferStdDev   string
 	TimeFactorUnderLoad     string
 
-	// LatencyCalculator selects the simulator latency model: "constant"
-	// (default) or "per-token". The per-token model derives TTFT from prompt
+	// LatencyCalculator selects the simulator latency model: "per-token"
+	// (default) or "constant". The per-token model derives TTFT from prompt
 	// length and uses the Prefill*/KVCacheTransferTime* knobs below instead of
 	// TimeToFirstToken / KVCacheTransferLatency.
 	LatencyCalculator string

--- a/pkg/gpu-node-mocker/controllers/config.go
+++ b/pkg/gpu-node-mocker/controllers/config.go
@@ -63,8 +63,7 @@ const (
 	// select the llm-d-inference-sim latency profile for its shadow pods.
 	// Recognized values are "auto" (default — pick a profile from the model
 	// size parsed out of the served model name) or one of the named profiles
-	// ("small-l40s", "8b-h100", "13b", "30b-tp2", "70b-tp8", "405b-tp8").
-	// Unknown values fall back to "auto".
+	// ("small-l40s", "8b-h100", "70b-tp8"). Unknown values fall back to "auto".
 	AnnotationLatencyProfile = "kaito.sh/latency-profile"
 
 	// AnnotationLatencyCalculator lets an InferenceSet select the simulator

--- a/pkg/gpu-node-mocker/controllers/latency_profiles.go
+++ b/pkg/gpu-node-mocker/controllers/latency_profiles.go
@@ -52,23 +52,24 @@ const (
 	// parameters). It is the default.
 	LatencyProfileAuto = "auto"
 
-	// LatencyProfile* are the named profiles from latency-profiles.md and its
-	// reference tables. Set one explicitly to force it regardless of model
-	// size. Buckets are keyed by parameter count: small (1–3B), 8B (7–8B, the
-	// fallback), 13B, 30B (TP=2), 70B (TP=8), and 405B (TP=8).
+	// LatencyProfile* are the three named profiles defined upstream in
+	// llm-d-inference-sim/manifests/latency-profiles. Each profile ships as two
+	// manifests — a constant-calculator and a per-token-calculator variant —
+	// whose knobs differ; latencyProfile below carries both sets and
+	// ensureSimConfigMap emits the subset for the active calculator. Set one
+	// explicitly to force it regardless of model size. Buckets are keyed by
+	// parameter count: small (1–3B), 8B (the fallback), and 70B (TP=8).
 	LatencyProfileSmallL40S = "small-l40s"
 	LatencyProfile8BH100    = "8b-h100"
-	LatencyProfile13B       = "13b"
-	LatencyProfile30BTP2    = "30b-tp2"
 	LatencyProfile70BTP8    = "70b-tp8"
-	LatencyProfile405BTP8   = "405b-tp8"
 
 	// DefaultLatencyProfile is the profile-selection mode used when none is set.
 	DefaultLatencyProfile = LatencyProfileAuto
 )
 
-// profile8BH100 mirrors "Profile 1: 8B-class model on H100, balanced load". It
-// is also the fallback for models whose size cannot be parsed.
+// profile8BH100 mirrors upstream 8b-h100-balanced ("Profile 1: 8B-class model
+// on H100, balanced load"). It is also the fallback for models whose size
+// cannot be parsed.
 var profile8BH100 = latencyProfile{
 	InterTokenLatency:           "12ms",
 	InterTokenLatencyStdDev:     "2ms",
@@ -79,45 +80,13 @@ var profile8BH100 = latencyProfile{
 	KVCacheTransferStdDev:       "400us",
 	PrefillOverhead:             "30ms",
 	PrefillTimePerToken:         "250us",
-	PrefillTimeStdDev:           "50us",
+	PrefillTimeStdDev:           "5ms",
 	KVCacheTransferTimePerToken: "3us",
-	KVCacheTransferTimeStdDev:   "600ns",
+	KVCacheTransferTimeStdDev:   "200us",
 }
 
-// profile13B mirrors the 13B reference row (H100-class, balanced load).
-var profile13B = latencyProfile{
-	InterTokenLatency:           "22ms",
-	InterTokenLatencyStdDev:     "3ms",
-	TimeFactorUnderLoad:         "2.2",
-	TimeToFirstToken:            "180ms",
-	TimeToFirstTokenStdDev:      "30ms",
-	KVCacheTransferLatency:      "2ms",
-	KVCacheTransferStdDev:       "400us",
-	PrefillOverhead:             "45ms",
-	PrefillTimePerToken:         "320us",
-	PrefillTimeStdDev:           "64us",
-	KVCacheTransferTimePerToken: "4us",
-	KVCacheTransferTimeStdDev:   "800ns",
-}
-
-// profile30BTP2 mirrors the 30–34B (TP=2) reference row.
-var profile30BTP2 = latencyProfile{
-	InterTokenLatency:           "30ms",
-	InterTokenLatencyStdDev:     "5ms",
-	TimeFactorUnderLoad:         "2.5",
-	TimeToFirstToken:            "250ms",
-	TimeToFirstTokenStdDev:      "50ms",
-	KVCacheTransferLatency:      "2ms",
-	KVCacheTransferStdDev:       "400us",
-	PrefillOverhead:             "60ms",
-	PrefillTimePerToken:         "400us",
-	PrefillTimeStdDev:           "80us",
-	KVCacheTransferTimePerToken: "6us",
-	KVCacheTransferTimeStdDev:   "1200ns",
-}
-
-// profile70BTP8 mirrors "Profile 2: 70B model on 8×H100 (TP=8),
-// throughput-optimized".
+// profile70BTP8 mirrors upstream 70b-h100-tp8-throughput ("Profile 2: 70B model
+// on 8×H100 (TP=8), throughput-optimized").
 var profile70BTP8 = latencyProfile{
 	InterTokenLatency:           "25ms",
 	InterTokenLatencyStdDev:     "4ms",
@@ -128,29 +97,13 @@ var profile70BTP8 = latencyProfile{
 	KVCacheTransferStdDev:       "400us",
 	PrefillOverhead:             "80ms",
 	PrefillTimePerToken:         "500us",
-	PrefillTimeStdDev:           "100us",
+	PrefillTimeStdDev:           "15ms",
 	KVCacheTransferTimePerToken: "8us",
-	KVCacheTransferTimeStdDev:   "1600ns",
+	KVCacheTransferTimeStdDev:   "500us",
 }
 
-// profile405BTP8 mirrors the 405B (TP=8) reference row.
-var profile405BTP8 = latencyProfile{
-	InterTokenLatency:           "80ms",
-	InterTokenLatencyStdDev:     "12ms",
-	TimeFactorUnderLoad:         "3.5",
-	TimeToFirstToken:            "900ms",
-	TimeToFirstTokenStdDev:      "150ms",
-	KVCacheTransferLatency:      "3ms",
-	KVCacheTransferStdDev:       "600us",
-	PrefillOverhead:             "200ms",
-	PrefillTimePerToken:         "1200us",
-	PrefillTimeStdDev:           "240us",
-	KVCacheTransferTimePerToken: "20us",
-	KVCacheTransferTimeStdDev:   "4us",
-}
-
-// profileSmallL40S mirrors "Profile 3: Small model (1–3B) on L40S,
-// low-latency edge".
+// profileSmallL40S mirrors upstream small-l40s-edge ("Profile 3: Small model
+// (1–3B) on L40S, low-latency edge").
 var profileSmallL40S = latencyProfile{
 	InterTokenLatency:           "15ms",
 	InterTokenLatencyStdDev:     "2ms",
@@ -161,21 +114,18 @@ var profileSmallL40S = latencyProfile{
 	KVCacheTransferStdDev:       "1ms",
 	PrefillOverhead:             "20ms",
 	PrefillTimePerToken:         "350us",
-	PrefillTimeStdDev:           "70us",
+	PrefillTimeStdDev:           "3ms",
 	KVCacheTransferTimePerToken: "12us",
-	KVCacheTransferTimeStdDev:   "2400ns",
+	KVCacheTransferTimeStdDev:   "500us",
 }
 
 // Model-size bucket boundaries (in billions of parameters) used by auto
 // selection. A model with a parsed size falls into the first bucket whose upper
-// bound it is below; models at/above the largest bound use the 405B profile.
+// bound it is below; models at/above the largest bound use the 70B profile.
 // Models whose size cannot be parsed fall back to the 8B profile.
 const (
-	modelSizeSmallMaxB = 5.0   // < 5B      ⇒ small-l40s (1–3B)
-	modelSize8BMaxB    = 10.0  // 5–10B     ⇒ 8b-h100 (7–8B)
-	modelSize13BMaxB   = 20.0  // 10–20B    ⇒ 13b
-	modelSize30BMaxB   = 50.0  // 20–50B    ⇒ 30b-tp2
-	modelSize70BMaxB   = 150.0 // 50–150B   ⇒ 70b-tp8; ≥150B ⇒ 405b-tp8
+	modelSizeSmallMaxB = 5.0  // < 5B    ⇒ small-l40s (1–3B)
+	modelSize8BMaxB    = 25.0 // 5–25B   ⇒ 8b-h100 (fallback); ≥25B ⇒ 70b-tp8
 )
 
 // modelSizeRe matches a parameter count immediately followed by a "b"/"B"
@@ -211,14 +161,8 @@ func profileForModelSize(sizeB float64) latencyProfile {
 		return profileSmallL40S
 	case sizeB < modelSize8BMaxB:
 		return profile8BH100
-	case sizeB < modelSize13BMaxB:
-		return profile13B
-	case sizeB < modelSize30BMaxB:
-		return profile30BTP2
-	case sizeB < modelSize70BMaxB:
-		return profile70BTP8
 	default:
-		return profile405BTP8
+		return profile70BTP8
 	}
 }
 
@@ -233,14 +177,8 @@ func selectLatencyProfile(mode, modelName string) latencyProfile {
 		return profileSmallL40S
 	case LatencyProfile8BH100:
 		return profile8BH100
-	case LatencyProfile13B:
-		return profile13B
-	case LatencyProfile30BTP2:
-		return profile30BTP2
 	case LatencyProfile70BTP8:
 		return profile70BTP8
-	case LatencyProfile405BTP8:
-		return profile405BTP8
 	default: // auto / empty / unknown
 		if sizeB, ok := parseModelSizeB(modelName); ok {
 			return profileForModelSize(sizeB)

--- a/pkg/gpu-node-mocker/controllers/latency_profiles.go
+++ b/pkg/gpu-node-mocker/controllers/latency_profiles.go
@@ -38,7 +38,13 @@ type latencyProfile struct {
 	KVCacheTransferLatency string
 	KVCacheTransferStdDev  string
 
-	// per-token calculator.
+	// per-token calculator. NOTE: the pinned sim image (DefaultInferenceSimImage,
+	// llm-d-inference-sim v0.8.1) rejects a config where PrefillTimeStdDev exceeds
+	// 30% of PrefillTimePerToken, or KVCacheTransferTimeStdDev exceeds 30% of
+	// KVCacheTransferTimePerToken (it compares std-dev to the PER-TOKEN base, not
+	// the final prefill time). Keep each *StdDev at ~20% of its per-token base.
+	// Do NOT copy the larger std-devs from upstream MAIN docs — those apply to
+	// the final prefill time and crash this pinned image at startup.
 	PrefillOverhead             string
 	PrefillTimePerToken         string
 	PrefillTimeStdDev           string
@@ -80,9 +86,9 @@ var profile8BH100 = latencyProfile{
 	KVCacheTransferStdDev:       "400us",
 	PrefillOverhead:             "30ms",
 	PrefillTimePerToken:         "250us",
-	PrefillTimeStdDev:           "5ms",
+	PrefillTimeStdDev:           "50us",
 	KVCacheTransferTimePerToken: "3us",
-	KVCacheTransferTimeStdDev:   "200us",
+	KVCacheTransferTimeStdDev:   "600ns",
 }
 
 // profile70BTP8 mirrors upstream 70b-h100-tp8-throughput ("Profile 2: 70B model
@@ -97,9 +103,9 @@ var profile70BTP8 = latencyProfile{
 	KVCacheTransferStdDev:       "400us",
 	PrefillOverhead:             "80ms",
 	PrefillTimePerToken:         "500us",
-	PrefillTimeStdDev:           "15ms",
+	PrefillTimeStdDev:           "100us",
 	KVCacheTransferTimePerToken: "8us",
-	KVCacheTransferTimeStdDev:   "500us",
+	KVCacheTransferTimeStdDev:   "1600ns",
 }
 
 // profileSmallL40S mirrors upstream small-l40s-edge ("Profile 3: Small model
@@ -114,9 +120,9 @@ var profileSmallL40S = latencyProfile{
 	KVCacheTransferStdDev:       "1ms",
 	PrefillOverhead:             "20ms",
 	PrefillTimePerToken:         "350us",
-	PrefillTimeStdDev:           "3ms",
+	PrefillTimeStdDev:           "70us",
 	KVCacheTransferTimePerToken: "12us",
-	KVCacheTransferTimeStdDev:   "500us",
+	KVCacheTransferTimeStdDev:   "2400ns",
 }
 
 // Model-size bucket boundaries (in billions of parameters) used by auto
@@ -188,24 +194,19 @@ func selectLatencyProfile(mode, modelName string) latencyProfile {
 }
 
 // resolveLatencyCalculator picks the simulator latency model. A per-deployment
-// annotation value takes precedence, then the operator-wide Config value, and
-// finally DefaultLatencyCalculator ("per-token"). The second return value is
-// true when the annotation was non-empty but unrecognized, so the caller can
-// log a warning; in that case the resolved value falls back to the Config /
-// default value rather than silently disabling serving.
-func resolveLatencyCalculator(annotation, configValue string) (calculator string, annotationInvalid bool) {
+// annotation value takes precedence; otherwise the operator-wide Config value
+// applies, falling back to DefaultLatencyCalculator ("per-token") when the
+// Config value is empty or unrecognized (main.go normalizes the flag at the
+// boundary, but tests build Config directly).
+func resolveLatencyCalculator(annotation, configValue string) string {
 	switch strings.ToLower(strings.TrimSpace(annotation)) {
 	case LatencyCalculatorConstant:
-		return LatencyCalculatorConstant, false
+		return LatencyCalculatorConstant
 	case LatencyCalculatorPerToken:
-		return LatencyCalculatorPerToken, false
-	case "":
-		// Absent/empty annotation: fall through to the Config/default chain.
-	default:
-		annotationInvalid = true
+		return LatencyCalculatorPerToken
 	}
 	if configValue == LatencyCalculatorConstant || configValue == LatencyCalculatorPerToken {
-		return configValue, annotationInvalid
+		return configValue
 	}
-	return DefaultLatencyCalculator, annotationInvalid
+	return DefaultLatencyCalculator
 }

--- a/pkg/gpu-node-mocker/controllers/latency_profiles.go
+++ b/pkg/gpu-node-mocker/controllers/latency_profiles.go
@@ -1,0 +1,273 @@
+/*
+Copyright 2026 The KAITO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controllers
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+// latencyProfile bundles the full set of llm-d-inference-sim latency knobs for
+// both calculators. Each profile mirrors one of the "Suggested Default
+// Profiles" in llm-d-inference-sim/docs/latency-profiles.md, so mocked
+// endpoints behave like a specific model/hardware combination.
+type latencyProfile struct {
+	// Common to both calculators.
+	InterTokenLatency       string
+	InterTokenLatencyStdDev string
+	TimeFactorUnderLoad     string
+
+	// constant calculator.
+	TimeToFirstToken       string
+	TimeToFirstTokenStdDev string
+	KVCacheTransferLatency string
+	KVCacheTransferStdDev  string
+
+	// per-token calculator.
+	PrefillOverhead             string
+	PrefillTimePerToken         string
+	PrefillTimeStdDev           string
+	KVCacheTransferTimePerToken string
+	KVCacheTransferTimeStdDev   string
+}
+
+const (
+	// LatencyProfileAuto selects a profile automatically from the model size
+	// parsed out of the served model name (e.g. "...-8B..." ⇒ 8 billion
+	// parameters). It is the default.
+	LatencyProfileAuto = "auto"
+
+	// LatencyProfile* are the named profiles from latency-profiles.md and its
+	// reference tables. Set one explicitly to force it regardless of model
+	// size. Buckets are keyed by parameter count: small (1–3B), 8B (7–8B, the
+	// fallback), 13B, 30B (TP=2), 70B (TP=8), and 405B (TP=8).
+	LatencyProfileSmallL40S = "small-l40s"
+	LatencyProfile8BH100    = "8b-h100"
+	LatencyProfile13B       = "13b"
+	LatencyProfile30BTP2    = "30b-tp2"
+	LatencyProfile70BTP8    = "70b-tp8"
+	LatencyProfile405BTP8   = "405b-tp8"
+
+	// DefaultLatencyProfile is the profile-selection mode used when none is set.
+	DefaultLatencyProfile = LatencyProfileAuto
+)
+
+// profile8BH100 mirrors "Profile 1: 8B-class model on H100, balanced load". It
+// is also the fallback for models whose size cannot be parsed.
+var profile8BH100 = latencyProfile{
+	InterTokenLatency:           "12ms",
+	InterTokenLatencyStdDev:     "2ms",
+	TimeFactorUnderLoad:         "2.0",
+	TimeToFirstToken:            "100ms",
+	TimeToFirstTokenStdDev:      "20ms",
+	KVCacheTransferLatency:      "2ms",
+	KVCacheTransferStdDev:       "400us",
+	PrefillOverhead:             "30ms",
+	PrefillTimePerToken:         "250us",
+	PrefillTimeStdDev:           "50us",
+	KVCacheTransferTimePerToken: "3us",
+	KVCacheTransferTimeStdDev:   "600ns",
+}
+
+// profile13B mirrors the 13B reference row (H100-class, balanced load).
+var profile13B = latencyProfile{
+	InterTokenLatency:           "22ms",
+	InterTokenLatencyStdDev:     "3ms",
+	TimeFactorUnderLoad:         "2.2",
+	TimeToFirstToken:            "180ms",
+	TimeToFirstTokenStdDev:      "30ms",
+	KVCacheTransferLatency:      "2ms",
+	KVCacheTransferStdDev:       "400us",
+	PrefillOverhead:             "45ms",
+	PrefillTimePerToken:         "320us",
+	PrefillTimeStdDev:           "64us",
+	KVCacheTransferTimePerToken: "4us",
+	KVCacheTransferTimeStdDev:   "800ns",
+}
+
+// profile30BTP2 mirrors the 30–34B (TP=2) reference row.
+var profile30BTP2 = latencyProfile{
+	InterTokenLatency:           "30ms",
+	InterTokenLatencyStdDev:     "5ms",
+	TimeFactorUnderLoad:         "2.5",
+	TimeToFirstToken:            "250ms",
+	TimeToFirstTokenStdDev:      "50ms",
+	KVCacheTransferLatency:      "2ms",
+	KVCacheTransferStdDev:       "400us",
+	PrefillOverhead:             "60ms",
+	PrefillTimePerToken:         "400us",
+	PrefillTimeStdDev:           "80us",
+	KVCacheTransferTimePerToken: "6us",
+	KVCacheTransferTimeStdDev:   "1200ns",
+}
+
+// profile70BTP8 mirrors "Profile 2: 70B model on 8×H100 (TP=8),
+// throughput-optimized".
+var profile70BTP8 = latencyProfile{
+	InterTokenLatency:           "25ms",
+	InterTokenLatencyStdDev:     "4ms",
+	TimeFactorUnderLoad:         "3.0",
+	TimeToFirstToken:            "200ms",
+	TimeToFirstTokenStdDev:      "40ms",
+	KVCacheTransferLatency:      "2ms",
+	KVCacheTransferStdDev:       "400us",
+	PrefillOverhead:             "80ms",
+	PrefillTimePerToken:         "500us",
+	PrefillTimeStdDev:           "100us",
+	KVCacheTransferTimePerToken: "8us",
+	KVCacheTransferTimeStdDev:   "1600ns",
+}
+
+// profile405BTP8 mirrors the 405B (TP=8) reference row.
+var profile405BTP8 = latencyProfile{
+	InterTokenLatency:           "80ms",
+	InterTokenLatencyStdDev:     "12ms",
+	TimeFactorUnderLoad:         "3.5",
+	TimeToFirstToken:            "900ms",
+	TimeToFirstTokenStdDev:      "150ms",
+	KVCacheTransferLatency:      "3ms",
+	KVCacheTransferStdDev:       "600us",
+	PrefillOverhead:             "200ms",
+	PrefillTimePerToken:         "1200us",
+	PrefillTimeStdDev:           "240us",
+	KVCacheTransferTimePerToken: "20us",
+	KVCacheTransferTimeStdDev:   "4us",
+}
+
+// profileSmallL40S mirrors "Profile 3: Small model (1–3B) on L40S,
+// low-latency edge".
+var profileSmallL40S = latencyProfile{
+	InterTokenLatency:           "15ms",
+	InterTokenLatencyStdDev:     "2ms",
+	TimeFactorUnderLoad:         "1.5",
+	TimeToFirstToken:            "110ms",
+	TimeToFirstTokenStdDev:      "15ms",
+	KVCacheTransferLatency:      "5ms",
+	KVCacheTransferStdDev:       "1ms",
+	PrefillOverhead:             "20ms",
+	PrefillTimePerToken:         "350us",
+	PrefillTimeStdDev:           "70us",
+	KVCacheTransferTimePerToken: "12us",
+	KVCacheTransferTimeStdDev:   "2400ns",
+}
+
+// Model-size bucket boundaries (in billions of parameters) used by auto
+// selection. A model with a parsed size falls into the first bucket whose upper
+// bound it is below; models at/above the largest bound use the 405B profile.
+// Models whose size cannot be parsed fall back to the 8B profile.
+const (
+	modelSizeSmallMaxB = 5.0   // < 5B      ⇒ small-l40s (1–3B)
+	modelSize8BMaxB    = 10.0  // 5–10B     ⇒ 8b-h100 (7–8B)
+	modelSize13BMaxB   = 20.0  // 10–20B    ⇒ 13b
+	modelSize30BMaxB   = 50.0  // 20–50B    ⇒ 30b-tp2
+	modelSize70BMaxB   = 150.0 // 50–150B   ⇒ 70b-tp8; ≥150B ⇒ 405b-tp8
+)
+
+// modelSizeRe matches a parameter count immediately followed by a "b"/"B"
+// suffix inside a model name, e.g. "8B", "0.5b", "70B", "405B".
+var modelSizeRe = regexp.MustCompile(`(\d+(?:\.\d+)?)[bB]`)
+
+// parseModelSizeB extracts the parameter count in billions from a model name.
+// It returns the largest "<number>B" token found (so "Llama-3.1-8B" ⇒ 8) and
+// false when no size token is present.
+func parseModelSizeB(modelName string) (float64, bool) {
+	matches := modelSizeRe.FindAllStringSubmatch(modelName, -1)
+	if len(matches) == 0 {
+		return 0, false
+	}
+	var maxB float64
+	var found bool
+	for _, m := range matches {
+		v, err := strconv.ParseFloat(m[1], 64)
+		if err != nil {
+			continue
+		}
+		if !found || v > maxB {
+			maxB, found = v, true
+		}
+	}
+	return maxB, found
+}
+
+// profileForModelSize maps a parameter count (billions) to a profile.
+func profileForModelSize(sizeB float64) latencyProfile {
+	switch {
+	case sizeB < modelSizeSmallMaxB:
+		return profileSmallL40S
+	case sizeB < modelSize8BMaxB:
+		return profile8BH100
+	case sizeB < modelSize13BMaxB:
+		return profile13B
+	case sizeB < modelSize30BMaxB:
+		return profile30BTP2
+	case sizeB < modelSize70BMaxB:
+		return profile70BTP8
+	default:
+		return profile405BTP8
+	}
+}
+
+// selectLatencyProfile resolves the baseline latency profile for a shadow pod.
+// The profile mode ("auto" or an explicit name) picks the baseline; individual
+// non-empty Config knobs still override the corresponding profile value in
+// ensureSimConfigMap. Unrecognized modes and models without a parseable size
+// fall back to the balanced 8B profile (the historical default).
+func selectLatencyProfile(mode, modelName string) latencyProfile {
+	switch strings.ToLower(strings.TrimSpace(mode)) {
+	case LatencyProfileSmallL40S:
+		return profileSmallL40S
+	case LatencyProfile8BH100:
+		return profile8BH100
+	case LatencyProfile13B:
+		return profile13B
+	case LatencyProfile30BTP2:
+		return profile30BTP2
+	case LatencyProfile70BTP8:
+		return profile70BTP8
+	case LatencyProfile405BTP8:
+		return profile405BTP8
+	default: // auto / empty / unknown
+		if sizeB, ok := parseModelSizeB(modelName); ok {
+			return profileForModelSize(sizeB)
+		}
+		return profile8BH100
+	}
+}
+
+// resolveLatencyCalculator picks the simulator latency model. A per-deployment
+// annotation value takes precedence, then the operator-wide Config value, and
+// finally DefaultLatencyCalculator ("per-token"). The second return value is
+// true when the annotation was non-empty but unrecognized, so the caller can
+// log a warning; in that case the resolved value falls back to the Config /
+// default value rather than silently disabling serving.
+func resolveLatencyCalculator(annotation, configValue string) (calculator string, annotationInvalid bool) {
+	switch strings.ToLower(strings.TrimSpace(annotation)) {
+	case LatencyCalculatorConstant:
+		return LatencyCalculatorConstant, false
+	case LatencyCalculatorPerToken:
+		return LatencyCalculatorPerToken, false
+	case "":
+		// Absent/empty annotation: fall through to the Config/default chain.
+	default:
+		annotationInvalid = true
+	}
+	if configValue == LatencyCalculatorConstant || configValue == LatencyCalculatorPerToken {
+		return configValue, annotationInvalid
+	}
+	return DefaultLatencyCalculator, annotationInvalid
+}

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
@@ -201,7 +201,7 @@ func (r *ShadowPodReconciler) ensureShadowPod(ctx context.Context, original *cor
 	}
 
 	// Ensure the ConfigMap for the inference simulator exists.
-	if err := r.ensureSimConfigMap(ctx, shadowNS, shadowName, modelName, servedModelName, servingPort, ownerRef); err != nil {
+	if err := r.ensureSimConfigMap(ctx, shadowNS, shadowName, modelName, servedModelName, servingPort, original.Annotations, ownerRef); err != nil {
 		return nil, fmt.Errorf("ensure sim configmap: %w", err)
 	}
 
@@ -488,30 +488,41 @@ func valueOrDefault(v, def string) string {
 // The config enables KV cache but does not set any threshold so cache_threshold
 // is never triggered. The port is set to match the original pod's serving port.
 //
+// The baseline latency knobs come from a latency profile selected via the
+// original pod's annotations: AnnotationLatencyProfile picks the profile
+// ("auto" — the default — chooses one from the served model size, or a named
+// profile), and AnnotationLatencyCalculator picks the calculator ("per-token"
+// — the default — or "constant"). Non-empty operator-wide Config knobs still
+// override the corresponding profile value, and the --latency-calculator flag
+// provides the calculator default when the annotation is absent.
+//
 // ownerRef is set on the ConfigMap so it is garbage-collected together with
 // the original pod (same namespace, K8s GC cascades the delete).
-func (r *ShadowPodReconciler) ensureSimConfigMap(ctx context.Context, namespace, shadowName, modelName, servedModelName string, port int32, ownerRef metav1.OwnerReference) error {
+func (r *ShadowPodReconciler) ensureSimConfigMap(ctx context.Context, namespace, shadowName, modelName, servedModelName string, port int32, annotations map[string]string, ownerRef metav1.OwnerReference) error {
 	cmName := shadowName + "-config"
 	existing := &corev1.ConfigMap{}
 	if err := r.Get(ctx, types.NamespacedName{Namespace: namespace, Name: cmName}, existing); err == nil {
 		return nil
 	}
 
-	itl := r.Config.InterTokenLatency
-	if itl == "" {
-		itl = DefaultInterTokenLatency
+	// Baseline latency knobs come from the profile selected by annotation
+	// (default "auto" ⇒ chosen from the served model size). Non-empty Config
+	// knobs override individual profile values below.
+	profileMode := annotations[AnnotationLatencyProfile]
+	if profileMode == "" {
+		profileMode = DefaultLatencyProfile
 	}
-	itlStdDev := r.Config.InterTokenLatencyStdDev
-	if itlStdDev == "" {
-		itlStdDev = DefaultInterTokenLatencyStdDev
-	}
-	timeFactor := r.Config.TimeFactorUnderLoad
-	if timeFactor == "" {
-		timeFactor = DefaultTimeFactorUnderLoad
-	}
-	calculator := r.Config.LatencyCalculator
-	if calculator == "" {
-		calculator = DefaultLatencyCalculator
+	profile := selectLatencyProfile(profileMode, servedModelName)
+
+	itl := valueOrDefault(r.Config.InterTokenLatency, profile.InterTokenLatency)
+	itlStdDev := valueOrDefault(r.Config.InterTokenLatencyStdDev, profile.InterTokenLatencyStdDev)
+	timeFactor := valueOrDefault(r.Config.TimeFactorUnderLoad, profile.TimeFactorUnderLoad)
+	calculator, calcAnnotationInvalid := resolveLatencyCalculator(annotations[AnnotationLatencyCalculator], r.Config.LatencyCalculator)
+	if calcAnnotationInvalid {
+		log.FromContext(ctx).Info("unrecognized latency-calculator annotation; falling back",
+			"annotation", AnnotationLatencyCalculator,
+			"value", annotations[AnnotationLatencyCalculator],
+			"fallback", calculator)
 	}
 
 	// Fields common to both calculators.
@@ -522,11 +533,11 @@ time-factor-under-load: %s
 `, calculator, itl, itlStdDev, timeFactor)
 
 	if calculator == LatencyCalculatorPerToken {
-		prefillOverhead := valueOrDefault(r.Config.PrefillOverhead, DefaultPrefillOverhead)
-		prefillPerToken := valueOrDefault(r.Config.PrefillTimePerToken, DefaultPrefillTimePerToken)
-		prefillStdDev := valueOrDefault(r.Config.PrefillTimeStdDev, DefaultPrefillTimeStdDev)
-		kvPerToken := valueOrDefault(r.Config.KVCacheTransferTimePerToken, DefaultKVCacheTransferTimePerToken)
-		kvTimeStdDev := valueOrDefault(r.Config.KVCacheTransferTimeStdDev, DefaultKVCacheTransferTimeStdDev)
+		prefillOverhead := valueOrDefault(r.Config.PrefillOverhead, profile.PrefillOverhead)
+		prefillPerToken := valueOrDefault(r.Config.PrefillTimePerToken, profile.PrefillTimePerToken)
+		prefillStdDev := valueOrDefault(r.Config.PrefillTimeStdDev, profile.PrefillTimeStdDev)
+		kvPerToken := valueOrDefault(r.Config.KVCacheTransferTimePerToken, profile.KVCacheTransferTimePerToken)
+		kvTimeStdDev := valueOrDefault(r.Config.KVCacheTransferTimeStdDev, profile.KVCacheTransferTimeStdDev)
 		latencyYAML += fmt.Sprintf(`prefill-overhead: %s
 prefill-time-per-token: %s
 prefill-time-std-dev: %s
@@ -534,10 +545,10 @@ kv-cache-transfer-time-per-token: %s
 kv-cache-transfer-time-std-dev: %s
 `, prefillOverhead, prefillPerToken, prefillStdDev, kvPerToken, kvTimeStdDev)
 	} else {
-		ttft := valueOrDefault(r.Config.TimeToFirstToken, DefaultTimeToFirstToken)
-		ttftStdDev := valueOrDefault(r.Config.TimeToFirstTokenStdDev, DefaultTimeToFirstTokenStdDev)
-		kvTransfer := valueOrDefault(r.Config.KVCacheTransferLatency, DefaultKVCacheTransferLatency)
-		kvTransferStdDev := valueOrDefault(r.Config.KVCacheTransferStdDev, DefaultKVCacheTransferStdDev)
+		ttft := valueOrDefault(r.Config.TimeToFirstToken, profile.TimeToFirstToken)
+		ttftStdDev := valueOrDefault(r.Config.TimeToFirstTokenStdDev, profile.TimeToFirstTokenStdDev)
+		kvTransfer := valueOrDefault(r.Config.KVCacheTransferLatency, profile.KVCacheTransferLatency)
+		kvTransferStdDev := valueOrDefault(r.Config.KVCacheTransferStdDev, profile.KVCacheTransferStdDev)
 		latencyYAML += fmt.Sprintf(`time-to-first-token: %s
 time-to-first-token-std-dev: %s
 kv-cache-transfer-latency: %s

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
@@ -488,13 +488,15 @@ func valueOrDefault(v, def string) string {
 // The config enables KV cache but does not set any threshold so cache_threshold
 // is never triggered. The port is set to match the original pod's serving port.
 //
-// The baseline latency knobs come from a latency profile selected via the
-// original pod's annotations: AnnotationLatencyProfile picks the profile
-// ("auto" — the default — chooses one from the served model size, or a named
-// profile), and AnnotationLatencyCalculator picks the calculator ("per-token"
-// — the default — or "constant"). Non-empty operator-wide Config knobs still
-// override the corresponding profile value, and the --latency-calculator flag
-// provides the calculator default when the annotation is absent.
+// The baseline latency knobs default to the operator-wide Config values and
+// are overridden by a latency profile selected via the original pod's
+// annotations: AnnotationLatencyProfile picks the profile ("auto" — the
+// default — chooses one from the served model size, or a named profile), and
+// AnnotationLatencyCalculator picks the calculator ("per-token" — the default
+// — or "constant"). A non-empty profile value overrides the corresponding
+// operator-wide Config default, which applies whenever the profile leaves that
+// knob empty; the --latency-calculator flag provides the calculator default
+// when the annotation is absent.
 //
 // ownerRef is set on the ConfigMap so it is garbage-collected together with
 // the original pod (same namespace, K8s GC cascades the delete).
@@ -505,18 +507,19 @@ func (r *ShadowPodReconciler) ensureSimConfigMap(ctx context.Context, namespace,
 		return nil
 	}
 
-	// Baseline latency knobs come from the profile selected by annotation
-	// (default "auto" ⇒ chosen from the served model size). Non-empty Config
-	// knobs override individual profile values below.
+	// Baseline latency knobs default to the operator-wide Config values and are
+	// overridden by the profile selected by annotation (default "auto" ⇒ chosen
+	// from the served model size). A non-empty profile value wins; the Config
+	// default applies whenever the profile leaves that knob empty.
 	profileMode := annotations[AnnotationLatencyProfile]
 	if profileMode == "" {
 		profileMode = DefaultLatencyProfile
 	}
 	profile := selectLatencyProfile(profileMode, servedModelName)
 
-	itl := valueOrDefault(r.Config.InterTokenLatency, profile.InterTokenLatency)
-	itlStdDev := valueOrDefault(r.Config.InterTokenLatencyStdDev, profile.InterTokenLatencyStdDev)
-	timeFactor := valueOrDefault(r.Config.TimeFactorUnderLoad, profile.TimeFactorUnderLoad)
+	itl := valueOrDefault(profile.InterTokenLatency, r.Config.InterTokenLatency)
+	itlStdDev := valueOrDefault(profile.InterTokenLatencyStdDev, r.Config.InterTokenLatencyStdDev)
+	timeFactor := valueOrDefault(profile.TimeFactorUnderLoad, r.Config.TimeFactorUnderLoad)
 	calculator, calcAnnotationInvalid := resolveLatencyCalculator(annotations[AnnotationLatencyCalculator], r.Config.LatencyCalculator)
 	if calcAnnotationInvalid {
 		log.FromContext(ctx).Info("unrecognized latency-calculator annotation; falling back",
@@ -533,11 +536,11 @@ time-factor-under-load: %s
 `, calculator, itl, itlStdDev, timeFactor)
 
 	if calculator == LatencyCalculatorPerToken {
-		prefillOverhead := valueOrDefault(r.Config.PrefillOverhead, profile.PrefillOverhead)
-		prefillPerToken := valueOrDefault(r.Config.PrefillTimePerToken, profile.PrefillTimePerToken)
-		prefillStdDev := valueOrDefault(r.Config.PrefillTimeStdDev, profile.PrefillTimeStdDev)
-		kvPerToken := valueOrDefault(r.Config.KVCacheTransferTimePerToken, profile.KVCacheTransferTimePerToken)
-		kvTimeStdDev := valueOrDefault(r.Config.KVCacheTransferTimeStdDev, profile.KVCacheTransferTimeStdDev)
+		prefillOverhead := valueOrDefault(profile.PrefillOverhead, r.Config.PrefillOverhead)
+		prefillPerToken := valueOrDefault(profile.PrefillTimePerToken, r.Config.PrefillTimePerToken)
+		prefillStdDev := valueOrDefault(profile.PrefillTimeStdDev, r.Config.PrefillTimeStdDev)
+		kvPerToken := valueOrDefault(profile.KVCacheTransferTimePerToken, r.Config.KVCacheTransferTimePerToken)
+		kvTimeStdDev := valueOrDefault(profile.KVCacheTransferTimeStdDev, r.Config.KVCacheTransferTimeStdDev)
 		latencyYAML += fmt.Sprintf(`prefill-overhead: %s
 prefill-time-per-token: %s
 prefill-time-std-dev: %s
@@ -545,10 +548,10 @@ kv-cache-transfer-time-per-token: %s
 kv-cache-transfer-time-std-dev: %s
 `, prefillOverhead, prefillPerToken, prefillStdDev, kvPerToken, kvTimeStdDev)
 	} else {
-		ttft := valueOrDefault(r.Config.TimeToFirstToken, profile.TimeToFirstToken)
-		ttftStdDev := valueOrDefault(r.Config.TimeToFirstTokenStdDev, profile.TimeToFirstTokenStdDev)
-		kvTransfer := valueOrDefault(r.Config.KVCacheTransferLatency, profile.KVCacheTransferLatency)
-		kvTransferStdDev := valueOrDefault(r.Config.KVCacheTransferStdDev, profile.KVCacheTransferStdDev)
+		ttft := valueOrDefault(profile.TimeToFirstToken, r.Config.TimeToFirstToken)
+		ttftStdDev := valueOrDefault(profile.TimeToFirstTokenStdDev, r.Config.TimeToFirstTokenStdDev)
+		kvTransfer := valueOrDefault(profile.KVCacheTransferLatency, r.Config.KVCacheTransferLatency)
+		kvTransferStdDev := valueOrDefault(profile.KVCacheTransferStdDev, r.Config.KVCacheTransferStdDev)
 		latencyYAML += fmt.Sprintf(`time-to-first-token: %s
 time-to-first-token-std-dev: %s
 kv-cache-transfer-latency: %s

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
@@ -520,13 +520,7 @@ func (r *ShadowPodReconciler) ensureSimConfigMap(ctx context.Context, namespace,
 	itl := valueOrDefault(profile.InterTokenLatency, r.Config.InterTokenLatency)
 	itlStdDev := valueOrDefault(profile.InterTokenLatencyStdDev, r.Config.InterTokenLatencyStdDev)
 	timeFactor := valueOrDefault(profile.TimeFactorUnderLoad, r.Config.TimeFactorUnderLoad)
-	calculator, calcAnnotationInvalid := resolveLatencyCalculator(annotations[AnnotationLatencyCalculator], r.Config.LatencyCalculator)
-	if calcAnnotationInvalid {
-		log.FromContext(ctx).Info("unrecognized latency-calculator annotation; falling back",
-			"annotation", AnnotationLatencyCalculator,
-			"value", annotations[AnnotationLatencyCalculator],
-			"fallback", calculator)
-	}
+	calculator := resolveLatencyCalculator(annotations[AnnotationLatencyCalculator], r.Config.LatencyCalculator)
 
 	// Fields common to both calculators.
 	latencyYAML := fmt.Sprintf(`latency-calculator: %s

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
@@ -915,9 +915,9 @@ func TestEnsureSimConfigMap(t *testing.T) {
 		"time-factor-under-load: 2.0",
 		"prefill-overhead: 30ms",
 		"prefill-time-per-token: 250us",
-		"prefill-time-std-dev: 5ms",
+		"prefill-time-std-dev: 50us",
 		"kv-cache-transfer-time-per-token: 3us",
-		"kv-cache-transfer-time-std-dev: 200us",
+		"kv-cache-transfer-time-std-dev: 600ns",
 	} {
 		if !strings.Contains(configYAML, want) {
 			t.Errorf("missing default %q in config: %s", want, configYAML)
@@ -1017,9 +1017,9 @@ func TestEnsureSimConfigMap_PerTokenCalculator(t *testing.T) {
 		"inter-token-latency: 12ms",
 		"prefill-overhead: 30ms",
 		"prefill-time-per-token: 250us",
-		"prefill-time-std-dev: 5ms",
+		"prefill-time-std-dev: 50us",
 		"kv-cache-transfer-time-per-token: 3us",
-		"kv-cache-transfer-time-std-dev: 200us",
+		"kv-cache-transfer-time-std-dev: 600ns",
 		"time-factor-under-load: 2.0",
 	} {
 		if !strings.Contains(configYAML, want) {

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
@@ -915,9 +915,9 @@ func TestEnsureSimConfigMap(t *testing.T) {
 		"time-factor-under-load: 2.0",
 		"prefill-overhead: 30ms",
 		"prefill-time-per-token: 250us",
-		"prefill-time-std-dev: 50us",
+		"prefill-time-std-dev: 5ms",
 		"kv-cache-transfer-time-per-token: 3us",
-		"kv-cache-transfer-time-std-dev: 600ns",
+		"kv-cache-transfer-time-std-dev: 200us",
 	} {
 		if !strings.Contains(configYAML, want) {
 			t.Errorf("missing default %q in config: %s", want, configYAML)
@@ -1017,9 +1017,9 @@ func TestEnsureSimConfigMap_PerTokenCalculator(t *testing.T) {
 		"inter-token-latency: 12ms",
 		"prefill-overhead: 30ms",
 		"prefill-time-per-token: 250us",
-		"prefill-time-std-dev: 50us",
+		"prefill-time-std-dev: 5ms",
 		"kv-cache-transfer-time-per-token: 3us",
-		"kv-cache-transfer-time-std-dev: 600ns",
+		"kv-cache-transfer-time-std-dev: 200us",
 		"time-factor-under-load: 2.0",
 	} {
 		if !strings.Contains(configYAML, want) {
@@ -1058,7 +1058,7 @@ func simConfigYAML(t *testing.T, cfg Config, modelName, servedModelName string, 
 
 // TestEnsureSimConfigMap_AutoProfileBySize verifies that with no profile
 // annotation, the baseline latency profile is auto-selected from the served
-// model size across all six buckets. The constant calculator is forced so the
+// model size across the three buckets. The constant calculator is forced so the
 // profile's time-to-first-token is emitted for assertion.
 func TestEnsureSimConfigMap_AutoProfileBySize(t *testing.T) {
 	tests := []struct {
@@ -1070,10 +1070,9 @@ func TestEnsureSimConfigMap_AutoProfileBySize(t *testing.T) {
 	}{
 		{"small 3B ⇒ small-l40s", "phi-3b-mini", "time-to-first-token: 110ms", "inter-token-latency: 15ms", "time-factor-under-load: 1.5"},
 		{"8B ⇒ 8b-h100", "llama-3.1-8b-instruct", "time-to-first-token: 100ms", "inter-token-latency: 12ms", "time-factor-under-load: 2.0"},
-		{"13B ⇒ 13b", "llama-2-13b-chat", "time-to-first-token: 180ms", "inter-token-latency: 22ms", "time-factor-under-load: 2.2"},
-		{"34B ⇒ 30b-tp2", "yi-34b-chat", "time-to-first-token: 250ms", "inter-token-latency: 30ms", "time-factor-under-load: 2.5"},
+		{"13B ⇒ 8b-h100 (fallback bucket)", "llama-2-13b-chat", "time-to-first-token: 100ms", "inter-token-latency: 12ms", "time-factor-under-load: 2.0"},
 		{"70B ⇒ 70b-tp8", "llama-3.1-70b-instruct", "time-to-first-token: 200ms", "inter-token-latency: 25ms", "time-factor-under-load: 3.0"},
-		{"405B ⇒ 405b-tp8", "llama-3.1-405b-instruct", "time-to-first-token: 900ms", "inter-token-latency: 80ms", "time-factor-under-load: 3.5"},
+		{"405B ⇒ 70b-tp8", "llama-3.1-405b-instruct", "time-to-first-token: 200ms", "inter-token-latency: 25ms", "time-factor-under-load: 3.0"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
@@ -880,7 +880,7 @@ func TestEnsureSimConfigMap(t *testing.T) {
 		Controller: ptr.To(true),
 	}
 
-	err := r.ensureSimConfigMap(ctx, "default", "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000, ownerRef)
+	err := r.ensureSimConfigMap(ctx, "default", "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000, nil, ownerRef)
 	if err != nil {
 		t.Fatalf("ensureSimConfigMap: %v", err)
 	}
@@ -906,28 +906,30 @@ func TestEnsureSimConfigMap(t *testing.T) {
 	if strings.Contains(configYAML, "threshold") {
 		t.Errorf("config should not contain threshold: %s", configYAML)
 	}
-	// Empty Config latency fields ⇒ Profile 1 constant-calculator defaults.
+	// Empty Config + no annotation ⇒ per-token calculator (the default) with
+	// the auto-selected 8B profile (served name "falcon-7b-instruct" ⇒ 7B).
 	for _, want := range []string{
-		"latency-calculator: constant",
-		"time-to-first-token: 100ms",
+		"latency-calculator: per-token",
 		"inter-token-latency: 12ms",
-		"time-to-first-token-std-dev: 20ms",
 		"inter-token-latency-std-dev: 2ms",
-		"kv-cache-transfer-latency: 2ms",
-		"kv-cache-transfer-latency-std-dev: 400us",
 		"time-factor-under-load: 2.0",
+		"prefill-overhead: 30ms",
+		"prefill-time-per-token: 250us",
+		"prefill-time-std-dev: 50us",
+		"kv-cache-transfer-time-per-token: 3us",
+		"kv-cache-transfer-time-std-dev: 600ns",
 	} {
 		if !strings.Contains(configYAML, want) {
 			t.Errorf("missing default %q in config: %s", want, configYAML)
 		}
 	}
-	// Constant calculator must not emit per-token-only fields.
-	if strings.Contains(configYAML, "prefill-overhead") {
-		t.Errorf("constant calculator should not emit prefill fields: %s", configYAML)
+	// Per-token calculator must not emit constant-only fields.
+	if strings.Contains(configYAML, "time-to-first-token:") {
+		t.Errorf("per-token calculator should not emit time-to-first-token: %s", configYAML)
 	}
 
 	// Idempotent: calling again should not error
-	if err := r.ensureSimConfigMap(ctx, "default", "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000, ownerRef); err != nil {
+	if err := r.ensureSimConfigMap(ctx, "default", "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000, nil, ownerRef); err != nil {
 		t.Fatalf("second call should be idempotent: %v", err)
 	}
 }
@@ -936,6 +938,9 @@ func TestEnsureSimConfigMap_LatencyOverrides(t *testing.T) {
 	ctx := context.Background()
 	scheme := testScheme()
 	cfg := testConfig()
+	// Force the constant calculator so the constant-only overrides below are
+	// exercised (per-token is now the default).
+	cfg.LatencyCalculator = LatencyCalculatorConstant
 	cfg.TimeToFirstToken = "200ms"
 	cfg.InterTokenLatency = "25ms"
 	cfg.TimeToFirstTokenStdDev = "40ms"
@@ -949,7 +954,7 @@ func TestEnsureSimConfigMap_LatencyOverrides(t *testing.T) {
 	r := &ShadowPodReconciler{Client: cl, Config: cfg}
 
 	ownerRef := metav1.OwnerReference{APIVersion: "v1", Kind: "Pod", Name: "falcon-0", UID: "test-uid", Controller: ptr.To(true)}
-	if err := r.ensureSimConfigMap(ctx, "default", "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000, ownerRef); err != nil {
+	if err := r.ensureSimConfigMap(ctx, "default", "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000, nil, ownerRef); err != nil {
 		t.Fatalf("ensureSimConfigMap: %v", err)
 	}
 
@@ -984,7 +989,7 @@ func TestEnsureSimConfigMap_PerTokenCalculator(t *testing.T) {
 	r := &ShadowPodReconciler{Client: cl, Config: cfg}
 
 	ownerRef := metav1.OwnerReference{APIVersion: "v1", Kind: "Pod", Name: "falcon-0", UID: "test-uid", Controller: ptr.To(true)}
-	if err := r.ensureSimConfigMap(ctx, "default", "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000, ownerRef); err != nil {
+	if err := r.ensureSimConfigMap(ctx, "default", "shadow-default-falcon-0", "tiiuae/falcon-7b", "falcon-7b-instruct", 5000, nil, ownerRef); err != nil {
 		t.Fatalf("ensureSimConfigMap: %v", err)
 	}
 
@@ -999,9 +1004,9 @@ func TestEnsureSimConfigMap_PerTokenCalculator(t *testing.T) {
 		"inter-token-latency: 12ms",
 		"prefill-overhead: 30ms",
 		"prefill-time-per-token: 250us",
-		"prefill-time-std-dev: 5ms",
+		"prefill-time-std-dev: 50us",
 		"kv-cache-transfer-time-per-token: 3us",
-		"kv-cache-transfer-time-std-dev: 200us",
+		"kv-cache-transfer-time-std-dev: 600ns",
 		"time-factor-under-load: 2.0",
 	} {
 		if !strings.Contains(configYAML, want) {
@@ -1016,5 +1021,113 @@ func TestEnsureSimConfigMap_PerTokenCalculator(t *testing.T) {
 		if strings.Contains(configYAML, unwanted) {
 			t.Errorf("per-token calculator should not emit %q: %s", unwanted, configYAML)
 		}
+	}
+}
+
+// simConfigYAML runs ensureSimConfigMap and returns the rendered config.yaml.
+func simConfigYAML(t *testing.T, cfg Config, modelName, servedModelName string, annotations map[string]string) string {
+	t.Helper()
+	ctx := context.Background()
+	scheme := testScheme()
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns).Build()
+	r := &ShadowPodReconciler{Client: cl, Config: cfg}
+	ownerRef := metav1.OwnerReference{APIVersion: "v1", Kind: "Pod", Name: "m-0", UID: "uid", Controller: ptr.To(true)}
+	if err := r.ensureSimConfigMap(ctx, "default", "shadow-default-m-0", modelName, servedModelName, 5000, annotations, ownerRef); err != nil {
+		t.Fatalf("ensureSimConfigMap: %v", err)
+	}
+	cm := &corev1.ConfigMap{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: "shadow-default-m-0-config", Namespace: "default"}, cm); err != nil {
+		t.Fatalf("configmap not found: %v", err)
+	}
+	return cm.Data["config.yaml"]
+}
+
+// TestEnsureSimConfigMap_AutoProfileBySize verifies that with no profile
+// annotation, the baseline latency profile is auto-selected from the served
+// model size across all six buckets. The constant calculator is forced so the
+// profile's time-to-first-token is emitted for assertion.
+func TestEnsureSimConfigMap_AutoProfileBySize(t *testing.T) {
+	tests := []struct {
+		name            string
+		servedModelName string
+		wantTTFT        string
+		wantITL         string
+		wantFactor      string
+	}{
+		{"small 3B ⇒ small-l40s", "phi-3b-mini", "time-to-first-token: 110ms", "inter-token-latency: 15ms", "time-factor-under-load: 1.5"},
+		{"8B ⇒ 8b-h100", "llama-3.1-8b-instruct", "time-to-first-token: 100ms", "inter-token-latency: 12ms", "time-factor-under-load: 2.0"},
+		{"13B ⇒ 13b", "llama-2-13b-chat", "time-to-first-token: 180ms", "inter-token-latency: 22ms", "time-factor-under-load: 2.2"},
+		{"34B ⇒ 30b-tp2", "yi-34b-chat", "time-to-first-token: 250ms", "inter-token-latency: 30ms", "time-factor-under-load: 2.5"},
+		{"70B ⇒ 70b-tp8", "llama-3.1-70b-instruct", "time-to-first-token: 200ms", "inter-token-latency: 25ms", "time-factor-under-load: 3.0"},
+		{"405B ⇒ 405b-tp8", "llama-3.1-405b-instruct", "time-to-first-token: 900ms", "inter-token-latency: 80ms", "time-factor-under-load: 3.5"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := testConfig()
+			cfg.LatencyCalculator = LatencyCalculatorConstant
+			configYAML := simConfigYAML(t, cfg, "org/"+tt.servedModelName, tt.servedModelName, nil)
+			for _, want := range []string{"latency-calculator: constant", tt.wantTTFT, tt.wantITL, tt.wantFactor} {
+				if !strings.Contains(configYAML, want) {
+					t.Errorf("missing %q in config: %s", want, configYAML)
+				}
+			}
+		})
+	}
+}
+
+// TestEnsureSimConfigMap_DefaultCalculatorPerToken verifies that, with no
+// annotation and an empty Config, the calculator defaults to per-token.
+func TestEnsureSimConfigMap_DefaultCalculatorPerToken(t *testing.T) {
+	configYAML := simConfigYAML(t, testConfig(), "org/falcon-7b", "falcon-7b-instruct", nil)
+	if !strings.Contains(configYAML, "latency-calculator: per-token") {
+		t.Errorf("default calculator should be per-token: %s", configYAML)
+	}
+	if strings.Contains(configYAML, "time-to-first-token:") {
+		t.Errorf("per-token default should not emit constant-only fields: %s", configYAML)
+	}
+}
+
+// TestEnsureSimConfigMap_ProfileAnnotation verifies the latency-profile
+// annotation forces a specific profile regardless of the model size.
+func TestEnsureSimConfigMap_ProfileAnnotation(t *testing.T) {
+	// A 70B model name would auto-select 70b-tp8, but the annotation forces
+	// small-l40s. Force the constant calculator so TTFT is emitted.
+	cfg := testConfig()
+	cfg.LatencyCalculator = LatencyCalculatorConstant
+	annotations := map[string]string{AnnotationLatencyProfile: LatencyProfileSmallL40S}
+	configYAML := simConfigYAML(t, cfg, "org/llama-70b", "llama-70b", annotations)
+	for _, want := range []string{
+		"time-to-first-token: 110ms",
+		"inter-token-latency: 15ms",
+		"time-factor-under-load: 1.5",
+	} {
+		if !strings.Contains(configYAML, want) {
+			t.Errorf("annotation should force small-l40s profile, missing %q: %s", want, configYAML)
+		}
+	}
+}
+
+// TestEnsureSimConfigMap_CalculatorAnnotation verifies the latency-calculator
+// annotation overrides the operator-wide default calculator.
+func TestEnsureSimConfigMap_CalculatorAnnotation(t *testing.T) {
+	// Default is per-token; annotation forces constant.
+	annotations := map[string]string{AnnotationLatencyCalculator: LatencyCalculatorConstant}
+	configYAML := simConfigYAML(t, testConfig(), "org/falcon-7b", "falcon-7b-instruct", annotations)
+	if !strings.Contains(configYAML, "latency-calculator: constant") {
+		t.Errorf("annotation should select constant calculator: %s", configYAML)
+	}
+	if !strings.Contains(configYAML, "time-to-first-token: 100ms") {
+		t.Errorf("constant knobs should be emitted: %s", configYAML)
+	}
+	if strings.Contains(configYAML, "prefill-overhead:") {
+		t.Errorf("constant calculator should not emit per-token-only fields: %s", configYAML)
+	}
+
+	// An unknown annotation value falls back to the operator default (per-token).
+	fallback := simConfigYAML(t, testConfig(), "org/falcon-7b", "falcon-7b-instruct",
+		map[string]string{AnnotationLatencyCalculator: "bogus"})
+	if !strings.Contains(fallback, "latency-calculator: per-token") {
+		t.Errorf("unknown calculator annotation should fall back to per-token: %s", fallback)
 	}
 }

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
@@ -934,12 +934,14 @@ func TestEnsureSimConfigMap(t *testing.T) {
 	}
 }
 
-func TestEnsureSimConfigMap_LatencyOverrides(t *testing.T) {
+func TestEnsureSimConfigMap_ProfileOverridesConfigDefaults(t *testing.T) {
 	ctx := context.Background()
 	scheme := testScheme()
 	cfg := testConfig()
-	// Force the constant calculator so the constant-only overrides below are
-	// exercised (per-token is now the default).
+	// Force the constant calculator so the constant-only knobs below are
+	// exercised (per-token is now the default). The Config knobs act as
+	// operator-wide DEFAULTS; the auto-selected 8B profile (served name
+	// "falcon-7b-instruct" ⇒ 7B) must OVERRIDE each of them.
 	cfg.LatencyCalculator = LatencyCalculatorConstant
 	cfg.TimeToFirstToken = "200ms"
 	cfg.InterTokenLatency = "25ms"
@@ -963,17 +965,28 @@ func TestEnsureSimConfigMap_LatencyOverrides(t *testing.T) {
 		t.Fatalf("configmap not found: %v", err)
 	}
 	configYAML := cm.Data["config.yaml"]
+	// The 8B profile values win over the Config defaults.
 	for _, want := range []string{
-		"time-to-first-token: 200ms",
-		"inter-token-latency: 25ms",
-		"time-to-first-token-std-dev: 40ms",
-		"inter-token-latency-std-dev: 4ms",
-		"kv-cache-transfer-latency: 8ms",
-		"kv-cache-transfer-latency-std-dev: 500us",
-		"time-factor-under-load: 3.0",
+		"time-to-first-token: 100ms",
+		"inter-token-latency: 12ms",
+		"time-to-first-token-std-dev: 20ms",
+		"inter-token-latency-std-dev: 2ms",
+		"kv-cache-transfer-latency: 2ms",
+		"kv-cache-transfer-latency-std-dev: 400us",
+		"time-factor-under-load: 2.0",
 	} {
 		if !strings.Contains(configYAML, want) {
-			t.Errorf("missing override %q in config: %s", want, configYAML)
+			t.Errorf("missing profile value %q in config: %s", want, configYAML)
+		}
+	}
+	// The Config defaults must NOT leak through when the profile defines the knob.
+	for _, notWant := range []string{
+		"time-to-first-token: 200ms",
+		"inter-token-latency: 25ms",
+		"time-factor-under-load: 3.0",
+	} {
+		if strings.Contains(configYAML, notWant) {
+			t.Errorf("Config default %q should be overridden by profile: %s", notWant, configYAML)
 		}
 	}
 }


### PR DESCRIPTION
**Reason for Change**:
Configure shadow pod latency via model size profiles and annotations.

Shadow pods previously ran llm-d-inference-sim with a single hardcoded
latency. They now derive latency from a model-size-based profile, selectable
per-InferenceSet via annotations, so mocked endpoints behave closer to real
vLLM serving.

- Add 3 latency profiles keyed by parsed model size mirroring the upstream latency-profiles.md
  reference tables. Auto-selection parses the parameter count from the served
  model name; unparseable names fall back to the 8B profile.
- Read kaito.sh/latency-profile to force a specific profile (or "auto"), and
  kaito.sh/latency-calculator to choose "per-token" (default) vs "constant".
  Unrecognized calculator values fall back to the default (per-token) and log a warning.
- Wire the selected profile/calculator through ensureSimConfigMap; operator-wide
  flags/Helm values remain as optional overrides and are omitted when empty.
- Update chart values/template, README, and add unit tests for size-bucket
  mapping, default calculator, and annotation precedence.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
https://github.com/kaito-project/production-stack/issues/136

**Notes for Reviewers**:
