### PR TITLE
feat(gpu-node-mocker): allow to configure deployment tolerations

### DIFF
--- a/charts/gpu-node-mocker/templates/deployment.yaml
+++ b/charts/gpu-node-mocker/templates/deployment.yaml
@@ -18,6 +18,10 @@ spec:
     spec:
       serviceAccountName: {{ include "gpu-node-mocker.fullname" . }}
       terminationGracePeriodSeconds: 30
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: controller
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/gpu-node-mocker/values.yaml
+++ b/charts/gpu-node-mocker/values.yaml
@@ -64,3 +64,8 @@ resources:
   limits:
     cpu: 500m
     memory: 256Mi
+
+# tolerations applied to the controller pod. Empty by default; the caller is
+# expected to pass any required tolerations (e.g. a CriticalAddonsOnly
+# toleration for nodes reserved for critical add-ons).
+tolerations: []

--- a/charts/modeldeployment/templates/epp-deployment.yaml
+++ b/charts/modeldeployment/templates/epp-deployment.yaml
@@ -28,6 +28,10 @@ spec:
     spec:
       serviceAccountName: {{ include "modeldeployment.eppServiceName" . }}
       terminationGracePeriodSeconds: 130
+      {{- with .Values.epp.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       containers:
         - name: epp
           image: "{{ .Values.epp.image.repository }}:{{ .Values.epp.image.tag }}"

--- a/charts/modeldeployment/values.yaml
+++ b/charts/modeldeployment/values.yaml
@@ -84,6 +84,10 @@ epp:
     requests:
       cpu: 100m
       memory: 256Mi
+  # tolerations applied to the EPP pod. Empty by default; the caller is
+  # expected to pass any required tolerations (e.g. a CriticalAddonsOnly
+  # toleration for nodes reserved for critical add-ons).
+  tolerations: []
   # modelServerSelector selects the inference pods this InferencePool routes
   # to. KAITO labels each inference pod with
   # `inferenceset.kaito.sh/created-by: <inferenceset-name>` and (for stateful

--- a/charts/productionstack/charts/body-based-routing/templates/bbr.yaml
+++ b/charts/productionstack/charts/body-based-routing/templates/bbr.yaml
@@ -16,6 +16,10 @@ spec:
         {{- include "bbr.selectorLabels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ include "bbr.serviceAccountName" . }}
+      {{- with .Values.bbr.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       # Spread BBR replicas across distinct {{ .Values.bbr.podAntiAffinity.topologyKey }}
       # domains so a single node failure cannot take down every replica
       # at once (issue #89: BBR is a cluster-scope SPOF on the request

--- a/charts/productionstack/charts/body-based-routing/values.yaml
+++ b/charts/productionstack/charts/body-based-routing/values.yaml
@@ -96,6 +96,11 @@ bbr:
       timeoutSeconds: 3
       failureThreshold: 3
 
+  # tolerations applied to the BBR pod. Empty by default; the caller is
+  # expected to pass any required tolerations (e.g. a CriticalAddonsOnly
+  # toleration for nodes reserved for critical add-ons).
+  tolerations: []
+
   image:
     registry: us-central1-docker.pkg.dev/k8s-staging-images
     repository: gateway-api-inference-extension/bbr

--- a/charts/productionstack/charts/keda-kaito-scaler/templates/keda-kaito-scaler.yaml
+++ b/charts/productionstack/charts/keda-kaito-scaler/templates/keda-kaito-scaler.yaml
@@ -74,6 +74,9 @@ spec:
           key: node-role.kubernetes.io/master
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
+        {{- with .Values.tolerations }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
       containers:
         - args:
             - --v={{ .Values.log.level }}

--- a/charts/productionstack/charts/keda-kaito-scaler/values.yaml
+++ b/charts/productionstack/charts/keda-kaito-scaler/values.yaml
@@ -36,4 +36,10 @@ resources:
   requests:
     cpu: 200m
     memory: 256Mi
+
+# Additional tolerations applied to the scaler pod, appended to the
+# always-present control-plane tolerations. Empty by default; the caller is
+# expected to pass any required tolerations (e.g. a CriticalAddonsOnly
+# toleration for nodes reserved for critical add-ons).
+tolerations: []
   


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

Add a tolerations helm value (default empty) to the gpu-node-mocker, EPP (modeldeployment), body-based-routing, and keda-kaito-scaler workloads, rendered only when set. This lets the caller pass any required tolerations (e.g. a CriticalAddonsOnly toleration for nodes reserved for critical add-ons) instead of hardcoding them in the charts. keda-kaito-scaler appends the option after its fixed control-plane tolerations.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
