### PR TITLE
Update e2e region to swedencentral due to capacity restraint

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -47,7 +47,7 @@ env:
   CLUSTER_NAME: "kaito-gw-e2e-aks-${{ github.run_id }}-${{ github.run_attempt }}"
   ACR_NAME: "kaitogwe2eaks${{ github.run_id }}a${{ github.run_attempt }}acr"
   GPU_MOCKER_IMAGE: "gpu-node-mocker:latest-${{ github.run_id }}-${{ github.run_attempt }}"
-  LOCATION: australiaeast
+  LOCATION: swedencentral
   NODE_COUNT: '3'
   NODE_VM_SIZE: Standard_D8s_v5
 

--- a/hack/e2e/scripts/prepare-image.sh
+++ b/hack/e2e/scripts/prepare-image.sh
@@ -11,7 +11,7 @@
 #   RESOURCE_GROUP   — Azure resource group name (default: kaito-rg)
 #   CLUSTER_NAME     — AKS cluster name          (default: kaito-aks)
 #   ACR_NAME         — ACR registry name         (default: <cluster_name>acr, sanitized)
-#   LOCATION         — Azure region              (default: australiaeast)
+#   LOCATION         — Azure region              (default: swedencentral)
 #   IMG              — Local docker tag for the gpu-node-mocker image
 #                      (default: gpu-node-mocker:latest)
 #
@@ -32,7 +32,7 @@ RESOURCE_GROUP="${RESOURCE_GROUP:-kaito-rg}"
 CLUSTER_NAME="${CLUSTER_NAME:-kaito-aks}"
 # ACR names must be alphanumeric, 5-50 chars. Strip dashes from cluster name.
 ACR_NAME="${ACR_NAME:-$(echo "${CLUSTER_NAME}acr" | tr -d '-' | head -c 50)}"
-LOCATION="${LOCATION:-australiaeast}"
+LOCATION="${LOCATION:-swedencentral}"
 IMG="${IMG:-gpu-node-mocker:latest}"
 
 # Verify the container tool used by the Makefile (docker/podman) is installed

--- a/hack/e2e/scripts/run-e2e-local.sh
+++ b/hack/e2e/scripts/run-e2e-local.sh
@@ -13,7 +13,7 @@
 # Environment variables (override defaults as needed):
 #   RESOURCE_GROUP   (default: kaito-e2e-local)
 #   CLUSTER_NAME     (default: kaito-e2e-local)
-#   LOCATION         (default: australiaeast)
+#   LOCATION         (default: swedencentral)
 #   NODE_COUNT       (default: 2)
 #   NODE_VM_SIZE     (default: Standard_D8d_v4)
 #   E2E_PARALLEL     (default: 2) — Ginkgo parallel worker count
@@ -81,7 +81,7 @@ echo ""
 
 export RESOURCE_GROUP="${RESOURCE_GROUP:-kaito-e2e-local}"
 export CLUSTER_NAME="${CLUSTER_NAME:-kaito-e2e-local}"
-export LOCATION="${LOCATION:-australiaeast}"
+export LOCATION="${LOCATION:-swedencentral}"
 export NODE_COUNT="${NODE_COUNT:-2}"
 export NODE_VM_SIZE="${NODE_VM_SIZE:-Standard_D8d_v4}"
 export E2E_PARALLEL="${E2E_PARALLEL:-2}"

--- a/hack/e2e/scripts/setup-cluster.sh
+++ b/hack/e2e/scripts/setup-cluster.sh
@@ -11,7 +11,7 @@
 #   RESOURCE_GROUP        — Azure resource group name  (default: kaito-rg)
 #   CLUSTER_NAME          — AKS cluster name           (default: kaito-aks)
 #   ACR_NAME              — ACR registry name           (default: <cluster_name>acr, sanitized)
-#   LOCATION              — Azure region               (default: australiaeast)
+#   LOCATION              — Azure region               (default: swedencentral)
 #   NODE_COUNT            — Number of worker nodes      (default: 2)
 #   NODE_VM_SIZE          — VM SKU for the node pool    (default: Standard_D8d_v4)
 #   E2E_PROVIDER          — upstream|azure              (default: upstream)
@@ -41,7 +41,7 @@ RESOURCE_GROUP="${RESOURCE_GROUP:-kaito-rg}"
 CLUSTER_NAME="${CLUSTER_NAME:-kaito-aks}"
 # ACR names must be alphanumeric, 5-50 chars. Strip dashes from cluster name.
 ACR_NAME="${ACR_NAME:-$(echo "${CLUSTER_NAME}acr" | tr -d '-' | head -c 50)}"
-LOCATION="${LOCATION:-australiaeast}"
+LOCATION="${LOCATION:-swedencentral}"
 NODE_COUNT="${NODE_COUNT:-2}"
 NODE_VM_SIZE="${NODE_VM_SIZE:-Standard_D8d_v4}"
 E2E_PROVIDER="${E2E_PROVIDER:-upstream}"


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->
The e2e pipeline has been failing for 2 days due to VM sku capacity constraint in Australiaeast.

```
ERROR: (ErrCode_InsufficientVCPUQuota) Insufficient vcpu quota requested 24, remaining 12 for family standardDSv5Family for region australiaeast. If you want to increase the quota, please follow this instruction: https://learn.microsoft.com/en-us/azure/quotas/view-quotas. Surge nodes would also consume vcpu quota, please consider use smaller maxSurge or use maxUnavailable to proceed upgrade without surge nodes, details: aka.ms/aks/maxUnavailable.
Code: ErrCode_InsufficientVCPUQuota
```
https://github.com/kaito-project/production-stack/actions/runs/28988056602/job/86258189073#step:3:40697

Update e2e region to swedencentral due to capacity restraint 
<img width="1874" height="80" alt="image" src="https://github.com/user-attachments/assets/efc65aad-dfa5-4436-8472-09c5c3dff32d" />

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
