### PR TITLE
feat(charts): integrate AKS App-Routing default domain via cloudprovider gate

### DIFF
--- a/charts/modeldeployment/templates/azure/httproute.yaml
+++ b/charts/modeldeployment/templates/azure/httproute.yaml
@@ -1,4 +1,19 @@
-{{- if eq .Values.cloudprovider "" }}
+{{- if eq .Values.cloudprovider "azure" }}
+{{- if not .Values.azure.defaultDomain.zoneName }}
+{{- fail "cloudprovider=\"azure\" requires azure.defaultDomain.zoneName. Use the SAME value as the corresponding modelharness release's azure.defaultDomain.zoneName. Fetch with: az aks show -g $RG -n $CLUSTER --query 'ingressProfile.webAppRouting.defaultDomain.domainName' -o tsv" }}
+{{- end }}
+# HTTPRoute with `hostnames` set to match the modelharness Gateway's
+# Azure default-domain HTTPS listener. Rendered only when
+# `cloudprovider=azure`; the non-Azure sibling `templates/httproute.yaml`
+# (no hostnames, header-only routing) renders otherwise.
+#
+# `hostnames` is required so Istio attaches this HTTPRoute to the
+# host-scoped HTTPS listener — without a matching hostname, the
+# Istio Gateway controller rejects the route from that listener even
+# though the parentRef is correct. Header-based routing
+# (X-Gateway-Model-Name matching this deployment's `name`) still
+# differentiates multiple deployments sharing the hostname within
+# the namespace.
 apiVersion: gateway.networking.k8s.io/v1
 kind: HTTPRoute
 metadata:
@@ -12,6 +27,8 @@ spec:
     - group: gateway.networking.k8s.io
       kind: Gateway
       name: {{ include "modeldeployment.gatewayName" . | quote }}
+  hostnames:
+    - {{ printf "%s.%s" (include "modeldeployment.namespace" .) (.Values.azure.defaultDomain.zoneName | trimPrefix ".") | quote }}
   rules:
     - matches:
         # Two match entries are OR'd by the Gateway API spec: a request is

--- a/charts/modeldeployment/values.schema.json
+++ b/charts/modeldeployment/values.schema.json
@@ -81,6 +81,30 @@
           "description": "EPP HTTP metrics port."
         }
       }
+    },
+    "cloudprovider": {
+      "type": "string",
+      "enum": ["", "azure"],
+      "description": "Cloud provider gate. When empty (default), templates/httproute.yaml renders (header-only routing). When \"azure\", templates/httproute.yaml is skipped and templates/azure/httproute.yaml renders instead (adds hostnames: [<namespace>.<zoneName>] matching the modelharness Gateway's Azure default-domain HTTPS listener)."
+    },
+    "azure": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Azure-specific values consumed by templates/azure/*. Ignored unless cloudprovider=\"azure\".",
+      "properties": {
+        "defaultDomain": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Drives the `hostnames` field on templates/azure/httproute.yaml so it attaches to the modelharness Gateway's HTTPS default-domain listener.",
+          "properties": {
+            "zoneName": {
+              "type": "string",
+              "description": "Cluster's AKS-issued default-domain zone (without the '*.' prefix). Required when cloudprovider=azure — template renders `fail` otherwise. MUST match the corresponding modelharness release's azure.defaultDomain.zoneName."
+            }
+          }
+        }
+      },
+      "required": ["defaultDomain"]
     }
   }
 }

--- a/charts/modeldeployment/values.yaml
+++ b/charts/modeldeployment/values.yaml
@@ -86,3 +86,44 @@ epp:
   modelServerSelector:
     inferenceset.kaito.sh/created-by: ""   # auto-filled with .Values.name when empty
     apps.kubernetes.io/pod-index: "0"
+
+# cloudprovider selects which cloud provider's integrations render.
+# When `cloudprovider=""` (the default), the non-cloud
+# `templates/httproute.yaml` renders (header-only routing, no
+# hostnames). When `cloudprovider=azure`, `templates/httproute.yaml`
+# renders nothing and `templates/azure/httproute.yaml` renders instead
+# (adds `hostnames: [<namespace>.<zoneName>]` matching the modelharness
+# Gateway's Azure default-domain HTTPS listener).
+#
+# Exactly one variant renders for a given cloudprovider — no inline
+# `{{ if }}` blocks inside spec bodies. The `azure` subtree below is
+# ignored unless `cloudprovider=azure`.
+cloudprovider: ""
+
+# azure groups every Azure-specific value used by templates under
+# `templates/azure/`. Consumed only when `cloudprovider=azure`.
+azure:
+  # defaultDomain drives the `hostnames` field on
+  # templates/azure/httproute.yaml so it attaches to the modelharness
+  # Gateway's HTTPS default-domain listener. The HTTPRoute carries
+  # `hostnames: ["<workload-namespace>.<zoneName>"]` — the SAME
+  # hostname the modelharness Gateway listener uses — so Istio
+  # attaches the route to that listener and requests on the
+  # default-domain hostname reach this InferencePool.
+  #
+  # Header-based routing (X-Gateway-Model-Name matching this
+  # deployment's `name`) still differentiates multiple deployments
+  # sharing the hostname within the namespace.
+  #
+  # `zoneName` MUST match the value used in the corresponding
+  # `modelharness` release's `azure.defaultDomain.zoneName` in the
+  # same namespace.
+  defaultDomain:
+    # zoneName is the cluster's AKS-issued default-domain zone (without
+    # the `*.` prefix). Required when cloudprovider=azure — the template
+    # `fail`s otherwise. Same value as used in the corresponding
+    # modelharness (and productionstack) release. Fetch with:
+    #   az aks show -g $RG -n $CLUSTER \
+    #     --query 'ingressProfile.webAppRouting.defaultDomain.domainName' \
+    #     -o tsv
+    zoneName: ""

--- a/charts/modelharness/templates/azure/gateway.yaml
+++ b/charts/modelharness/templates/azure/gateway.yaml
@@ -1,0 +1,55 @@
+{{- if eq .Values.cloudprovider "azure" }}
+{{- if not .Values.azure.defaultDomain.zoneName }}
+{{- fail "cloudprovider=\"azure\" requires azure.defaultDomain.zoneName. Fetch with: az aks show -g $RG -n $CLUSTER --query 'ingressProfile.webAppRouting.defaultDomain.domainName' -o tsv" }}
+{{- end }}
+# Gateway with an Azure App-Routing default-domain HTTPS listener
+# alongside the standard HTTP listener. Rendered only when
+# `cloudprovider=azure`; the non-Azure sibling `templates/gateway.yaml`
+# (HTTP only) renders otherwise. Kept as a separate file (rather
+# than an inline conditional in the shared Gateway spec) so the two
+# variants can evolve independently and it's obvious at a glance
+# which cloud a given cluster is running.
+#
+# Hostname on the HTTPS listener is composed as
+# `<workload-namespace>.<zoneName>` so every modelharness release
+# gets a unique subdomain that the App-Routing operator's
+# `default-domain-dns` ClusterExternalDNS auto-publishes into the
+# aksapp.io zone.
+#
+# The cross-namespace `certificateRefs.namespace` is authorised by
+# the ReferenceGrant this chart renders in
+# `templates/azure/referencegrant.yaml` (into `secretRef.namespace`,
+# not this workload namespace).
+#
+# `gatewayClassName` MUST be `approuting-istio` for the HTTPS
+# listener to be reconciled; the Istio service-mesh add-on's
+# `istio` GatewayClass does not integrate with the default-domain
+# controller.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: {{ include "modelharness.gatewayName" . | quote }}
+  namespace: {{ include "modelharness.namespace" . }}
+  labels:
+    {{- include "modelharness.labels" . | nindent 4 }}
+spec:
+  gatewayClassName: {{ .Values.gatewayClassName }}
+  listeners:
+    - name: http
+      port: {{ .Values.gatewayPort }}
+      protocol: HTTP
+    - name: {{ .Values.azure.defaultDomain.listenerName | quote }}
+      port: {{ .Values.azure.defaultDomain.httpsPort }}
+      protocol: HTTPS
+      hostname: {{ printf "%s.%s" (include "modelharness.namespace" .) (.Values.azure.defaultDomain.zoneName | trimPrefix ".") | quote }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - kind: Secret
+            group: ""
+            name: {{ .Values.azure.defaultDomain.secretRef.name | quote }}
+            namespace: {{ .Values.azure.defaultDomain.secretRef.namespace | quote }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+{{- end }}

--- a/charts/modelharness/templates/azure/referencegrant.yaml
+++ b/charts/modelharness/templates/azure/referencegrant.yaml
@@ -1,0 +1,30 @@
+{{- if eq .Values.cloudprovider "azure" }}
+# ReferenceGrant: authorises THIS workload namespace's Gateway to
+# cross-namespace-reference the shared default-domain TLS Secret in
+# `secretRef.namespace`. Gateway API rejects cross-namespace
+# SecretObjectReferences unless a ReferenceGrant in the referent's
+# namespace explicitly permits the (kind, namespace) pair.
+#
+# Written OUTSIDE this chart's workload namespace — the grant must
+# live in the Secret's namespace, not the consumer Gateway's. Named
+# after the workload namespace so multiple modelharness releases in
+# different namespaces don't collide in the shared referent
+# namespace. Uninstalling this release removes the grant atomically
+# with the Gateway — no orphaned authorisations.
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: ReferenceGrant
+metadata:
+  name: {{ printf "modelharness-%s-default-domain" (include "modelharness.namespace" .) | quote }}
+  namespace: {{ .Values.azure.defaultDomain.secretRef.namespace | quote }}
+  labels:
+    {{- include "modelharness.labels" . | nindent 4 }}
+spec:
+  from:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      namespace: {{ include "modelharness.namespace" . | quote }}
+  to:
+    - group: ""
+      kind: Secret
+      name: {{ .Values.azure.defaultDomain.secretRef.name | quote }}
+{{- end }}

--- a/charts/modelharness/templates/gateway.yaml
+++ b/charts/modelharness/templates/gateway.yaml
@@ -1,3 +1,4 @@
+{{- if eq .Values.cloudprovider "" }}
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -11,3 +12,4 @@ spec:
     - name: http
       port: {{ .Values.gatewayPort }}
       protocol: HTTP
+{{- end }}

--- a/charts/modelharness/values.schema.json
+++ b/charts/modelharness/values.schema.json
@@ -104,6 +104,55 @@
         }
       },
       "required": ["enabled"]
+    },
+    "cloudprovider": {
+      "type": "string",
+      "enum": ["", "azure"],
+      "description": "Cloud provider gate. When empty (default), templates/gateway.yaml renders and templates/azure/* is skipped. When \"azure\", templates/gateway.yaml is skipped and templates/azure/* render the Azure variants (Gateway with default-domain HTTPS listener + ReferenceGrant)."
+    },
+    "azure": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Azure-specific values consumed by templates/azure/*. Ignored unless cloudprovider=\"azure\".",
+      "properties": {
+        "defaultDomain": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Consumer-side wiring for the cluster-wide AKS App-Routing default-domain TLS Secret rendered by charts/productionstack. When cloudprovider=azure, templates/azure/gateway.yaml adds an HTTPS listener with hostname '<namespace>.<zoneName>' + cross-namespace certificateRefs, and templates/azure/referencegrant.yaml renders a ReferenceGrant into secretRef.namespace authorising the cross-namespace ref.",
+          "properties": {
+            "zoneName": {
+              "type": "string",
+              "description": "Cluster's AKS-issued default-domain zone (without the '*.' prefix). Required when cloudprovider=azure — template renders `fail` otherwise. Fetch from `az aks show ... --query 'ingressProfile.webAppRouting.defaultDomain.domainName'`."
+            },
+            "secretRef": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Cross-namespace reference to the shared TLS Secret. MUST match productionstack's `azure.defaultDomain.secretName` (name) and the DDC's namespace (default: kube-system).",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "minLength": 1,
+                  "maxLength": 63,
+                  "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                },
+                "namespace": {
+                  "type": "string",
+                  "minLength": 1
+                }
+              },
+              "required": ["name", "namespace"]
+            },
+            "httpsPort": { "type": "integer", "minimum": 1, "maximum": 65535 },
+            "listenerName": {
+              "type": "string",
+              "minLength": 1,
+              "maxLength": 63,
+              "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+            }
+          }
+        }
+      },
+      "required": ["defaultDomain"]
     }
   }
 }

--- a/charts/modelharness/values.yaml
+++ b/charts/modelharness/values.yaml
@@ -171,3 +171,80 @@ networkPolicy:
     - kaito-system
     - kube-system
     - monitoring
+
+# cloudprovider selects which cloud provider's integrations render.
+# When `cloudprovider=""` (the default), the non-cloud
+# `templates/gateway.yaml` renders and cloud-specific templates
+# under `templates/<provider>/` render nothing. When
+# `cloudprovider=azure`, `templates/gateway.yaml` renders nothing
+# and `templates/azure/*.yaml` render the Azure variants instead
+# (Gateway with default-domain HTTPS listener + ReferenceGrant).
+#
+# Exactly one variant renders for a given cloudprovider — no inline
+# `{{ if }}` blocks inside spec bodies. The `azure` subtree below is
+# ignored unless `cloudprovider=azure`.
+cloudprovider: ""
+
+# azure groups every Azure-specific value used by templates under
+# `templates/azure/`. Consumed only when `cloudprovider=azure`.
+azure:
+  # defaultDomain wires THIS namespace's Gateway into the cluster's AKS
+  # Application Routing "default domain". Pure consumer of the
+  # cluster-wide DefaultDomainCertificate rendered by charts/productionstack
+  # — this chart does NOT render its own DDC because one Azure-issued
+  # wildcard cert covers the whole cluster and N per-namespace DDCs
+  # would drive N redundant reconciliation loops against the same
+  # underlying Azure cert.
+  #
+  # The listener hostname is composed as
+  # `<workload-namespace>.<azure-default-domain>`. The namespace prefix
+  # guarantees a unique subdomain per modelharness release on the same
+  # cluster; the App-Routing operator's `default-domain-dns`
+  # ClusterExternalDNS then auto-publishes an A record for that name.
+  #
+  # The chart also renders a ReferenceGrant into `secretRef.namespace`
+  # authorising THIS workload namespace's Gateway to cross-namespace-
+  # reference the shared TLS Secret. Gateway API rejects cross-namespace
+  # certificateRefs without a matching ReferenceGrant in the Secret's
+  # namespace. Each modelharness release brings its own grant so there
+  # is no cross-chart coordination.
+  #
+  # Prerequisites (validated by the caller, not the chart):
+  #   - `gatewayClassName: approuting-istio` above. The Istio
+  #     service-mesh add-on's `istio` class does NOT reconcile
+  #     default-domain TLS.
+  #   - charts/productionstack installed with cloudprovider=azure
+  #     and azure.defaultDomain.enabled=true so the DDC and its
+  #     Secret exist.
+  #   - The Helm caller has RBAC to create/patch/delete
+  #     ReferenceGrants in `secretRef.namespace`.
+  defaultDomain:
+    # zoneName is the cluster's AKS-issued default-domain zone (WITHOUT
+    # the `*.` prefix). Required when cloudprovider=azure — the template
+    # `fail`s otherwise. Fetch with:
+    #   az aks show -g $RG -n $CLUSTER \
+    #     --query 'ingressProfile.webAppRouting.defaultDomain.domainName' \
+    #     -o tsv
+    # Per-cluster constant; use the same value for every modelharness
+    # release on the same cluster.
+    zoneName: ""
+
+    # secretRef points at the TLS Secret reconciled by the App-Routing
+    # operator from the productionstack DDC. Defaults match
+    # productionstack's DDC pinning to kube-system with secretName=cert;
+    # override both together if productionstack was installed with
+    # different values.
+    secretRef:
+      name: "cert"
+      namespace: "kube-system"
+
+    # httpsPort is the HTTPS listener port. AKS App-Routing's managed
+    # LoadBalancer only reconciles 80/443 by default; don't change
+    # without matching load-balancer customisation.
+    httpsPort: 443
+
+    # listenerName is the Gateway listener name. Must be unique within
+    # `spec.listeners`. Kept short and stable so any
+    # `istio-gateway-class-defaults` per-listener overrides key off a
+    # predictable name.
+    listenerName: "https-default"

--- a/charts/productionstack/templates/azure/defaultdomaincertificate.yaml
+++ b/charts/productionstack/templates/azure/defaultdomaincertificate.yaml
@@ -1,0 +1,29 @@
+{{- if and (eq .Values.cloudprovider "azure") .Values.azure.defaultDomain.enabled }}
+# DefaultDomainCertificate: triggers the AKS App-Routing operator to
+# reconcile `spec.target.secret` in `.Values.azure.defaultDomain.namespace`
+# with an Azure-issued wildcard cert for the cluster's aksapp.io
+# default domain, and to auto-renew it. Rendered outside the
+# productionstack release namespace because the DDC and its Secret
+# are cluster-level shared state — the value defaults to `kube-system`,
+# the natural home and the convention AI Manager RP already uses.
+#
+# Consuming Gateways (rendered by charts/modelharness) cross-namespace-
+# reference the resulting Secret; the corresponding ReferenceGrant is
+# rendered by charts/modelharness itself into `secretRef.namespace`
+# (which MUST match `.Values.azure.defaultDomain.namespace` here), so
+# productionstack stays free of consumer-namespace knowledge.
+apiVersion: approuting.kubernetes.azure.com/v1alpha1
+kind: DefaultDomainCertificate
+metadata:
+  name: {{ .Values.azure.defaultDomain.name | quote }}
+  namespace: {{ .Values.azure.defaultDomain.namespace | quote }}
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    kaito.sh/owned-by: productionstack
+spec:
+  target:
+    secret: {{ .Values.azure.defaultDomain.secretName | quote }}
+{{- else if .Values.azure.defaultDomain.enabled }}
+{{- fail "azure.defaultDomain.enabled=true requires cloudprovider=\"azure\"" }}
+{{- end }}

--- a/charts/productionstack/values.yaml
+++ b/charts/productionstack/values.yaml
@@ -156,3 +156,77 @@ llm-gateway-apikey:
     # at the chart default to avoid surprising the upstream template.
     extAuthzInsert:
       operation: INSERT_FIRST
+
+# cloudprovider selects which cloud provider's integrations render.
+# Cloud-specific templates (those living under templates/<provider>/)
+# are gated on this matching their subfolder AND the per-feature
+# `.enabled` toggle. Empty string — the default — keeps the chart
+# provider-agnostic and renders zero cloud-specific resources.
+#
+# Enabling `azure.<feature>.enabled=true` without setting
+# `cloudprovider=azure` is a hard error (template `fail`), not a
+# silent no-op — config drift between the two knobs should be caught
+# at install time.
+cloudprovider: ""
+
+# azure groups every Azure-specific integration under one namespace.
+# Each sub-feature carries its own `.enabled` toggle in addition to
+# the top-level `cloudprovider` gate — opting into Azure doesn't
+# force every Azure feature on.
+azure:
+  # defaultDomain renders the cluster-wide DefaultDomainCertificate CR
+  # that triggers the AKS App-Routing operator to reconcile a TLS Secret
+  # containing an Azure-issued wildcard cert for the cluster's aksapp.io
+  # default domain, and to auto-renew it.
+  #
+  # One DDC per cluster is sufficient — the cert covers the wildcard
+  # host, and every per-namespace Gateway (rendered by charts/modelharness)
+  # cross-namespace-references the reconciled Secret.
+  #
+  # The DDC is pinned to the `kube-system` namespace regardless of the
+  # productionstack release namespace. Rationale: the DDC and its
+  # reconciled Secret are cluster-level shared state; kube-system is the
+  # natural home, matches AI Manager RP conventions (`kubectl apply -n
+  # kube-system` in the reference bootstrap), and gives consuming
+  # Gateways a stable, well-known referent namespace.
+  #
+  # ReferenceGrants authorising each consumer namespace to reference
+  # the Secret are rendered by charts/modelharness (not here) into
+  # kube-system, so productionstack stays free of consumer-namespace
+  # knowledge and each modelharness release brings its own grant.
+  #
+  # AKS cluster prerequisites (all required; enabling only some leaves
+  # the DDC stuck at Available=False):
+  #   - Application Routing add-on          (`--enable-app-routing`)
+  #   - Application Routing Gateway API     (`--enable-app-routing-istio`)
+  #   - Managed Gateway API CRDs installed
+  #
+  # NOTE: `--enable-app-routing-istio` is mutually exclusive with the
+  # Istio service-mesh add-on. Consuming Gateways MUST set
+  # `gatewayClassName: approuting-istio` in charts/modelharness — the
+  # vanilla `istio` GatewayClass will not reconcile default-domain TLS.
+  #
+  # The App-Routing operator's cluster-scoped `default-domain-dns`
+  # ClusterExternalDNS auto-publishes the A record for the aksapp.io
+  # hostname; this chart does NOT render an ExternalDNS.
+  defaultDomain:
+    enabled: false
+
+    # namespace is where the DefaultDomainCertificate CR (and the
+    # reconciled TLS Secret) lives. Defaults to `kube-system` — the
+    # natural home for cluster-level shared state and matches AI Manager
+    # RP conventions. Consumers in charts/modelharness reference the
+    # Secret cross-namespace via `azure.defaultDomain.secretRef.namespace`,
+    # which MUST match this value.
+    namespace: kube-system
+
+    # name is the DefaultDomainCertificate CR name.
+    name: "cert"
+
+    # secretName is the kubernetes.io/tls Secret the App-Routing operator
+    # populates and rotates (in kube-system). Must be a DNS-1123 label
+    # (matches the DefaultDomainCertificate CRD's own validation on
+    # `spec.target.secret`) and <= 63 chars. Consuming Gateways in
+    # charts/modelharness must reference the same name/namespace via
+    # `azure.defaultDomain.secretRef`.
+    secretName: "cert"


### PR DESCRIPTION
**Reason for Change**:

Opt-in integration with the AKS Application Routing "default domain" feature (`*.<hash>.<region>.aksapp.io` wildcard hostname) via a new top-level `cloudprovider` value gating cloud-specific templates. Default `cloudprovider=""` keeps the chart cloud-agnostic and byte-identical to pre-change renders.

### Design

A top-level `cloudprovider` string selects which templates render:

| `cloudprovider` | What renders |
| --- | --- |
| `""` (default) | Non-cloud templates only (`templates/gateway.yaml` HTTP-only, `templates/httproute.yaml` header-only). `templates/azure/` files render nothing. |
| `"azure"` | Non-cloud templates render nothing; `templates/azure/*.yaml` render the Azure variants instead. |

Exactly one variant renders per chart — no inline `{{ if }}` blocks inside spec bodies. Schema `enum: ["", "azure"]` catches typos at install time.

Under `cloudprovider=azure`, the Azure sub-tree (`azure.defaultDomain.*`) is consumed for hostname composition, TLS cert reference, and ReferenceGrant placement.

### productionstack

- New `templates/azure/defaultdomaincertificate.yaml` renders one cluster-wide `DefaultDomainCertificate` (`approuting.kubernetes.azure.com/v1alpha1`) into `azure.defaultDomain.namespace` (default `kube-system`). One CR per cluster is sufficient — one Azure-issued wildcard cert covers the whole cluster.
- Dual gate on `cloudprovider=azure` **AND** `azure.defaultDomain.enabled` because a cluster where AI Manager RP already creates the DDC needs an escape hatch (`enabled: false` while still `cloudprovider=azure`).
- `enabled=true` without `cloudprovider=azure` is a hard template `fail`, not a silent no-op.

### modelharness

- New `templates/azure/gateway.yaml` renders the Azure Gateway with HTTP + HTTPS listeners. Hostname on the HTTPS listener is composed as `<workload-namespace>.<zoneName>` so every modelharness release lands on a unique subdomain that the App-Routing operator's `default-domain-dns` ClusterExternalDNS auto-publishes into the aksapp.io zone.
- New `templates/azure/referencegrant.yaml` renders a `ReferenceGrant` into `secretRef.namespace` (`kube-system` by default), authorising THIS namespace's Gateway to cross-namespace-reference the shared TLS Secret. Gateway API mandates the grant in the referent's namespace; the split file makes it obvious that this is the one resource this chart writes outside its workload namespace.
- Non-Azure `templates/gateway.yaml` remains unchanged in content but is now gated on `cloudprovider == ""`.
- `trimPrefix "."` on `zoneName` normalises a leading dot silently.

### modeldeployment

- New `templates/azure/httproute.yaml` renders the HTTPRoute with `hostnames: [<namespace>.<zoneName>]` matching the modelharness Gateway listener, so Istio attaches the route to the host-scoped HTTPS listener. Header-based routing (`X-Gateway-Model-Name` matching this deployment's `name`) still differentiates multiple deployments sharing the hostname within the namespace.
- Non-Azure `templates/httproute.yaml` remains unchanged in content but is now gated on `cloudprovider == ""`.

### How the zone reaches Helm

The cluster's aksapp.io zone is exposed by AI Manager RP on the cluster resource — `ingressProfile.webAppRouting.defaultDomain.domainName`. Callers fetch it once per cluster with:

```sh
az aks show -g $RG -n $CLUSTER \
  --query 'ingressProfile.webAppRouting.defaultDomain.domainName' -o tsv
```

…and pass it via `--set cloudprovider=azure --set azure.defaultDomain.zoneName=$ZONE` to every `modelharness` / `modeldeployment` install on that cluster.

### Install flow

```sh
ZONE=$(az aks show -g $RG -n $CLUSTER \
  --query 'ingressProfile.webAppRouting.defaultDomain.domainName' -o tsv)

# Umbrella (once per cluster)
helm install productionstack charts/productionstack \
  --namespace kaito-system --create-namespace \
  --set cloudprovider=azure \
  --set azure.defaultDomain.enabled=true

# Per workload namespace
helm install modelharness charts/modelharness \
  --namespace my-models --create-namespace \
  --set gatewayClassName=approuting-istio \
  --set cloudprovider=azure \
  --set azure.defaultDomain.zoneName=$ZONE

# Per model deployment
helm install phi3 charts/modeldeployment \
  --namespace my-models \
  --set model=phi-3-mini-4k-instruct \
  --set cloudprovider=azure \
  --set azure.defaultDomain.zoneName=$ZONE
```

### Prerequisites (validated by the caller, not the charts)

- AKS Application Routing add-on enabled (`--enable-app-routing`).
- Application Routing Gateway API implementation enabled (`--enable-app-routing-istio`) — provides the `approuting-istio` `GatewayClass`, mutually exclusive with the Istio service-mesh add-on.
- Managed Gateway API CRDs installed.
- Caller has RBAC to create/patch/delete `ReferenceGrant`s in `productionstack.azure.defaultDomain.namespace`.

### Verification

`helm template` rendered across all three charts, all combinations of `cloudprovider` and `azure.defaultDomain.enabled`, plus every fail-guard path (missing `zoneName`, `enabled=true` without `cloudprovider=azure`, invalid `cloudprovider` values).

Cross-namespace `ReferenceGrant` enforcement verified on a kind cluster with Gateway API v1.2 CRDs and Istio 1.30:

| Test | Result |
| --- | --- |
| Gateway with cross-ns certificateRef, no grant | `ResolvedRefs=False, reason=RefNotPermitted` (as expected) |
| Grant applied in referent's namespace | Flips to `ResolvedRefs=True, Programmed=True` within ~5s |
| Grant deleted | Regresses to `RefNotPermitted` within ~5s |
| Grant in consumer's namespace (wrong) | Still `RefNotPermitted` — confirms grant MUST live in referent's ns |

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

*No new tests in this PR — the change is behind an opt-in toggle and depends on Azure-managed control-plane behaviour (App-Routing operator + AI Manager RP) that isn't reproducible in the existing e2e infra. Ready to add tests once we have an AI Manager cluster in CI.*

**Issue Fixed**:

Fixes #139

**Notes for Reviewers**:

- Every existing install (no `cloudprovider` set) renders byte-identical to `main`. The change is fully opt-in.
- The `zoneName` value is duplicated across `modelharness` and `modeldeployment` releases on purpose — each release is a separate `helm install`, and the value comes from an out-of-band cluster property. Keeping them independent avoids cross-chart coupling.
- `productionstack.azure.defaultDomain.enabled` is kept as a separate toggle from `cloudprovider` because the DDC lifecycle differs — a cluster where AI Manager RP already provisions the DDC should install with `cloudprovider=azure` but `enabled=false` to skip the duplicate.
- `modelharness` and `modeldeployment` do NOT have `azure.defaultDomain.enabled` — opting into `cloudprovider=azure` is the entire commitment. The Azure Gateway variant always includes the default-domain listener when Azure is selected.
- The `ReferenceGrant` was intentionally split into its own template file (`templates/azure/referencegrant.yaml`) rather than co-located with the Gateway. It's the only resource in `modelharness` written outside the workload namespace, and the file split makes that visible.