### PR TITLE
feat(charts): add performanceMode value to modeldeployment

### DIFF
--- a/charts/modeldeployment/templates/inferenceset.yaml
+++ b/charts/modeldeployment/templates/inferenceset.yaml
@@ -69,9 +69,14 @@ spec:
         cross-namespace ingress to them would silently succeed.
         */}}
         {{- include "modeldeployment.ownerLabel" . | nindent 8 }}
-      {{- if not .Values.enableBenchmark }}
+      {{- if or (not .Values.enableBenchmark) .Values.performanceMode }}
       annotations:
+        {{- if not .Values.enableBenchmark }}
         kaito.sh/disable-benchmark: "true"
+        {{- end }}
+        {{- with .Values.performanceMode }}
+        kaito.sh/performance-mode: {{ . | quote }}
+        {{- end }}
       {{- end }}
     resource:
       instanceType: {{ .Values.instanceType | quote }}

--- a/charts/modeldeployment/values.schema.json
+++ b/charts/modeldeployment/values.schema.json
@@ -102,6 +102,11 @@
       "type": "boolean",
       "description": "Toggles KAITO benchmark runs for this InferenceSet. When false, the kaito.sh/disable-benchmark annotation is stamped on the InferenceSet."
     },
+    "performanceMode": {
+      "type": "string",
+      "enum": ["", "balanced", "interactivity", "throughput"],
+      "description": "When non-empty, stamps kaito.sh/performance-mode: <value> on the InferenceSet template so the KAITO controller applies the corresponding vLLM profile. Empty (default) omits the annotation and the controller falls back to its own default (balanced). Allowed values: interactivity (low per-request latency), balanced (trade-off), throughput (maximize aggregate tokens/sec)."
+    },
     "gatewayName": {
       "type": "string",
       "description": "Gateway the HTTPRoute attaches to. Empty derives '<namespace>-gw'."

--- a/charts/modeldeployment/values.yaml
+++ b/charts/modeldeployment/values.yaml
@@ -107,6 +107,18 @@ scaling:
 # the InferenceSet so the KAITO controller skips benchmark provisioning.
 enableBenchmark: true
 
+# performanceMode, when set, stamps the `kaito.sh/performance-mode: <value>`
+# annotation on the InferenceSet template so the KAITO controller applies
+# the corresponding performance profile. Empty (the default) omits the
+# annotation and the controller falls back to its own default ("balanced").
+# Valid values are "balanced" (default), "interactivity", and "throughput":
+#   - "interactivity": optimizes for low per-request latency (fine-grained
+#     CUDA graphs, latency-oriented kernels, smaller batch sizes).
+#   - "balanced": sensible trade-off between latency and throughput.
+#   - "throughput": maximizes aggregate tokens/sec (larger CUDA graphs, more
+#     aggressive batching, throughput-oriented kernels).
+performanceMode: ""
+
 # gatewayName is the Gateway resource the HTTPRoute attaches to. When
 # empty (the default), the chart derives it as "<namespace>-gw" so the
 # rendered HTTPRoute parents the per-namespace Gateway provisioned by


### PR DESCRIPTION

**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

Stamps kaito.sh/performance-mode annotation on the InferenceSet template when set, letting callers pick between balanced/interactivity/throughput profiles. Empty (default) omits the annotation.


**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
