### PR TITLE
feat(modeldeployment): add enableBenchmark switch

### DIFF
--- a/charts/modeldeployment/templates/inferenceset.yaml
+++ b/charts/modeldeployment/templates/inferenceset.yaml
@@ -36,6 +36,10 @@ spec:
         cross-namespace ingress to them would silently succeed.
         */}}
         {{- include "modeldeployment.ownerLabel" . | nindent 8 }}
+      {{- if not .Values.enableBenchmark }}
+      annotations:
+        kaito.sh/disable-benchmark: "true"
+      {{- end }}
     resource:
       instanceType: {{ .Values.instanceType | quote }}
     inference:

--- a/charts/modeldeployment/values.schema.json
+++ b/charts/modeldeployment/values.schema.json
@@ -42,6 +42,10 @@
       "minimum": 1,
       "description": "Queue-depth threshold used by the ScaledObject. Only used when enableScaling is true. MUST be positive."
     },
+    "enableBenchmark": {
+      "type": "boolean",
+      "description": "Toggles KAITO benchmark runs for this InferenceSet. When false, the kaito.sh/disable-benchmark annotation is stamped on the InferenceSet."
+    },
     "gatewayName": {
       "type": "string",
       "description": "Gateway the HTTPRoute attaches to. Empty derives '<namespace>-gw'."

--- a/charts/modeldeployment/values.yaml
+++ b/charts/modeldeployment/values.yaml
@@ -42,6 +42,11 @@ maxReplicas: 3
 # scaledobject.kaito.sh/threshold annotation.
 scalingThreshold: 10
 
+# enableBenchmark toggles KAITO benchmark runs for this InferenceSet. When
+# false, the `kaito.sh/disable-benchmark: "true"` annotation is stamped on
+# the InferenceSet so the KAITO controller skips benchmark provisioning.
+enableBenchmark: true
+
 # gatewayName is the Gateway resource the HTTPRoute attaches to. When
 # empty (the default), the chart derives it as "<namespace>-gw" so the
 # rendered HTTPRoute parents the per-namespace Gateway provisioned by


### PR DESCRIPTION

**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

When set to false, stamps the kaito.sh/disable-benchmark="true" annotation on spec.template.metadata so the KAITO controller skips benchmark provisioning for the rendered Workspaces. Defaults to true to preserve existing behavior.


**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
