### PR TITLE
docs(scaling): use keda-kaito-scaler v0.6.1 composite metrics; label shadow pods with mirrored InferenceSet

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,15 @@ helm install qwen oci://ghcr.io/kaito-project/helm/modeldeployment \
   --set replicas=2 \
   --set maxReplicas=5 \
   --set enableScaling=true \
-  --set scalingThreshold=10
+  --set scaling.metrics[0].name=vllm:num_requests_waiting \
+  --set scaling.metrics[0].type=gauge \
+  --set scaling.metrics[0].upThreshold=10 \
+  --set scaling.metrics[0].downThreshold=3 \
+  --set scaling.metrics[1].name=vllm:request_queue_time_seconds \
+  --set scaling.metrics[1].type=histogram \
+  --set scaling.metrics[1].upThreshold=2 \
+  --set scaling.metrics[1].downThreshold=0.5 \
+  --set scaling.metrics[1].quantile=0.95
 ```
 
 For the full value schema (EPP image / ports / resources, scaling knobs, naming conventions, KAITO `FeatureFlagGatewayAPIInferenceExtension` compatibility note), see [`charts/modeldeployment/README.md`](charts/modeldeployment/README.md).

--- a/examples/multi-modelharness-deployment.md
+++ b/examples/multi-modelharness-deployment.md
@@ -124,7 +124,7 @@ flowchart TB
   class authz,bbr,kaito,keda,mocker svc;
 ```
 
-| Namespace | ModelHarness | ModelDeployment | Preset | Replicas (min) | Autoscaling (max / threshold) |
+| Namespace | ModelHarness | ModelDeployment | Preset | Replicas (min) | Autoscaling (max / up-threshold) |
 | --- | --- | --- | --- | --- | --- |
 | `demo-team-a` | auth **on** | `chat-phi` | `phi-4-mini-instruct` | **2** | 4 / 5 |
 | `demo-team-a` |  | `code-ministral` | `ministral-3-3b-instruct` | 1 | 3 / 5 |
@@ -135,8 +135,13 @@ This satisfies the demo's goals: **2 `modelharness`**, **2 `modeldeployment`
 each**, and **multiple deployments with `replicas > 1`**. Every deployment also
 has **KAITO autoscaling enabled** (`enableScaling=true`): the `keda-kaito-scaler`
 provisions a `ScaledObject` that scales each `InferenceSet` between its
-`replicas` baseline and `maxReplicas` once the per-replica request-queue depth
-crosses `scalingThreshold`.
+`replicas` baseline and `maxReplicas`. Scaling is driven by the chart's composite
+`scaling.metrics` list — the two chart defaults, per-replica queue depth
+(`vllm:num_requests_waiting`, gauge) and p95 request-queue time
+(`vllm:request_queue_time_seconds`, histogram) — that `keda-kaito-scaler` v0.6.1
+combines under a conservative **AND** policy: it scales up by one replica only
+when *both* signals exceed their `upThreshold`, and scales down only when *both*
+fall below their `downThreshold`.
 
 ---
 
@@ -260,7 +265,16 @@ helm upgrade --install chat-phi charts/modeldeployment \
   --set replicas=2 \
   --set enableScaling=true \
   --set maxReplicas=4 \
-  --set scalingThreshold=5 \
+  --set enableBenchmark=false \
+  --set scaling.metrics[0].name=vllm:num_requests_waiting \
+  --set scaling.metrics[0].type=gauge \
+  --set scaling.metrics[0].upThreshold=5 \
+  --set scaling.metrics[0].downThreshold=2 \
+  --set scaling.metrics[1].name=vllm:request_queue_time_seconds \
+  --set scaling.metrics[1].type=histogram \
+  --set scaling.metrics[1].upThreshold=2 \
+  --set scaling.metrics[1].downThreshold=0.5 \
+  --set scaling.metrics[1].quantile=0.95 \
   --set instanceType=Standard_NV36ads_A10_v5 \
   --wait --timeout=10m
 
@@ -273,7 +287,16 @@ helm upgrade --install code-ministral charts/modeldeployment \
   --set replicas=1 \
   --set enableScaling=true \
   --set maxReplicas=3 \
-  --set scalingThreshold=5 \
+  --set enableBenchmark=false \
+  --set scaling.metrics[0].name=vllm:num_requests_waiting \
+  --set scaling.metrics[0].type=gauge \
+  --set scaling.metrics[0].upThreshold=5 \
+  --set scaling.metrics[0].downThreshold=2 \
+  --set scaling.metrics[1].name=vllm:request_queue_time_seconds \
+  --set scaling.metrics[1].type=histogram \
+  --set scaling.metrics[1].upThreshold=2 \
+  --set scaling.metrics[1].downThreshold=0.5 \
+  --set scaling.metrics[1].quantile=0.95 \
   --set instanceType=Standard_NV36ads_A10_v5 \
   --wait --timeout=10m
 ```
@@ -300,7 +323,16 @@ helm upgrade --install assistant-phi charts/modeldeployment \
   --set replicas=2 \
   --set enableScaling=true \
   --set maxReplicas=4 \
-  --set scalingThreshold=5 \
+  --set enableBenchmark=false \
+  --set scaling.metrics[0].name=vllm:num_requests_waiting \
+  --set scaling.metrics[0].type=gauge \
+  --set scaling.metrics[0].upThreshold=5 \
+  --set scaling.metrics[0].downThreshold=2 \
+  --set scaling.metrics[1].name=vllm:request_queue_time_seconds \
+  --set scaling.metrics[1].type=histogram \
+  --set scaling.metrics[1].upThreshold=2 \
+  --set scaling.metrics[1].downThreshold=0.5 \
+  --set scaling.metrics[1].quantile=0.95 \
   --set instanceType=Standard_NV36ads_A10_v5 \
   --wait --timeout=10m
 
@@ -313,7 +345,16 @@ helm upgrade --install summarizer-ministral charts/modeldeployment \
   --set replicas=1 \
   --set enableScaling=true \
   --set maxReplicas=3 \
-  --set scalingThreshold=5 \
+  --set enableBenchmark=false \
+  --set scaling.metrics[0].name=vllm:num_requests_waiting \
+  --set scaling.metrics[0].type=gauge \
+  --set scaling.metrics[0].upThreshold=5 \
+  --set scaling.metrics[0].downThreshold=2 \
+  --set scaling.metrics[1].name=vllm:request_queue_time_seconds \
+  --set scaling.metrics[1].type=histogram \
+  --set scaling.metrics[1].upThreshold=2 \
+  --set scaling.metrics[1].downThreshold=0.5 \
+  --set scaling.metrics[1].quantile=0.95 \
   --set instanceType=Standard_NV36ads_A10_v5 \
   --wait --timeout=10m
 ```

--- a/pkg/gpu-node-mocker/controllers/config.go
+++ b/pkg/gpu-node-mocker/controllers/config.go
@@ -79,6 +79,12 @@ const (
 	// ShadowPodLabelKey marks shadow pods so we can watch only those.
 	ShadowPodLabelKey = "kaito.sh/shadow-pod-for"
 
+	// ShadowPodInferenceSetLabelKey records the InferenceSet (modeldeployment)
+	// that the shadow pod mirrors. Intentionally distinct from the upstream
+	// `inferenceset.kaito.sh/created-by` label to avoid the InferencePool
+	// selector accidentally treating shadow pods as real inference endpoints.
+	ShadowPodInferenceSetLabelKey = "kaito.sh/shadow-pod-inferenceset"
+
 	// InferenceSetCreatedByLabelKey is the upstream KAITO label that the
 	// InferenceSet controller stamps on its child pods. The Phase-2 pod
 	// predicate reads it to recognize InferenceSet (modeldeployment) pods.

--- a/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
+++ b/pkg/gpu-node-mocker/controllers/shadow_pod_controller.go
@@ -257,6 +257,10 @@ func (r *ShadowPodReconciler) ensureShadowPod(ctx context.Context, original *cor
 		OwnedByLabelKey: OwnedByLabelValue,
 	}
 
+	if v, ok := original.Labels[InferenceSetCreatedByLabelKey]; ok && v != "" {
+		labels[ShadowPodInferenceSetLabelKey] = v
+	}
+
 	udsTokenizerImage := r.Config.UDSTokenizerImage
 	if udsTokenizerImage == "" {
 		udsTokenizerImage = DefaultUDSTokenizerImage


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

- README.md + examples/multi-modelharness-deployment.md: replace the deprecated scalingThreshold flag with the composite scaling.metrics[*] config (queue-depth gauge + p95 queue-time histogram under the AND policy); add --set enableBenchmark=false to the example install commands
- gpu-node-mocker: add ShadowPodInferenceSetLabelKey (kaito.sh/shadow-pod-inferenceset) and stamp it on shadow pods from the original pod's inferenceset.kaito.sh/created-by, kept distinct from the InferencePool selector label

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
