### PR TITLE
Consolidate coverage report by labels

### DIFF
--- a/hack/e2e/report/report.go
+++ b/hack/e2e/report/report.go
@@ -261,33 +261,48 @@ func buildReportData(files []TestFile, workflow, labelFilter string) *ReportData
 		data.Files = append(data.Files, filtered)
 	}
 
-	// Bar chart / donut data — grouped by label rather than by file. Each
-	// running It block contributes to the count of every label it carries, so
-	// a spec with multiple labels is counted once per label.
+	// Bar chart / donut data — grouped by capability. Each running It block is
+	// attributed to exactly one capability (the first label it carries in the
+	// canonical orderedLabels order) so that the per-capability counts sum to
+	// TotalIts. Specs whose labels are all outside orderedLabels fall into an
+	// "Other" bucket.
+	labelPriority := make(map[string]int, len(orderedLabels))
+	for i, lbl := range orderedLabels {
+		labelPriority[lbl] = i
+	}
+	const otherCapability = "Other"
 	barLabelCounts := make(map[string]int)
 	for _, f := range files {
 		for _, b := range f.Blocks {
 			if b.Type != "It" || !matchesLabelFilter(labelFilter, b.EffectiveLabels) {
 				continue
 			}
-			seen := make(map[string]bool, len(b.EffectiveLabels))
+			primary := ""
+			bestRank := len(orderedLabels)
 			for _, lbl := range b.EffectiveLabels {
-				if seen[lbl] {
-					continue
+				if rank, ok := labelPriority[lbl]; ok && rank < bestRank {
+					bestRank = rank
+					primary = lbl
 				}
-				seen[lbl] = true
-				barLabelCounts[lbl]++
 			}
+			if primary == "" {
+				primary = otherCapability
+			}
+			barLabelCounts[primary]++
 		}
 	}
 
-	// Preserve the canonical label ordering, keeping only labels that have at
-	// least one matching test under the active filter.
+	// Preserve the canonical label ordering, keeping only capabilities that
+	// have at least one matching test under the active filter. The "Other"
+	// bucket, if present, is appended last.
 	var chartLabels []string
 	for _, lbl := range orderedLabels {
 		if barLabelCounts[lbl] > 0 {
 			chartLabels = append(chartLabels, lbl)
 		}
+	}
+	if barLabelCounts[otherCapability] > 0 {
+		chartLabels = append(chartLabels, otherCapability)
 	}
 
 	maxTests := 0
@@ -319,9 +334,9 @@ func buildReportData(files []TestFile, workflow, labelFilter string) *ReportData
 			Color:   color,
 		})
 
-		// Donut segment — proportional to each label's share of the summed
-		// per-label counts (which may exceed TotalIts when specs are
-		// multi-labelled).
+		// Donut segment — proportional to each capability's share of the
+		// total. Because every spec is attributed to exactly one capability,
+		// labelTotal equals TotalIts.
 		startDeg := 0
 		if labelTotal > 0 {
 			startDeg = cumulative * 360 / labelTotal
@@ -451,23 +466,23 @@ func writeMarkdown(data *ReportData, path string) error {
 	p("---")
 	p("")
 
-	// Mermaid pie chart — tests per label.
+	// Mermaid pie chart — tests per dimension.
 	p("### 📈 Test Distribution")
 	p("")
 	p("```mermaid")
-	p("pie title Tests by Label")
+	p("pie title Tests by Dimensions")
 	for _, entry := range data.BarChart {
 		p("    %q : %d", entry.Label, entry.Value)
 	}
 	p("```")
 	p("")
 
-	// Mermaid bar chart — tests per label.
-	p("### 📊 Tests per Label")
+	// Mermaid bar chart — tests per dimension.
+	p("### 📊 Tests per Dimension")
 	p("")
 	p("```mermaid")
 	p("xychart-beta horizontal")
-	p("    title \"Tests per Label\"")
+	p("    title \"Tests per Dimension\"")
 	barLabels := make([]string, len(data.BarChart))
 	barValues := make([]string, len(data.BarChart))
 	for i, entry := range data.BarChart {
@@ -477,16 +492,6 @@ func writeMarkdown(data *ReportData, path string) error {
 	p("    x-axis [%s]", strings.Join(barLabels, ", "))
 	p("    bar [%s]", strings.Join(barValues, ", "))
 	p("```")
-	p("")
-
-	// Label coverage table with counts.
-	p("### 🏷️ Coverage by Label")
-	p("")
-	p("| Label | Blocks | Description |")
-	p("|-------|-------:|-------------|")
-	for _, card := range data.LabelCards {
-		p("| `%s` | **%d** | %s |", card.Name, card.Count, labelDescriptions[card.Name])
-	}
 	p("")
 	p("---")
 	p("")

--- a/hack/e2e/report/report.go
+++ b/hack/e2e/report/report.go
@@ -82,42 +82,39 @@ type LabelCard struct {
 // ---------------------------------------------------------------------------
 
 var orderedLabels = []string{
-	"Smoke", "Infra", "Routing", "Auth",
-	"Scaling", "ScaleUp", "ScaleDown", "AntiFlapping",
-	"FilterOrder", "Nightly", "NetworkPolicy",
-	"PrefixCache", "InferenceSet",
+	"Smoke", "Nightly",
+	"Infra", "Routing", "PrefixCache", "Auth", "NetworkPolicy",
+	"Scaling", "InferenceSet", "FilterOrder", "Karpenter", "Outage",
 }
 
 var labelDescriptions = map[string]string{
 	"Smoke":         "Basic sanity checks — every PR",
+	"Nightly":       "Long-running tests (nightly only)",
 	"Infra":         "Infrastructure lifecycle (nodes, pods, GC)",
 	"Routing":       "Gateway / model routing correctness",
-	"Auth":          "API key authentication",
-	"Scaling":       "KEDA-driven scale-up / scale-down",
-	"ScaleUp":       "Scale-up specific assertions",
-	"ScaleDown":     "Scale-down specific assertions",
-	"AntiFlapping":  "Prevents premature re-scaling",
-	"FilterOrder":   "Envoy HTTP filter chain execution order",
-	"Nightly":       "Long-running tests (nightly only)",
-	"NetworkPolicy": "Kubernetes NetworkPolicy enforcement",
 	"PrefixCache":   "Prefix / KV-cache aware routing",
+	"Auth":          "API key authentication",
+	"NetworkPolicy": "Kubernetes NetworkPolicy enforcement",
+	"Scaling":       "KEDA-driven scale-up / scale-down / anti-flapping",
 	"InferenceSet":  "InferenceSet chart lifecycle",
+	"FilterOrder":   "Envoy HTTP filter chain execution order",
+	"Karpenter":     "GPU node provisioning from zero",
+	"Outage":        "Fail-closed / HA outage resilience",
 }
 
 var labelColors = map[string]string{
 	"Smoke":         "#3fb950",
+	"Nightly":       "#d29922",
 	"Infra":         "#bc8cff",
 	"Routing":       "#f0883e",
-	"Auth":          "#f85149",
-	"Scaling":       "#39d353",
-	"ScaleUp":       "#39d353",
-	"ScaleDown":     "#39d353",
-	"AntiFlapping":  "#39d353",
-	"FilterOrder":   "#58a6ff",
-	"Nightly":       "#d29922",
-	"NetworkPolicy": "#bc8cff",
 	"PrefixCache":   "#f0883e",
+	"Auth":          "#f85149",
+	"NetworkPolicy": "#bc8cff",
+	"Scaling":       "#39d353",
 	"InferenceSet":  "#bc8cff",
+	"FilterOrder":   "#58a6ff",
+	"Karpenter":     "#56d364",
+	"Outage":        "#f85149",
 }
 
 var chartColors = []string{

--- a/hack/e2e/report/report.go
+++ b/hack/e2e/report/report.go
@@ -261,44 +261,78 @@ func buildReportData(files []TestFile, workflow, labelFilter string) *ReportData
 		data.Files = append(data.Files, filtered)
 	}
 
-	// Bar chart data.
+	// Bar chart / donut data — grouped by label rather than by file. Each
+	// running It block contributes to the count of every label it carries, so
+	// a spec with multiple labels is counted once per label.
+	barLabelCounts := make(map[string]int)
+	for _, f := range files {
+		for _, b := range f.Blocks {
+			if b.Type != "It" || !matchesLabelFilter(labelFilter, b.EffectiveLabels) {
+				continue
+			}
+			seen := make(map[string]bool, len(b.EffectiveLabels))
+			for _, lbl := range b.EffectiveLabels {
+				if seen[lbl] {
+					continue
+				}
+				seen[lbl] = true
+				barLabelCounts[lbl]++
+			}
+		}
+	}
+
+	// Preserve the canonical label ordering, keeping only labels that have at
+	// least one matching test under the active filter.
+	var chartLabels []string
+	for _, lbl := range orderedLabels {
+		if barLabelCounts[lbl] > 0 {
+			chartLabels = append(chartLabels, lbl)
+		}
+	}
+
 	maxTests := 0
-	for _, fc := range filteredFiles {
-		if fc.count > maxTests {
-			maxTests = fc.count
+	labelTotal := 0
+	for _, lbl := range chartLabels {
+		labelTotal += barLabelCounts[lbl]
+		if barLabelCounts[lbl] > maxTests {
+			maxTests = barLabelCounts[lbl]
 		}
 	}
 
 	cumulative := 0
 	var gradientParts []string
-	for i, fc := range filteredFiles {
-		f := fc.file
-		color := chartColors[i%len(chartColors)]
+	for i, lbl := range chartLabels {
+		count := barLabelCounts[lbl]
+		color := labelColors[lbl]
+		if color == "" {
+			color = chartColors[i%len(chartColors)]
+		}
 		pct := 0
 		if maxTests > 0 {
-			pct = fc.count * 100 / maxTests
+			pct = count * 100 / maxTests
 		}
-		shortName := strings.TrimSuffix(f.Name, "_test.go")
 
 		data.BarChart = append(data.BarChart, BarEntry{
-			Label:   shortName,
-			Value:   fc.count,
+			Label:   lbl,
+			Value:   count,
 			Percent: pct,
 			Color:   color,
 		})
 
-		// Donut segment.
+		// Donut segment — proportional to each label's share of the summed
+		// per-label counts (which may exceed TotalIts when specs are
+		// multi-labelled).
 		startDeg := 0
-		if data.TotalIts > 0 {
-			startDeg = cumulative * 360 / data.TotalIts
+		if labelTotal > 0 {
+			startDeg = cumulative * 360 / labelTotal
 		}
-		cumulative += fc.count
+		cumulative += count
 		endDeg := 0
-		if data.TotalIts > 0 {
-			endDeg = cumulative * 360 / data.TotalIts
+		if labelTotal > 0 {
+			endDeg = cumulative * 360 / labelTotal
 		}
 		gradientParts = append(gradientParts, fmt.Sprintf("%s %ddeg %ddeg", color, startDeg, endDeg))
-		data.DonutLegend = append(data.DonutLegend, LegendEntry{Label: shortName, Color: color})
+		data.DonutLegend = append(data.DonutLegend, LegendEntry{Label: lbl, Color: color})
 	}
 	if len(gradientParts) > 0 {
 		data.ConicGradient = strings.Join(gradientParts, ", ")
@@ -417,23 +451,23 @@ func writeMarkdown(data *ReportData, path string) error {
 	p("---")
 	p("")
 
-	// Mermaid pie chart — tests per file.
+	// Mermaid pie chart — tests per label.
 	p("### 📈 Test Distribution")
 	p("")
 	p("```mermaid")
-	p("pie title Tests by File")
+	p("pie title Tests by Label")
 	for _, entry := range data.BarChart {
 		p("    %q : %d", entry.Label, entry.Value)
 	}
 	p("```")
 	p("")
 
-	// Mermaid bar chart — tests per file.
-	p("### 📊 Tests per File")
+	// Mermaid bar chart — tests per label.
+	p("### 📊 Tests per Label")
 	p("")
 	p("```mermaid")
 	p("xychart-beta horizontal")
-	p("    title \"Tests per File\"")
+	p("    title \"Tests per Label\"")
 	barLabels := make([]string, len(data.BarChart))
 	barValues := make([]string, len(data.BarChart))
 	for i, entry := range data.BarChart {

--- a/hack/e2e/report/report_test.go
+++ b/hack/e2e/report/report_test.go
@@ -66,13 +66,16 @@ func TestBuildReportData_Totals(t *testing.T) {
 func TestBuildReportData_BarChart(t *testing.T) {
 	data := buildReportData(sampleFiles(), "", "")
 
-	if len(data.BarChart) != 2 {
-		t.Fatalf("expected 2 bar entries, got %d", len(data.BarChart))
+	// Bars are grouped by label (ordered per orderedLabels): Smoke=2, Infra=2,
+	// Auth=1. Both alpha Its carry Smoke and Infra; the single beta It carries
+	// Auth.
+	if len(data.BarChart) != 3 {
+		t.Fatalf("expected 3 bar entries, got %d", len(data.BarChart))
 	}
 
-	// alpha_test.go has 2 tests (max), so its percent should be 100.
-	if data.BarChart[0].Label != "alpha" {
-		t.Errorf("expected bar[0].Label=alpha, got %q", data.BarChart[0].Label)
+	// Smoke has 2 tests (max), so its percent should be 100.
+	if data.BarChart[0].Label != "Smoke" {
+		t.Errorf("expected bar[0].Label=Smoke, got %q", data.BarChart[0].Label)
 	}
 	if data.BarChart[0].Value != 2 {
 		t.Errorf("expected bar[0].Value=2, got %d", data.BarChart[0].Value)
@@ -81,12 +84,20 @@ func TestBuildReportData_BarChart(t *testing.T) {
 		t.Errorf("expected bar[0].Percent=100, got %d", data.BarChart[0].Percent)
 	}
 
-	// beta_test.go has 1 test → 50%.
-	if data.BarChart[1].Label != "beta" {
-		t.Errorf("expected bar[1].Label=beta, got %q", data.BarChart[1].Label)
+	// Infra also has 2 tests → 100%.
+	if data.BarChart[1].Label != "Infra" {
+		t.Errorf("expected bar[1].Label=Infra, got %q", data.BarChart[1].Label)
 	}
-	if data.BarChart[1].Percent != 50 {
-		t.Errorf("expected bar[1].Percent=50, got %d", data.BarChart[1].Percent)
+	if data.BarChart[1].Value != 2 {
+		t.Errorf("expected bar[1].Value=2, got %d", data.BarChart[1].Value)
+	}
+
+	// Auth has 1 test → 50%.
+	if data.BarChart[2].Label != "Auth" {
+		t.Errorf("expected bar[2].Label=Auth, got %q", data.BarChart[2].Label)
+	}
+	if data.BarChart[2].Percent != 50 {
+		t.Errorf("expected bar[2].Percent=50, got %d", data.BarChart[2].Percent)
 	}
 }
 
@@ -99,8 +110,9 @@ func TestBuildReportData_DonutGradient(t *testing.T) {
 	if !strings.Contains(data.ConicGradient, "deg") {
 		t.Errorf("expected degree values in gradient, got %q", data.ConicGradient)
 	}
-	if len(data.DonutLegend) != 2 {
-		t.Errorf("expected 2 legend entries, got %d", len(data.DonutLegend))
+	// One legend entry per label with matching tests: Smoke, Infra, Auth.
+	if len(data.DonutLegend) != 3 {
+		t.Errorf("expected 3 legend entries, got %d", len(data.DonutLegend))
 	}
 }
 
@@ -173,9 +185,9 @@ func TestWriteMarkdown(t *testing.T) {
 		"🟢 test A",
 		// Mermaid pie chart.
 		"```mermaid",
-		"pie title Tests by File",
-		`"alpha" : 2`,
-		`"beta" : 1`,
+		"pie title Tests by Label",
+		`"Smoke" : 2`,
+		`"Auth" : 1`,
 		// Mermaid bar chart.
 		"xychart-beta horizontal",
 		// Label coverage table.

--- a/hack/e2e/report/report_test.go
+++ b/hack/e2e/report/report_test.go
@@ -66,11 +66,12 @@ func TestBuildReportData_Totals(t *testing.T) {
 func TestBuildReportData_BarChart(t *testing.T) {
 	data := buildReportData(sampleFiles(), "", "")
 
-	// Bars are grouped by label (ordered per orderedLabels): Smoke=2, Infra=2,
-	// Auth=1. Both alpha Its carry Smoke and Infra; the single beta It carries
-	// Auth.
-	if len(data.BarChart) != 3 {
-		t.Fatalf("expected 3 bar entries, got %d", len(data.BarChart))
+	// Each spec is attributed to exactly one capability (the first label it
+	// carries in orderedLabels order), so per-capability counts sum to TotalIts.
+	// Both alpha Its carry Smoke and Infra → Smoke wins (ranks first); the single
+	// beta It carries Auth. Result: Smoke=2, Auth=1.
+	if len(data.BarChart) != 2 {
+		t.Fatalf("expected 2 bar entries, got %d", len(data.BarChart))
 	}
 
 	// Smoke has 2 tests (max), so its percent should be 100.
@@ -84,20 +85,24 @@ func TestBuildReportData_BarChart(t *testing.T) {
 		t.Errorf("expected bar[0].Percent=100, got %d", data.BarChart[0].Percent)
 	}
 
-	// Infra also has 2 tests → 100%.
-	if data.BarChart[1].Label != "Infra" {
-		t.Errorf("expected bar[1].Label=Infra, got %q", data.BarChart[1].Label)
+	// Auth has 1 test → 50%.
+	if data.BarChart[1].Label != "Auth" {
+		t.Errorf("expected bar[1].Label=Auth, got %q", data.BarChart[1].Label)
 	}
-	if data.BarChart[1].Value != 2 {
-		t.Errorf("expected bar[1].Value=2, got %d", data.BarChart[1].Value)
+	if data.BarChart[1].Value != 1 {
+		t.Errorf("expected bar[1].Value=1, got %d", data.BarChart[1].Value)
+	}
+	if data.BarChart[1].Percent != 50 {
+		t.Errorf("expected bar[1].Percent=50, got %d", data.BarChart[1].Percent)
 	}
 
-	// Auth has 1 test → 50%.
-	if data.BarChart[2].Label != "Auth" {
-		t.Errorf("expected bar[2].Label=Auth, got %q", data.BarChart[2].Label)
+	// The sum of all capability counts must equal the total test count.
+	sum := 0
+	for _, e := range data.BarChart {
+		sum += e.Value
 	}
-	if data.BarChart[2].Percent != 50 {
-		t.Errorf("expected bar[2].Percent=50, got %d", data.BarChart[2].Percent)
+	if sum != data.TotalIts {
+		t.Errorf("expected capability counts to sum to TotalIts=%d, got %d", data.TotalIts, sum)
 	}
 }
 
@@ -110,9 +115,9 @@ func TestBuildReportData_DonutGradient(t *testing.T) {
 	if !strings.Contains(data.ConicGradient, "deg") {
 		t.Errorf("expected degree values in gradient, got %q", data.ConicGradient)
 	}
-	// One legend entry per label with matching tests: Smoke, Infra, Auth.
-	if len(data.DonutLegend) != 3 {
-		t.Errorf("expected 3 legend entries, got %d", len(data.DonutLegend))
+	// One legend entry per capability with matching tests: Smoke, Auth.
+	if len(data.DonutLegend) != 2 {
+		t.Errorf("expected 2 legend entries, got %d", len(data.DonutLegend))
 	}
 }
 
@@ -185,15 +190,11 @@ func TestWriteMarkdown(t *testing.T) {
 		"🟢 test A",
 		// Mermaid pie chart.
 		"```mermaid",
-		"pie title Tests by Label",
+		"pie title Tests by Dimensions",
 		`"Smoke" : 2`,
 		`"Auth" : 1`,
 		// Mermaid bar chart.
 		"xychart-beta horizontal",
-		// Label coverage table.
-		"Coverage by Label",
-		"| `Smoke` | **2**",
-		"| `Auth` | **2**",
 	}
 
 	for _, want := range checks {

--- a/hack/e2e/report/template.html
+++ b/hack/e2e/report/template.html
@@ -101,7 +101,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,san
 </div>
 
 <div class="charts">
-  <div class="panel"><h3>📊 Tests by File</h3>
+  <div class="panel"><h3>📊 Tests by Label</h3>
     {{- range .BarChart}}
     <div class="bar-row">
       <span class="bar-label">{{.Label}}</span>

--- a/hack/e2e/report/template.html
+++ b/hack/e2e/report/template.html
@@ -101,7 +101,7 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,san
 </div>
 
 <div class="charts">
-  <div class="panel"><h3>📊 Tests by Label</h3>
+  <div class="panel"><h3>📊 Tests by Dimensions</h3>
     {{- range .BarChart}}
     <div class="bar-row">
       <span class="bar-label">{{.Label}}</span>
@@ -121,18 +121,6 @@ body{font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,san
         {{- end}}
       </div>
     </div>
-  </div>
-</div>
-
-<div class="lbl-section"><h3>🏷️ Coverage by Label</h3>
-  <div class="lbl-grid">
-    {{- range .LabelCards}}
-    <div class="lbl-card">
-      <div style="position:absolute;bottom:0;left:0;right:0;height:3px;background:{{.Color}}"></div>
-      <div class="lc-n" style="color:{{.Color}}">{{.Count}}</div>
-      <div class="lc-l" style="color:{{.Color}}">{{.Name}}</div>
-    </div>
-    {{- end}}
   </div>
 </div>
 

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -48,7 +48,11 @@ E2E_LABEL=Smoke make test-e2e
 E2E_PARALLEL=4 make test-e2e
 ```
 
-Labels live in [`utils/ginkgo.go`](utils/ginkgo.go): `GinkgoLabelSmoke`, `GinkgoLabelRouting`, `GinkgoLabelPrefixCache`, `GinkgoLabelInfra`.
+Labels live in [`utils/ginkgo.go`](utils/ginkgo.go) and fall into two groups:
+
+- **Cadence** (when a spec runs): `Smoke` (every PR), `Nightly` (long-running, nightly only).
+- **Feature area** (what a spec verifies): `Infra`, `Routing`, `PrefixCache`, `Auth`, `NetworkPolicy`, `Scaling` (scale-up / scale-down / anti-flapping), `InferenceSet`, `FilterOrder`, `Karpenter`, `Outage` (fail-closed / HA resilience).
+
 
 ### Bring up a cluster from scratch
 

--- a/test/e2e/bbr_outage_test.go
+++ b/test/e2e/bbr_outage_test.go
@@ -54,7 +54,7 @@ import (
 // the mesh. Scaling it to zero breaks every other in-flight inference
 // request, so this suite must not run concurrently with any other spec.
 var _ = Describe("BBR outage (fail-closed cluster filter)",
-	Ordered, Serial, utils.GinkgoLabelClusterOutage, func() {
+	Ordered, Serial, utils.GinkgoLabelOutage, func() {
 
 		const (
 			bbrNamespace      = "kaito-system"

--- a/test/e2e/cluster_filter_ha_test.go
+++ b/test/e2e/cluster_filter_ha_test.go
@@ -59,7 +59,7 @@ import (
 // It is intentionally NOT asserted here; the all-replicas-down case below
 // asserts only that the request fails closed (5xx, never a silent 404).
 var _ = Describe("BBR cluster-filter HA",
-	Ordered, Serial, utils.GinkgoLabelClusterFilterHA, utils.GinkgoLabelSmoke, func() {
+	Ordered, Serial, utils.GinkgoLabelOutage, utils.GinkgoLabelSmoke, func() {
 
 		const (
 			bbrNamespace  = "kaito-system"

--- a/test/e2e/epp_outage_test.go
+++ b/test/e2e/epp_outage_test.go
@@ -56,7 +56,7 @@ import (
 // namespace's request path, not any cluster-wide singleton, so the suite
 // is safe to run alongside other (non-overlapping) specs.
 var _ = Describe("EPP outage (fail-closed InferencePool ext_proc)",
-	Ordered, utils.GinkgoLabelDataplaneOutage, utils.GinkgoLabelNightly, func() {
+	Ordered, utils.GinkgoLabelOutage, utils.GinkgoLabelNightly, func() {
 
 		var (
 			ctx           context.Context

--- a/test/e2e/ext_authz_outage_test.go
+++ b/test/e2e/ext_authz_outage_test.go
@@ -59,7 +59,7 @@ import (
 // authenticated request, so this suite must not run concurrently with any
 // other spec.
 var _ = Describe("ext_authz outage (fail-closed cluster filter)",
-	Ordered, Serial, utils.GinkgoLabelClusterOutage, utils.GinkgoLabelAuth, func() {
+	Ordered, Serial, utils.GinkgoLabelOutage, utils.GinkgoLabelAuth, func() {
 
 		const (
 			authNamespace      = "llm-gateway-auth"

--- a/test/e2e/model_unavailable_test.go
+++ b/test/e2e/model_unavailable_test.go
@@ -54,7 +54,7 @@ import (
 // own namespace's inference pool, not any cluster-wide singleton, so the
 // suite is safe to run alongside other (non-overlapping) specs.
 var _ = Describe("model_unavailable (zero ready inference endpoints)",
-	Ordered, utils.GinkgoLabelDataplaneOutage, utils.GinkgoLabelNightly, func() {
+	Ordered, utils.GinkgoLabelOutage, utils.GinkgoLabelNightly, func() {
 
 		var (
 			ctx          context.Context

--- a/test/e2e/scaling_test.go
+++ b/test/e2e/scaling_test.go
@@ -95,7 +95,7 @@ var _ = Describe("InferenceSet Scaling — Infra",
 		}
 
 		Describe("Scale-Up → Scale-Down End-to-End",
-			Ordered, utils.GinkgoLabelScaleUp, utils.GinkgoLabelScaleDown, func() {
+			Ordered, func() {
 
 				var (
 					ctx      context.Context
@@ -570,7 +570,7 @@ var _ = Describe("InferenceSet Scaling — Infra",
 			},
 		)
 
-		Describe("Anti-Flapping", utils.GinkgoLabelAntiFlapping, func() {
+		Describe("Anti-Flapping", func() {
 
 			var (
 				ctx  context.Context

--- a/test/e2e/utils/ginkgo.go
+++ b/test/e2e/utils/ginkgo.go
@@ -48,19 +48,11 @@ var (
 	GinkgoLabelNetworkPolicy = g.Label("NetworkPolicy")
 
 	// GinkgoLabelScaling marks tests that verify end-to-end KEDA-driven
-	// scaling of InferenceSet replicas. Nightly-only because KEDA polling
-	// and cooldown windows make these tests take minutes per run.
+	// scaling of InferenceSet replicas, covering the scale-up and
+	// scale-down phases as well as anti-flapping (no oscillation near the
+	// threshold or during cooldown). Nightly-only because KEDA polling and
+	// cooldown windows make these tests take minutes per run.
 	GinkgoLabelScaling = g.Label("Scaling")
-
-	// GinkgoLabelScaleUp marks the scale-up phase of a scaling test.
-	GinkgoLabelScaleUp = g.Label("ScaleUp")
-
-	// GinkgoLabelScaleDown marks the scale-down phase of a scaling test.
-	GinkgoLabelScaleDown = g.Label("ScaleDown")
-
-	// GinkgoLabelAntiFlapping marks anti-flapping tests that verify KEDA
-	// does not oscillate replicas near the threshold or during cooldown.
-	GinkgoLabelAntiFlapping = g.Label("AntiFlapping")
 
 	// GinkgoLabelFilterOrder marks tests that verify the Envoy HTTP
 	// filter chain execution order on the per-namespace Gateway:
@@ -68,26 +60,17 @@ var (
 	// See test/e2e/filter_order_test.go for the test matrix.
 	GinkgoLabelFilterOrder = g.Label("FilterOrder")
 
-	// GinkgoLabelClusterFilterHA marks tests that verify the cluster-wide
-	// BBR ext_proc filter's high availability and single-replica-loss
-	// failover (issue #89). These tests perturb the shared kaito-system
-	// BBR Deployment, so the suite MUST decorate them Serial.
-	// See test/e2e/cluster_filter_ha_test.go.
-	GinkgoLabelClusterFilterHA = g.Label("ClusterFilterHA")
-
-	// GinkgoLabelClusterOutage marks tests that verify the fail-closed
-	// behavior of the cluster-wide filters (BBR ext_proc, llm-gateway-auth
-	// ext_authz) and the unified outage local_reply mapping. These tests
-	// scale cluster-wide singleton Deployments to zero, so they MUST run
-	// Serial and are Nightly-only.
-	GinkgoLabelClusterOutage = g.Label("ClusterOutage")
-
-	// GinkgoLabelDataplaneOutage marks tests that verify the per-namespace
-	// half of the consolidated outage local_reply: the model-serving hops
-	// (EPP ext_proc fail-closed -> epp_unavailable; zero ready inference
-	// endpoints -> model_unavailable). Unlike GinkgoLabelClusterOutage,
-	// these perturb only the case's OWN namespace (its EPP Deployment or
-	// InferenceSet replicas), so they do not need Serial; they are Nightly
-	// because they take an inference pool through an outage + recovery.
-	GinkgoLabelDataplaneOutage = g.Label("DataplaneOutage")
+	// GinkgoLabelOutage marks tests that verify fail-closed / high-availability
+	// behavior when a filter or model-serving component goes down. It spans
+	// two halves:
+	//   - Cluster-wide singletons (BBR ext_proc, llm-gateway-auth ext_authz):
+	//     HA / single-replica-loss failover and scale-to-zero fail-closed
+	//     behavior. These perturb shared kaito-system Deployments, so the
+	//     corresponding suites MUST be decorated Serial.
+	//   - Per-namespace data plane (EPP ext_proc fail-closed -> epp_unavailable;
+	//     zero ready inference endpoints -> model_unavailable). These perturb
+	//     only the case's OWN namespace, so they do not need Serial.
+	// See test/e2e/{bbr,ext_authz,epp}_outage_test.go, model_unavailable_test.go
+	// and cluster_filter_ha_test.go.
+	GinkgoLabelOutage = g.Label("Outage")
 )


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->
Consolidate coverage report by dimensions instead of labels.

Each test case is assigned to a dimension  (its highest-priority label), so the "Tests per Dimension" chart splits those 94 tests across dimensions.

Report summary: https://github.com/kaito-project/production-stack/actions/runs/28988056602/job/86021522790?pr=140

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
