### PR TITLE
feat(charts): composite multi-metric autoscaling for modeldeployment

### DIFF
--- a/charts/gpu-node-mocker/Chart.yaml
+++ b/charts/gpu-node-mocker/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: gpu-node-mocker
 description: GPU Node Mocker controller for KAITO production-stack
 type: application
-version: 0.2.2
-appVersion: "0.2.2"
+version: 0.3.0
+appVersion: "0.3.0"

--- a/charts/modeldeployment/Chart.yaml
+++ b/charts/modeldeployment/Chart.yaml
@@ -4,5 +4,5 @@ description: |
   Deploys a KAITO InferenceSet together with the Istio DestinationRule and
   Gateway API HTTPRoute required to route inference traffic to it.
 type: application
-version: 0.2.2
-appVersion: "0.2.2"
+version: 0.3.0
+appVersion: "0.3.0"

--- a/charts/modeldeployment/README.md
+++ b/charts/modeldeployment/README.md
@@ -17,10 +17,12 @@ identifying labels `kaito.sh/inferenceset: <name>` and
 deployment.
 
 Chart values are validated by `values.schema.json` at install time
-(`model` non-empty, `replicas` / `maxReplicas` / `scalingThreshold`
-positive). The cross-field guard `maxReplicas >= replicas` (not
-expressible in JSON Schema) is enforced by a fail-fast template guard
-when `enableScaling=true`.
+(`model` non-empty, `replicas` / `maxReplicas` positive, and — when
+`enableScaling=true` — at least one `scaling.metrics` entry). The
+cross-field guard `maxReplicas >= replicas` and the non-empty
+`scaling.metrics` requirement (neither expressible in JSON Schema alone)
+are additionally enforced by fail-fast template guards when
+`enableScaling=true`.
 
 The EPP runs the [`llm-d-inference-scheduler`](https://github.com/llm-d/llm-d-inference-scheduler/tree/v0.7.1)
 distribution with `--secure-serving=false`, so the Istio Gateway can reach it
@@ -35,9 +37,17 @@ over plaintext gRPC and **no `DestinationRule` is required**.
 | `model`                   | required | `""`                                                                 | Preset model name. Used only as `spec.template.inference.preset.name`.                     |
 | `instanceType`            | required | `Standard_NV36ads_A10_v5`                                            | VM instance type for the underlying nodes.                                                 |
 | `replicas`                | required | `1`                                                                  | InferenceSet replicas. Also wired to `scaledobject.kaito.sh/min-replicas`.                 |
-| `enableScaling`           | optional | `false`                                                              | Wired to `scaledobject.kaito.sh/auto-provision`.                                           |
+| `enableScaling`           | optional | `false`                                                              | Wired to `scaledobject.kaito.sh/auto-provision`. Gates the entire `scaling` block.         |
 | `maxReplicas`             | optional | `3`                                                                  | Wired to `scaledobject.kaito.sh/max-replicas` (only when `enableScaling=true`).            |
-| `scalingThreshold`        | optional | `10`                                                                 | Wired to `scaledobject.kaito.sh/threshold` (only when `enableScaling=true`).               |
+| `scaling.metrics`         | optional | `vllm:num_requests_waiting` gauge + `vllm:request_queue_time_seconds` histogram | Ordered list of scaling signals combined under the AND policy; each entry renders one indexed `scaledobject.kaito.sh/<key>/<i>` slot. At least one entry is required when `enableScaling=true`. |
+| `scaling.metrics[].name`  | required | `vllm:num_requests_waiting`                                         | Prometheus metric family name. Wired to `scaledobject.kaito.sh/metricName/<i>`.            |
+| `scaling.metrics[].type`  | optional | `gauge`                                                             | `gauge` (per-replica average) or `histogram` (per-pod quantile). Wired to `scaledobject.kaito.sh/metricstype/<i>`. |
+| `scaling.metrics[].upThreshold`   | required | _empty_                                                    | Per-replica scale-up threshold. Empty by default; a template guard rejects the install when unset (`enableScaling=true`). Wired to `scaledobject.kaito.sh/upthreshold/<i>`. |
+| `scaling.metrics[].downThreshold` | required | _empty_                                                    | Per-replica scale-down threshold (MUST be `< upThreshold`). Empty by default; a template guard rejects the install when unset or `>= upThreshold` (`enableScaling=true`). Wired to `scaledobject.kaito.sh/downthreshold/<i>`. |
+| `scaling.metrics[].quantile`      | optional | _empty_ → `0.95`                                            | Target quantile for `histogram` metrics; ignored for `gauge`. Wired to `scaledobject.kaito.sh/quantile/<i>`. |
+| `scaling.evaluationWindow`| optional | `60`                                                                | Scale-up stabilization window (seconds). Wired to `scaledobject.kaito.sh/evaluationwindow`. |
+| `scaling.scaleUpCooldown` | optional | `300`                                                               | Minimum seconds between scale-up steps. Wired to `scaledobject.kaito.sh/scaleupcooldown`.  |
+| `scaling.scaleDownCooldown` | optional | `300`                                                             | Minimum seconds between scale-down steps. Wired to `scaledobject.kaito.sh/scaledowncooldown`. |
 | `gatewayName`             | optional | _empty_ → `<namespace>-gw`                                          | Gateway the HTTPRoute attaches to. Defaults to the per-namespace Gateway provisioned by `charts/modelharness`. |
 | `epp.image.repository`    | optional | `mcr.microsoft.com/oss/v2/llm-d/llm-d-inference-scheduler`           | EPP container image.                                                                       |
 | `epp.image.tag`           | optional | `v0.7.1`                                                             | EPP image tag.                                                                             |

--- a/charts/modeldeployment/templates/inferenceset.yaml
+++ b/charts/modeldeployment/templates/inferenceset.yaml
@@ -2,6 +2,9 @@
 {{- if lt ((.Values.maxReplicas | int)) ((.Values.replicas | int)) }}
 {{- fail (printf "modeldeployment: maxReplicas (%d) must be >= replicas (%d) when enableScaling is true" (.Values.maxReplicas | int) (.Values.replicas | int)) }}
 {{- end }}
+{{- if not (.Values.scaling).metrics }}
+{{- fail "modeldeployment: scaling.metrics must contain at least one entry when enableScaling is true" }}
+{{- end }}
 {{- end }}
 apiVersion: kaito.sh/v1alpha1
 kind: InferenceSet
@@ -13,9 +16,39 @@ metadata:
   {{- if .Values.enableScaling }}
   annotations:
     scaledobject.kaito.sh/auto-provision: "true"
-    scaledobject.kaito.sh/threshold: {{ .Values.scalingThreshold | quote }}
     scaledobject.kaito.sh/min-replicas: {{ .Values.replicas | quote }}
     scaledobject.kaito.sh/max-replicas: {{ .Values.maxReplicas | quote }}
+    {{- range $i, $m := .Values.scaling.metrics }}
+    {{- if not $m.name }}
+    {{- fail (printf "modeldeployment: scaling.metrics[%d].name is required when enableScaling is true" $i) }}
+    {{- end }}
+    {{- if not $m.upThreshold }}
+    {{- fail (printf "modeldeployment: scaling.metrics[%d].upThreshold is required when enableScaling is true" $i) }}
+    {{- end }}
+    {{- if not $m.downThreshold }}
+    {{- fail (printf "modeldeployment: scaling.metrics[%d].downThreshold is required when enableScaling is true" $i) }}
+    {{- end }}
+    {{- if not (gt (subf $m.upThreshold $m.downThreshold) 0.0) }}
+    {{- fail (printf "modeldeployment: scaling.metrics[%d].upThreshold (%v) must be greater than downThreshold (%v) when enableScaling is true" $i $m.upThreshold $m.downThreshold) }}
+    {{- end }}
+    {{- $type := default "gauge" $m.type }}
+    scaledobject.kaito.sh/metricName/{{ $i }}: {{ $m.name | quote }}
+    scaledobject.kaito.sh/metricstype/{{ $i }}: {{ $type | quote }}
+    scaledobject.kaito.sh/upthreshold/{{ $i }}: {{ $m.upThreshold | quote }}
+    scaledobject.kaito.sh/downthreshold/{{ $i }}: {{ $m.downThreshold | quote }}
+    {{- if and (eq $type "histogram") $m.quantile }}
+    scaledobject.kaito.sh/quantile/{{ $i }}: {{ $m.quantile | quote }}
+    {{- end }}
+    {{- end }}
+    {{- with (.Values.scaling).evaluationWindow }}
+    scaledobject.kaito.sh/evaluationwindow: {{ . | quote }}
+    {{- end }}
+    {{- with (.Values.scaling).scaleUpCooldown }}
+    scaledobject.kaito.sh/scaleupcooldown: {{ . | quote }}
+    {{- end }}
+    {{- with (.Values.scaling).scaleDownCooldown }}
+    scaledobject.kaito.sh/scaledowncooldown: {{ . | quote }}
+    {{- end }}
   {{- end }}
 spec:
   replicas: {{ .Values.replicas }}

--- a/charts/modeldeployment/values.schema.json
+++ b/charts/modeldeployment/values.schema.json
@@ -40,7 +40,63 @@
     "scalingThreshold": {
       "type": "integer",
       "minimum": 1,
-      "description": "Queue-depth threshold used by the ScaledObject. Only used when enableScaling is true. MUST be positive."
+      "description": "Deprecated single-metric queue-depth threshold, superseded by scaling.metrics[*].upThreshold/downThreshold. Retained so pre-existing overrides still validate; no longer wired to any annotation."
+    },
+    "scaling": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "Composite (multi-metric) autoscaling configuration wired to scaledobject.kaito.sh/* annotations. Consumed only when enableScaling is true; keda-kaito-scaler combines every metric under a conservative AND policy. Misconfiguration here is surfaced as inferencesetScalingMisconfigured.",
+      "properties": {
+        "metrics": {
+          "type": "array",
+          "minItems": 1,
+          "description": "Ordered list of scaling signals. Each entry renders one indexed scaledobject.kaito.sh/<key>/<i> slot. MUST contain at least one entry when enableScaling is true (also enforced by a fail-fast template guard).",
+          "items": {
+            "type": "object",
+            "additionalProperties": true,
+            "required": ["name", "upThreshold", "downThreshold"],
+            "properties": {
+              "name": {
+                "type": "string",
+                "minLength": 1,
+                "description": "Prometheus metric family name exposed by each inference pod. Wired to scaledobject.kaito.sh/metricName/<i>."
+              },
+              "type": {
+                "type": "string",
+                "enum": ["gauge", "histogram"],
+                "description": "Aggregation applied to the metric: gauge -> per-replica average; histogram -> per-pod quantile. Wired to scaledobject.kaito.sh/metricstype/<i>. Defaults to gauge."
+              },
+              "upThreshold": {
+                "type": ["string", "number"],
+                "description": "Per-replica scale-up threshold (float). REQUIRED when enableScaling is true: empty by default, and a fail-fast template guard rejects the install when it is left unset. MUST be strictly greater than downThreshold (also enforced by the template guard). Wired to scaledobject.kaito.sh/upthreshold/<i>."
+              },
+              "downThreshold": {
+                "type": ["string", "number"],
+                "description": "Per-replica scale-down threshold (float). MUST be strictly less than upThreshold. REQUIRED when enableScaling is true: empty by default, and a fail-fast template guard rejects the install when it is left unset. Wired to scaledobject.kaito.sh/downthreshold/<i>."
+              },
+              "quantile": {
+                "type": ["string", "number"],
+                "description": "Target quantile in (0, 1] for histogram metrics; ignored for gauge. Empty inherits keda-kaito-scaler's 0.95 default. Wired to scaledobject.kaito.sh/quantile/<i>."
+              }
+            }
+          }
+        },
+        "evaluationWindow": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Scale-up stabilization window in seconds. Wired to scaledobject.kaito.sh/evaluationwindow."
+        },
+        "scaleUpCooldown": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Minimum seconds between scale-up steps. Wired to scaledobject.kaito.sh/scaleupcooldown."
+        },
+        "scaleDownCooldown": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Minimum seconds between scale-down steps. Wired to scaledobject.kaito.sh/scaledowncooldown."
+        }
+      }
     },
     "enableBenchmark": {
       "type": "boolean",

--- a/charts/modeldeployment/values.yaml
+++ b/charts/modeldeployment/values.yaml
@@ -29,18 +29,78 @@ replicas: 1
 
 # enableScaling toggles KAITO ScaledObject auto-provisioning. When false,
 # none of the scaledobject.kaito.sh/* annotations are rendered on the
-# InferenceSet, and `maxReplicas` / `scalingThreshold` are ignored.
+# InferenceSet, and the entire `scaling` block below is ignored.
 enableScaling: false
 
 # maxReplicas is the upper bound for autoscaling. Only used when
 # enableScaling is true. Wired to the scaledobject.kaito.sh/max-replicas
-# annotation.
+# annotation. `replicas` above doubles as the lower bound, wired to
+# scaledobject.kaito.sh/min-replicas.
 maxReplicas: 3
 
-# scalingThreshold is the queue depth threshold used by the ScaledObject.
-# Only used when enableScaling is true. Wired to the
-# scaledobject.kaito.sh/threshold annotation.
-scalingThreshold: 10
+# scaling holds the composite (multi-metric) autoscaling configuration
+# consumed by keda-kaito-scaler. It is read only when enableScaling is
+# true. Every entry in `metrics` becomes one indexed slot of
+# `scaledobject.kaito.sh/<key>/<i>` annotations; keda-kaito-scaler builds a
+# single KEDA ScaledObject whose scalingModifiers formula combines them
+# under a conservative AND policy — scale up by one replica only when EVERY
+# metric is above its upThreshold (and newly added pods are Ready), scale
+# down by one replica only when EVERY metric is below its downThreshold,
+# otherwise hold. Each step is capped at ±1 replica per cooldown to protect
+# expensive GPU capacity. A single metric is fully supported; it simply
+# yields a one-signal formula.
+scaling:
+  # metrics is the ordered list of scaling signals. MUST contain at least
+  # one entry when enableScaling is true.
+  metrics:
+      # name is the Prometheus metric family name exposed by each inference
+      # (model server) pod. Wired to scaledobject.kaito.sh/metricName/<i>.
+    - name: "vllm:num_requests_waiting"
+      # type is the aggregation applied to the metric; it MUST keep the
+      # signal replica-count independent:
+      #   gauge     -> per-replica average across pods
+      #   histogram -> per-pod quantile
+      # Wired to scaledobject.kaito.sh/metricstype/<i>. Defaults to gauge
+      # when empty.
+      type: "gauge"
+      # upThreshold is the per-replica scale-up threshold (float, quoted).
+      # REQUIRED when enableScaling is true — left empty by default so the
+      # caller MUST set it; an empty value rejects the Helm install. Wired
+      # to scaledobject.kaito.sh/upthreshold/<i>.
+      upThreshold: ""
+      # downThreshold is the per-replica scale-down threshold (float,
+      # quoted). MUST be strictly less than upThreshold. REQUIRED when
+      # enableScaling is true — left empty by default so the caller MUST
+      # set it; an empty value rejects the Helm install. Wired to
+      # scaledobject.kaito.sh/downthreshold/<i>.
+      downThreshold: ""
+      # quantile is the target quantile in (0, 1] for histogram metrics;
+      # ignored for gauge. Optional; empty lets keda-kaito-scaler apply its
+      # 0.95 default. Wired to scaledobject.kaito.sh/quantile/<i>.
+      quantile: ""
+      # p95 request queue time (histogram). Combined with the metric above
+      # under the AND policy: scale up only when both are above their
+      # upThresholds, scale down only when both are below their
+      # downThresholds. upThreshold / downThreshold are REQUIRED (empty by
+      # default) and reject the install when unset.
+    - name: "vllm:request_queue_time_seconds"
+      type: "histogram"
+      upThreshold: ""
+      downThreshold: ""
+      quantile: "0.95"
+
+  # evaluationWindow is the scale-up stabilization window in seconds.
+  # Optional; empty lets keda-kaito-scaler apply its 60s default. Wired to
+  # scaledobject.kaito.sh/evaluationwindow.
+  evaluationWindow: 60
+  # scaleUpCooldown is the minimum seconds between scale-up steps.
+  # Optional; empty lets keda-kaito-scaler apply its 300s default. Wired to
+  # scaledobject.kaito.sh/scaleupcooldown.
+  scaleUpCooldown: 300
+  # scaleDownCooldown is the minimum seconds between scale-down steps.
+  # Optional; empty lets keda-kaito-scaler apply its 300s default. Wired to
+  # scaledobject.kaito.sh/scaledowncooldown.
+  scaleDownCooldown: 300
 
 # enableBenchmark toggles KAITO benchmark runs for this InferenceSet. When
 # false, the `kaito.sh/disable-benchmark: "true"` annotation is stamped on

--- a/charts/modelharness/Chart.yaml
+++ b/charts/modelharness/Chart.yaml
@@ -15,5 +15,5 @@ description: |
   Service itself is installed once per cluster by the E2E install
   script.
 type: application
-version: 0.2.2
-appVersion: "0.2.2"
+version: 0.3.0
+appVersion: "0.3.0"

--- a/charts/productionstack/Chart.lock
+++ b/charts/productionstack/Chart.lock
@@ -4,12 +4,12 @@ dependencies:
   version: 0.1.0
 - name: keda-kaito-scaler
   repository: ""
-  version: 0.5.1
+  version: 0.6.0
 - name: gpu-node-mocker
   repository: file://../gpu-node-mocker
-  version: 0.2.2
+  version: 0.3.0
 - name: llm-gateway-apikey
   repository: oci://mcr.microsoft.com/aks/kaito/helm
   version: 0.0.12-alpha
-digest: sha256:b80857f131f8c7eead15f17bc47f11fe384946df252a69a87b3ac1e9740d1a3d
-generated: "2026-06-30T11:04:20.554428384+10:00"
+digest: sha256:0176723e6429ea55af81d3ff88a06b85cf3b1d4c5dd61e4ac9ca6e866f08fabb
+generated: "2026-07-14T19:55:48.137968+10:00"

--- a/charts/productionstack/Chart.yaml
+++ b/charts/productionstack/Chart.yaml
@@ -21,8 +21,8 @@ description: |
   under `charts/` and appending a new entry to the `dependencies` list
   below.
 type: application
-version: 0.2.2
-appVersion: "0.2.2"
+version: 0.3.0
+appVersion: "0.3.0"
 keywords:
   - kaito
   - production-stack
@@ -43,7 +43,7 @@ dependencies:
       - gateway
       - routing
   - name: keda-kaito-scaler
-    version: 0.5.1
+    version: 0.6.0
     tags:
       - autoscaling
   # In-tree gpu-node-mocker chart. Sourced via a `file://` repository
@@ -55,7 +55,7 @@ dependencies:
   # an `image.repository` and is only relevant for E2E / dev clusters
   # that don't have a real GPU node provisioner.
   - name: gpu-node-mocker
-    version: 0.2.2
+    version: 0.3.0
     repository: file://../gpu-node-mocker
     condition: gpu-node-mocker.enabled
     tags:

--- a/charts/productionstack/charts/keda-kaito-scaler/Chart.yaml
+++ b/charts/productionstack/charts/keda-kaito-scaler/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.5.1
+version: 0.6.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "v0.5.1"
+appVersion: "v0.6.0"

--- a/charts/productionstack/charts/keda-kaito-scaler/README.md
+++ b/charts/productionstack/charts/keda-kaito-scaler/README.md
@@ -126,7 +126,7 @@ Set `namespaceOverride: ""` to fall back to the standard Helm
 | `log.level`                | `3`                                      | klog verbosity (`--v`). Bump to `5` for debug logging.                                                        |
 | `image.registry`           | `ghcr.io`                                | Container image registry.                                                                                    |
 | `image.repository`         | `kaito-project/keda-kaito-scaler`        | Container image repository.                                                                                  |
-| `image.tag`                | `0.5.1`                                  | Container image tag.                                                                                         |
+| `image.tag`                | `0.6.0`                                  | Container image tag.                                                                                         |
 | `image.pullSecrets`        | `[]`                                     | `imagePullSecrets` for the pod spec.                                                                         |
 | `ports.grpc`               | `10450`                                  | gRPC `ExternalScaler` port exposed via the Service.                                                          |
 | `ports.metrics`            | `10451`                                  | Prometheus metrics port (`--metrics-port`). Not currently fronted by a Service.                              |

--- a/charts/productionstack/charts/keda-kaito-scaler/values.yaml
+++ b/charts/productionstack/charts/keda-kaito-scaler/values.yaml
@@ -21,7 +21,7 @@ namespaceOverride: ""
 image:
     registry: ghcr.io
     repository: kaito-project/keda-kaito-scaler
-    tag: 0.5.1
+    tag: 0.6.0
     pullSecrets: []
 
 ports:

--- a/test/e2e/cases.go
+++ b/test/e2e/cases.go
@@ -326,14 +326,28 @@ var CaseDeployments = map[string][]utils.ModelDeploymentValues{
 			// the queue drains and clamps to minReplicaCount=1, so the
 			// pool would never return to its starting size and Scale-Down
 			// assertions would fail.
-			Name:             "scaling-phi",
-			Namespace:        "e2e-scaling",
-			Model:            presetPhi,
-			Replicas:         1,
-			InstanceType:     "Standard_NV36ads_A10_v5",
-			EnableScaling:    true,
-			MaxReplicas:      2,
-			ScalingThreshold: 10, // low threshold to trigger scaling during tests
+			Name:          "scaling-phi",
+			Namespace:     "e2e-scaling",
+			Model:         presetPhi,
+			Replicas:      1,
+			InstanceType:  "Standard_NV36ads_A10_v5",
+			EnableScaling: true,
+			MaxReplicas:   2,
+			// Single gauge signal on the vLLM waiting-queue length. The
+			// up-threshold is deliberately low so the pressure workload
+			// (scalingPressureConcurrency) pushes the per-replica queue
+			// above it and scale-up fires; the down-threshold sits below
+			// it so the sub-threshold workload (scalingSubThresholdConcurrency)
+			// drains the queue under it and scale-down converges back to
+			// the baseline. UpThreshold MUST be > DownThreshold (chart guard).
+			ScalingMetrics: []utils.ScalingMetric{
+				{
+					Name:          "vllm:num_requests_waiting",
+					Type:          "gauge",
+					UpThreshold:   "10",
+					DownThreshold: "5",
+				},
+			},
 		},
 	},
 	CaseKarpenterSmall: {

--- a/test/e2e/scaling_test.go
+++ b/test/e2e/scaling_test.go
@@ -44,15 +44,16 @@ import (
 
 const (
 	// Concurrency for queue-pressure workloads. The CaseScaling baseline
-	// is 1 replica with KEDA threshold=10 and the inference simulator's
-	// max-num-seqs=5, so the single pod has 5 running slots and any
-	// extra in-flight requests pile into the queue. Setting concurrency
-	// to 40 leaves ~35 requests waiting on that pod — well above the
-	// threshold — guaranteeing scale-up fires.
+	// is 1 replica with the gauge up-threshold=10 and the inference
+	// simulator's max-num-seqs=5, so the single pod has 5 running slots
+	// and any extra in-flight requests pile into the queue. Setting
+	// concurrency to 40 leaves ~35 requests waiting on that pod — well
+	// above the up-threshold — guaranteeing scale-up fires.
 	scalingPressureConcurrency = 40
 
 	// Concurrency for below-threshold workload. Chosen so the queue settles
-	// strictly below threshold=10 even with the scheduler's load spread.
+	// strictly below the gauge down-threshold=5 even with the scheduler's
+	// load spread, so scale-down converges back to the baseline.
 	scalingSubThresholdConcurrency = 4
 
 	// Rate of the background low-rate stream used for "no 5xx during scale-down".

--- a/test/e2e/utils/helm.go
+++ b/test/e2e/utils/helm.go
@@ -50,15 +50,42 @@ type ModelDeploymentValues struct {
 	// MaxReplicas is the upper bound for autoscaling. Only used when
 	// EnableScaling is true.
 	MaxReplicas int64
-	// ScalingThreshold is the queue depth threshold. Only used when
-	// EnableScaling is true.
-	ScalingThreshold int64
+	// ScalingMetrics is the ordered list of composite scaling signals wired
+	// onto the modeldeployment chart's scaling.metrics[<i>] entries. Only
+	// used when EnableScaling is true; at least one entry is required in
+	// that case (the chart rejects an empty metrics list). Each entry's
+	// UpThreshold MUST be strictly greater than its DownThreshold.
+	ScalingMetrics []ScalingMetric
 	// AuthAPIKeyEnabled signals that this deployment runs behind the
 	// apikey-ext-authz CUSTOM provider. The per-namespace
 	// AuthorizationPolicy and APIKey CR are provisioned by
 	// EnsureNamespace; the warmup loop in SetupInferenceSetsWithRouting
 	// reads the resulting Secret and sends Bearer + Host headers.
 	AuthAPIKeyEnabled bool
+}
+
+// ScalingMetric describes one composite scaling signal, mirroring a single
+// entry of the modeldeployment chart's scaling.metrics list. Each field maps
+// 1:1 to a scaledobject.kaito.sh/<key>/<i> annotation the chart renders.
+type ScalingMetric struct {
+	// Name is the Prometheus metric family name
+	// (scaledobject.kaito.sh/metricName/<i>). Required.
+	Name string
+	// Type is the aggregation applied to the metric: "gauge" (per-replica
+	// average) or "histogram" (per-pod quantile)
+	// (scaledobject.kaito.sh/metricstype/<i>). Empty defaults to gauge.
+	Type string
+	// UpThreshold is the per-replica scale-up threshold
+	// (scaledobject.kaito.sh/upthreshold/<i>). Required; MUST be strictly
+	// greater than DownThreshold.
+	UpThreshold string
+	// DownThreshold is the per-replica scale-down threshold
+	// (scaledobject.kaito.sh/downthreshold/<i>). Required; MUST be strictly
+	// less than UpThreshold.
+	DownThreshold string
+	// Quantile is the target quantile in (0, 1] for histogram metrics
+	// (scaledobject.kaito.sh/quantile/<i>). Optional; ignored for gauge.
+	Quantile string
 }
 
 // DefaultModelDeploymentValues returns a populated ModelDeploymentValues for a
@@ -98,8 +125,19 @@ func (v ModelDeploymentValues) helmSetArgs() []string {
 		if v.MaxReplicas > 0 {
 			args = append(args, "--set", "maxReplicas="+strconv.FormatInt(v.MaxReplicas, 10))
 		}
-		if v.ScalingThreshold > 0 {
-			args = append(args, "--set", "scalingThreshold="+strconv.FormatInt(v.ScalingThreshold, 10))
+		for i, m := range v.ScalingMetrics {
+			prefix := fmt.Sprintf("scaling.metrics[%d].", i)
+			args = append(args, "--set", prefix+"name="+m.Name)
+			if m.Type != "" {
+				args = append(args, "--set", prefix+"type="+m.Type)
+			}
+			args = append(args,
+				"--set", prefix+"upThreshold="+m.UpThreshold,
+				"--set", prefix+"downThreshold="+m.DownThreshold,
+			)
+			if m.Quantile != "" {
+				args = append(args, "--set", prefix+"quantile="+m.Quantile)
+			}
 		}
 	}
 	return args

--- a/test/e2e/utils/scaling.go
+++ b/test/e2e/utils/scaling.go
@@ -113,10 +113,12 @@ func GetKEDAParams(ctx context.Context, model, namespace string) (KEDAParams, er
 		}
 	}
 	if p.Threshold == 0 {
-		// Fallback to the annotation on the InferenceSet.
+		// Fallback to the annotation on the InferenceSet. With the
+		// composite (multi-metric) format the per-replica scale-up
+		// threshold for the first metric lives under upthreshold/0.
 		is, err := dynClient.Resource(InferenceSetGVR).Namespace(namespace).Get(ctx, model, metav1.GetOptions{})
 		if err == nil {
-			if v, ok := is.GetAnnotations()["scaledobject.kaito.sh/threshold"]; ok {
+			if v, ok := is.GetAnnotations()["scaledobject.kaito.sh/upthreshold/0"]; ok {
 				if n, err := strconv.Atoi(v); err == nil {
 					p.Threshold = n
 				}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

- Bump keda-kaito-scaler to v0.6.0 and modeldeployment/modelharness/ gpu-node-mocker/productionstack charts to 0.3.0 (Chart.lock regenerated).
- Replace the single scalingThreshold with a composite scaling.metrics list (name/type/upThreshold/downThreshold/quantile) plus evaluationWindow and scale up/down cooldowns, wired to keda-kaito-scaler v0.6.0's indexed scaledobject.kaito.sh/<key>/<i> annotations under the AND policy.
- Enforce via fail-fast template guards: at least one metric, non-empty up/down thresholds, and upThreshold > downThreshold when scaling is on.
- Update values.schema.json and README accordingly.
- Rework the e2e harness: ModelDeploymentValues gains a ScalingMetrics slice + ScalingMetric type; CaseScaling uses up=10/down=5; scaling helper reads the upthreshold/0 annotation fallback.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
