### PR TITLE
fix(gpu-node-mocker): self-heal shadow pods lost on real node recreation

### DIFF
--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
@@ -63,36 +63,46 @@ type ShadowPodReconciler struct {
 
 // SetupWithManager registers the controller with two watches:
 //
-//  1. Primary watch on Pods (all namespaces) filtered to Pending pods on fake
-//     nodes — these are the "original" pods we need to mirror.
+//  1. Primary watch on Pods (all namespaces) filtered to KAITO pods on fake
+//     nodes — these are the "original" pods we need to mirror. We deliberately
+//     do NOT filter on phase==Pending here: an already-adopted pod that we
+//     previously patched to Running must still be reconciled so we can
+//     self-heal its shadow pod if it disappears (e.g. when the real AKS node
+//     hosting the shadow pod is recreated). Reconcile stays idempotent.
 //  2. Secondary watch on shadow pods — when a shadow pod transitions to Running
-//     we re-queue the original pod so we can apply the status patch immediately.
+//     we re-queue the original pod to apply the status patch immediately, and
+//     when a shadow pod is deleted we re-queue the original pod so a fresh
+//     shadow pod is recreated.
 func (r *ShadowPodReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// Predicate: only enqueue pods that are Pending AND assigned to a fake node.
-	pendingOnFakeNode := predicate.Funcs{
-		CreateFunc:  func(e event.CreateEvent) bool { return isPendingOnFakeNode(e.Object) },
-		UpdateFunc:  func(e event.UpdateEvent) bool { return isPendingOnFakeNode(e.ObjectNew) },
+	// Predicate: enqueue KAITO pods assigned to a fake node, regardless of phase.
+	kaitoOnFakeNode := predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return isKaitoPodOnFakeNode(e.Object) },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return isKaitoPodOnFakeNode(e.ObjectNew) },
 		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
 
-	// Predicate: shadow pods — only care about Running transitions.
-	shadowPodRunning := predicate.Funcs{
+	// Predicate: shadow pods — re-queue the original pod when the shadow pod
+	// becomes Running (apply the status patch) or is deleted (recreate it).
+	shadowPodEvents := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool { return false },
 		UpdateFunc: func(e event.UpdateEvent) bool {
 			pod, ok := e.ObjectNew.(*corev1.Pod)
 			return ok && isShadowPod(pod) && pod.Status.Phase == corev1.PodRunning && pod.Status.PodIP != ""
 		},
-		DeleteFunc:  func(e event.DeleteEvent) bool { return false },
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			pod, ok := e.Object.(*corev1.Pod)
+			return ok && isShadowPod(pod)
+		},
 		GenericFunc: func(e event.GenericEvent) bool { return false },
 	}
 
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&corev1.Pod{}, builder.WithPredicates(pendingOnFakeNode)).
+		For(&corev1.Pod{}, builder.WithPredicates(kaitoOnFakeNode)).
 		Watches(
 			&corev1.Pod{},
 			handler.EnqueueRequestsFromMapFunc(r.shadowPodToOriginalPod),
-			builder.WithPredicates(shadowPodRunning),
+			builder.WithPredicates(shadowPodEvents),
 		).
 		Complete(r)
 }
@@ -112,14 +122,30 @@ func (r *ShadowPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, fmt.Errorf("get pod: %w", err)
 	}
 
-	if !isPendingOnFakeNode(original) {
-		return ctrl.Result{}, nil
-	}
-	if original.Status.Phase == corev1.PodRunning {
+	if !isKaitoPodOnFakeNode(original) {
 		return ctrl.Result{}, nil
 	}
 
-	log.Info("processing pending pod on fake node", "node", original.Spec.NodeName)
+	// Pods being torn down are handled by FakeNodePodReaper; the GC removes the
+	// shadow pod via its OwnerReference. Never (re)create a shadow pod for them.
+	if original.DeletionTimestamp != nil {
+		return ctrl.Result{}, nil
+	}
+
+	// Act only when the pod still needs mirroring:
+	//   (a) it is still Pending — the normal Phase-2 flow, or
+	//   (b) it was already adopted by us (shadow-pod-ref annotation present) but
+	//       its shadow pod may have vanished — self-heal by recreating it. This
+	//       covers the real AKS node hosting the shadow pod being recreated,
+	//       which leaves the original pod stuck in a patched-Running state that
+	//       points at a dead pod IP.
+	// A Running pod we never adopted is not ours to touch.
+	adopted := original.Annotations[AnnotationShadowPodRef] != ""
+	if original.Status.Phase != corev1.PodPending && !adopted {
+		return ctrl.Result{}, nil
+	}
+
+	log.Info("processing KAITO pod on fake node", "node", original.Spec.NodeName, "phase", original.Status.Phase)
 
 	shadowName := shadowPodName(original)
 	shadowPod, err := r.ensureShadowPod(ctx, original, shadowName)
@@ -146,11 +172,17 @@ func (r *ShadowPodReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{RequeueAfter: 5_000_000_000}, nil // 5 s
 	}
 
-	if err := r.patchOriginalPodStatus(ctx, original, shadowPod); err != nil {
-		return ctrl.Result{}, fmt.Errorf("patch original pod status: %w", err)
+	// Patch the original pod's status only when it is stale — either not yet
+	// Running or pointing at a different (dead) shadow IP. This keeps the
+	// reconcile idempotent and avoids a patch→event→reconcile hot loop now that
+	// already-Running pods are also watched.
+	if original.Status.Phase != corev1.PodRunning || original.Status.PodIP != shadowPod.Status.PodIP {
+		if err := r.patchOriginalPodStatus(ctx, original, shadowPod); err != nil {
+			return ctrl.Result{}, fmt.Errorf("patch original pod status: %w", err)
+		}
+		log.Info("original pod patched to Running", "podIP", shadowPod.Status.PodIP)
 	}
 
-	log.Info("original pod patched to Running", "podIP", shadowPod.Status.PodIP)
 	return ctrl.Result{}, nil
 }
 
@@ -434,23 +466,35 @@ func (r *ShadowPodReconciler) shadowPodToOriginalPod(_ context.Context, obj clie
 	}
 }
 
-func isPendingOnFakeNode(obj client.Object) bool {
+// isKaitoPodOnFakeNode reports whether the pod is a KAITO-provisioned pod
+// assigned to a fake node, regardless of its phase. Two provisioning paths
+// exist:
+//   - InferenceSet (modeldeployment) pods carry `inferenceset.kaito.sh/created-by`.
+//   - Workspace pods (KAITO StatefulSet) carry `kaito.sh/workspace`.
+//
+// Both end up on a fake node and need a shadow pod. The phase-agnostic form is
+// used by the watch predicate and Reconcile so that already-adopted pods can be
+// re-reconciled to self-heal a vanished shadow pod.
+func isKaitoPodOnFakeNode(obj client.Object) bool {
 	pod, ok := obj.(*corev1.Pod)
 	if !ok {
 		return false
 	}
-	// Only process pods created by KAITO. Two provisioning paths exist:
-	//   - InferenceSet (modeldeployment) pods carry `inferenceset.kaito.sh/created-by`.
-	//   - Workspace pods (KAITO StatefulSet) carry `kaito.sh/workspace`.
-	// Both end up Pending on a fake node and need a shadow pod.
 	_, hasInferenceSet := pod.Labels[InferenceSetCreatedByLabelKey]
 	_, hasWorkspace := pod.Labels[LabelKaitoWorkspace]
 	if !hasInferenceSet && !hasWorkspace {
 		return false
 	}
-	return pod.Spec.NodeName != "" &&
-		strings.HasPrefix(pod.Spec.NodeName, "fake-") &&
-		pod.Status.Phase == corev1.PodPending
+	return pod.Spec.NodeName != "" && strings.HasPrefix(pod.Spec.NodeName, "fake-")
+}
+
+// isPendingOnFakeNode is isKaitoPodOnFakeNode narrowed to Pending pods.
+func isPendingOnFakeNode(obj client.Object) bool {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return false
+	}
+	return isKaitoPodOnFakeNode(pod) && pod.Status.Phase == corev1.PodPending
 }
 
 func isShadowPod(pod *corev1.Pod) bool {

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller_test.go
@@ -549,6 +549,44 @@ func TestShadowPodReconcile_PatchesWhenShadowRunning(t *testing.T) {
 	}
 }
 
+// TestShadowPodReconcile_RecreatesShadowWhenMissing exercises the self-heal
+// path: an already-adopted pod that we previously patched to Running (its
+// shadow pod was destroyed when the real host node was recreated) must have a
+// fresh shadow pod recreated instead of being skipped as "already Running".
+func TestShadowPodReconcile_RecreatesShadowWhenMissing(t *testing.T) {
+	ctx := context.Background()
+	scheme := testScheme()
+	cfg := testConfig()
+
+	ns := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
+	original := newPendingPodOnFakeNode("falcon-0", "default", "fake-ws1")
+	// Simulate the stuck state: adopted + patched Running, pointing at a dead
+	// shadow IP, but no shadow pod exists any more.
+	original.Annotations = map[string]string{
+		AnnotationShadowPodRef: "default/shadow-default-falcon-0",
+	}
+	original.Status.Phase = corev1.PodRunning
+	original.Status.PodIP = "10.244.9.99" // dead IP from the lost shadow pod
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).WithObjects(ns, original).WithStatusSubresource(original).Build()
+	r := &ShadowPodReconciler{Client: cl, Config: cfg}
+
+	result, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: "falcon-0", Namespace: "default"}})
+	if err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+	// Shadow pod is Pending (no kubelet in test), so should requeue.
+	if result.RequeueAfter == 0 {
+		t.Error("should requeue while waiting for recreated shadow pod to be Running")
+	}
+
+	// A fresh shadow pod must have been recreated.
+	shadow := &corev1.Pod{}
+	if err := cl.Get(ctx, types.NamespacedName{Name: "shadow-default-falcon-0", Namespace: "default"}, shadow); err != nil {
+		t.Fatalf("shadow pod was not recreated: %v", err)
+	}
+}
+
 // Test that shadowPodToOriginalPod returns empty for non-pod objects
 func TestShadowPodToOriginalPod_NonPod(t *testing.T) {
 	r := &ShadowPodReconciler{}

--- a/test/e2e/gpu_mocker_test.go
+++ b/test/e2e/gpu_mocker_test.go
@@ -431,6 +431,88 @@ var _ = Describe("GPU Mocker E2E", Ordered, func() {
 				}, 2*time.Minute, 10*time.Second).Should(Succeed(),
 					"original Workspace pod should be patched to Running with the shadow pod IP")
 			})
+
+			It("should self-heal a shadow pod that is deleted for a Running original pod", func() {
+				clientset, err := utils.GetK8sClientset()
+				Expect(err).NotTo(HaveOccurred())
+
+				ctx := context.Background()
+
+				// Pick an original inference pod already adopted and patched to
+				// Running on a fake node in THIS case's namespace (parallel-
+				// isolation pattern). Deleting its shadow pod faithfully
+				// simulates the real AKS node hosting the shadow pod being
+				// recreated: the shadow pod carries an OwnerReference to the
+				// original pod (not vice-versa), so the original is left stuck
+				// in a patched-Running state pointing at a dead IP.
+				deploymentName := caseDeployments[0].Name
+				origPods, err := clientset.CoreV1().Pods(caseNamespace).List(ctx, metav1.ListOptions{
+					LabelSelector: fmt.Sprintf("inferenceset.kaito.sh/created-by=%s", deploymentName),
+				})
+				Expect(err).NotTo(HaveOccurred())
+
+				var origName string
+				for _, p := range origPods.Items {
+					if strings.HasPrefix(p.Spec.NodeName, "fake-") &&
+						p.Status.Phase == corev1.PodRunning &&
+						p.Annotations["kaito.sh/shadow-pod-ref"] != "" {
+						origName = p.Name
+						break
+					}
+				}
+				Expect(origName).NotTo(BeEmpty(),
+					"need an adopted Running original pod on a fake node for %q", deploymentName)
+
+				shadowName := "shadow-" + caseNamespace + "-" + origName
+
+				// Record the current shadow pod's UID so we can prove a *fresh*
+				// one is created rather than the old one lingering.
+				oldShadow, err := clientset.CoreV1().Pods(caseNamespace).Get(ctx, shadowName, metav1.GetOptions{})
+				Expect(err).NotTo(HaveOccurred(), "shadow pod %q should exist before deletion", shadowName)
+				oldUID := oldShadow.UID
+
+				By(fmt.Sprintf("deleting shadow pod %q to simulate the real node being recreated", shadowName))
+				err = clientset.CoreV1().Pods(caseNamespace).Delete(ctx, shadowName,
+					metav1.DeleteOptions{GracePeriodSeconds: ptr.To(int64(0))})
+				Expect(err).NotTo(HaveOccurred())
+
+				By("waiting for the controller to recreate a fresh Running shadow pod")
+				Eventually(func() error {
+					s, err := clientset.CoreV1().Pods(caseNamespace).Get(ctx, shadowName, metav1.GetOptions{})
+					if err != nil {
+						return fmt.Errorf("get shadow pod %q: %w", shadowName, err)
+					}
+					if s.UID == oldUID {
+						return fmt.Errorf("shadow pod %q still has the old UID; not recreated yet", shadowName)
+					}
+					if s.Status.Phase != corev1.PodRunning || s.Status.PodIP == "" {
+						return fmt.Errorf("recreated shadow pod %q not Running yet (phase=%s)", shadowName, s.Status.Phase)
+					}
+					return nil
+				}, 3*time.Minute, 5*time.Second).Should(Succeed(),
+					"a fresh shadow pod should be recreated and become Running")
+
+				By("verifying the original pod is re-patched to the recreated shadow pod IP")
+				Eventually(func() error {
+					newShadow, err := clientset.CoreV1().Pods(caseNamespace).Get(ctx, shadowName, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					orig, err := clientset.CoreV1().Pods(caseNamespace).Get(ctx, origName, metav1.GetOptions{})
+					if err != nil {
+						return err
+					}
+					if orig.Status.Phase != corev1.PodRunning {
+						return fmt.Errorf("original pod %q phase = %s, want Running", origName, orig.Status.Phase)
+					}
+					if orig.Status.PodIP != newShadow.Status.PodIP {
+						return fmt.Errorf("original pod %q podIP = %q, want recreated shadow IP %q",
+							origName, orig.Status.PodIP, newShadow.Status.PodIP)
+					}
+					return nil
+				}, 2*time.Minute, 5*time.Second).Should(Succeed(),
+					"original pod should be re-patched to the recreated shadow pod's IP")
+			})
 		})
 
 		Context("Original pod status patching", func() {


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

The ShadowPodReconciler only acted on Pending KAITO pods on fake nodes. Once an original pod's status was patched to Running, a fake node (no kubelet) never reverts it, so if the shadow pod was destroyed (e.g. the real AKS node hosting it was recreated) nothing recreated it: the original pod stayed Running pointing at a dead pod IP.

- Add phase-agnostic isKaitoPodOnFakeNode; isPendingOnFakeNode narrows it.
- Broaden the primary Pod watch to all phases so adopted-Running orphans are re-reconciled.
- Watch shadow-pod deletions to re-enqueue the original for timely heal.
- Reconcile now acts when Pending OR already adopted, recreating a missing shadow pod; skip pods being deleted or Running-but-never-adopted.
- Patch original status only when stale (phase!=Running || IP mismatch) to keep reconcile idempotent and avoid a patch->event->reconcile loop.
- Add TestShadowPodReconcile_RecreatesShadowWhenMissing.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
