### PR TITLE
Bump llm-gateway-apikey subchart to 0.0.13-alpha

### DIFF
--- a/charts/productionstack/Chart.lock
+++ b/charts/productionstack/Chart.lock
@@ -10,6 +10,6 @@ dependencies:
   version: 0.3.1
 - name: llm-gateway-apikey
   repository: oci://mcr.microsoft.com/aks/kaito/helm
-  version: 0.0.12-alpha
-digest: sha256:842699ad26a587820e23d4494ac73bd62383a397233e11d6a11e7ca05f40a131
-generated: "2026-07-17T00:15:30.494079+10:00"
+  version: 0.0.13-alpha
+digest: sha256:a5b170f8df8a7f426cc2beb3c4ced1c04b627fc9be53a6eecbf5824c800263ca
+generated: "2026-07-17T12:13:58.84452+10:00"

--- a/charts/productionstack/Chart.yaml
+++ b/charts/productionstack/Chart.yaml
@@ -74,7 +74,7 @@ dependencies:
   # is part of the umbrella `productionstack` release manifest, so
   # `helm uninstall productionstack` cleans it up automatically.
   - name: llm-gateway-apikey
-    version: 0.0.12-alpha
+    version: 0.0.13-alpha
     repository: oci://mcr.microsoft.com/aks/kaito/helm
     condition: llm-gateway-apikey.enabled
     tags:


### PR DESCRIPTION
**Reason for Change**:
Bump llm-gateway-apikey chart to workaround issue with Istio CRDs not found. 

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
