### PR TITLE
feat: enable autoupgrade configuration in modeldeployment chart

### DIFF
--- a/charts/modeldeployment/README.md
+++ b/charts/modeldeployment/README.md
@@ -48,6 +48,9 @@ over plaintext gRPC and **no `DestinationRule` is required**.
 | `scaling.evaluationWindow`| optional | `60`                                                                | Scale-up stabilization window (seconds). Wired to `scaledobject.kaito.sh/evaluationwindow`. |
 | `scaling.scaleUpCooldown` | optional | `300`                                                               | Minimum seconds between scale-up steps. Wired to `scaledobject.kaito.sh/scaleupcooldown`.  |
 | `scaling.scaleDownCooldown` | optional | `300`                                                             | Minimum seconds between scale-down steps. Wired to `scaledobject.kaito.sh/scaledowncooldown`. |
+| `autoUpgrade.enabled`     | optional | `false`                                                             | Opts this InferenceSet into KAITO automatic base image upgrades. Renders `spec.autoUpgrade.enabled: true`. Also requires the `enableBaseImageAutoUpgrade` feature gate on the KAITO controller. |
+| `autoUpgrade.maintenanceWindow.schedule` | optional | _empty_                                             | 5-field cron (UTC) marking when rollouts may begin, e.g. `"0 2 * * 6"`. Empty lets upgrades start at any time (the `maintenanceWindow` block is omitted). Consumed only when `autoUpgrade.enabled=true`. |
+| `autoUpgrade.maintenanceWindow.duration` | optional | _empty_ → `4h`                                      | How long the window stays open once it opens, e.g. `"4h"`. Empty inherits the KAITO controller's `4h` default. Ignored when `schedule` is empty. |
 | `gatewayName`             | optional | _empty_ → `<namespace>-gw`                                          | Gateway the HTTPRoute attaches to. Defaults to the per-namespace Gateway provisioned by `charts/modelharness`. |
 | `epp.image.repository`    | optional | `mcr.microsoft.com/oss/v2/llm-d/llm-d-inference-scheduler`           | EPP container image.                                                                       |
 | `epp.image.tag`           | optional | `v0.7.1`                                                             | EPP image tag.                                                                             |
@@ -87,6 +90,36 @@ helm install qwen ./charts/modeldeployment \
 The rendered `HTTPRoute` parents into the `my-models-gw` `Gateway`
 because `gatewayName` is left empty. Override `--set gatewayName=...`
 only when attaching to a Gateway with a business-specific name.
+
+## Automatic base image upgrades
+
+KAITO embeds the version of its base serving image in its controller.
+When the controller is upgraded to a release bundling a newer base image, 
+existing `InferenceSet` replicas keep running the old image until
+they are recreated. Setting `autoUpgrade.enabled=true` renders
+`spec.autoUpgrade.enabled: true` on the InferenceSet so the KAITO
+controller detects the version drift and rolls the replicas onto the new
+image one at a time — waiting for each replica to become Ready before
+moving to the next — without recreating the InferenceSet. See the
+[KAITO docs](https://kaito-project.github.io/kaito/docs/inference#automatic-base-image-upgrades).
+
+Optionally restrict when rollouts may begin with a maintenance window
+(`schedule` is a 5-field cron in UTC; `duration` defaults to `4h`):
+
+```sh
+helm install qwen ./charts/modeldeployment \
+  --namespace my-models \
+  --set name=qwen \
+  --set model=qwen2-5-coder-7b-instruct \
+  --set autoUpgrade.enabled=true \
+  --set autoUpgrade.maintenanceWindow.schedule="0 2 * * 6" \
+  --set autoUpgrade.maintenanceWindow.duration="4h"
+```
+
+> **Note:** auto-upgrade ALSO requires the `enableBaseImageAutoUpgrade`
+> feature gate to be enabled on the KAITO controller (off by default).
+> This chart value only opts the individual InferenceSet in; without the
+> feature gate the controller ignores `spec.autoUpgrade`.
 
 ## Compatibility note
 

--- a/charts/modeldeployment/templates/inferenceset.yaml
+++ b/charts/modeldeployment/templates/inferenceset.yaml
@@ -86,3 +86,16 @@ spec:
     inference:
       preset:
         name: {{ .Values.model | quote }}
+  {{- if (.Values.autoUpgrade).enabled }}
+  autoUpgrade:
+    enabled: true
+    {{- with (.Values.autoUpgrade).maintenanceWindow }}
+    {{- if .schedule }}
+    maintenanceWindow:
+      schedule: {{ .schedule | quote }}
+      {{- with .duration }}
+      duration: {{ . | quote }}
+      {{- end }}
+    {{- end }}
+    {{- end }}
+  {{- end }}

--- a/charts/modeldeployment/values.schema.json
+++ b/charts/modeldeployment/values.schema.json
@@ -111,6 +111,32 @@
       "type": "string",
       "description": "Gateway the HTTPRoute attaches to. Empty derives '<namespace>-gw'."
     },
+    "autoUpgrade": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "KAITO automatic base image upgrade configuration, rendered as spec.autoUpgrade. When enabled, the controller rolls replicas onto a newer embedded base image one at a time after a controller upgrade. Requires the enableBaseImageAutoUpgrade feature gate on the KAITO controller (off by default); this value only opts the InferenceSet in.",
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Toggles spec.autoUpgrade.enabled. When false (default), the spec.autoUpgrade block is omitted and replicas stay pinned to their creation-time base image."
+        },
+        "maintenanceWindow": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Optionally restricts when rollouts may begin. Consumed only when enabled is true. Omitted entirely when schedule is empty.",
+          "properties": {
+            "schedule": {
+              "type": "string",
+              "description": "5-field cron expression (UTC) marking the start of each maintenance window, e.g. '0 2 * * 6'. Empty (default) lets upgrades start at any time."
+            },
+            "duration": {
+              "type": "string",
+              "description": "How long the window stays open once it opens, e.g. '4h'. Empty inherits the KAITO controller's 4h default. Ignored when schedule is empty."
+            }
+          }
+        }
+      }
+    },
     "epp": {
       "type": "object",
       "additionalProperties": true,

--- a/charts/modeldeployment/values.yaml
+++ b/charts/modeldeployment/values.yaml
@@ -122,6 +122,41 @@ enableBenchmark: true
 #     aggressive batching, throughput-oriented kernels).
 performanceMode: ""
 
+# autoUpgrade configures KAITO's automatic base image upgrades for this
+# InferenceSet, rendered as spec.autoUpgrade. KAITO ships the vLLM base
+# image embedded in the controller; when the controller is upgraded to a
+# release bundling a newer base image, existing replicas keep running the
+# old image until recreated. With auto-upgrade enabled, the controller
+# detects the version drift and rolls replicas onto the new image one at a
+# time — waiting for each replica to become Ready before moving to the
+# next — keeping the service available throughout the rollout.
+#
+# NOTE: auto-upgrade ALSO requires the `enableBaseImageAutoUpgrade` feature
+# gate to be enabled on the KAITO controller (off by default). This chart
+# value only opts the individual InferenceSet in; without the feature gate
+# the controller ignores spec.autoUpgrade.
+autoUpgrade:
+  # enabled toggles spec.autoUpgrade.enabled. When false (the default),
+  # the entire spec.autoUpgrade block is omitted and replicas stay pinned
+  # to the base image they were created with until manually recreated.
+  enabled: false
+  # maintenanceWindow optionally restricts when rollouts may begin. When
+  # `schedule` is empty (the default), upgrades may start at any time.
+  # When set, the controller only starts upgrading replicas while the
+  # current time is inside the window; an upgrade already in progress is
+  # allowed to finish even if the window closes, and the next replica
+  # waits for the following window. Consumed only when enabled is true.
+  maintenanceWindow:
+    # schedule is a 5-field cron expression (UTC) marking the start of
+    # each maintenance window, e.g. "0 2 * * 6" (every Saturday at 02:00
+    # UTC). Empty (the default) lets upgrades start at any time; the
+    # maintenanceWindow block is omitted entirely.
+    schedule: ""
+    # duration is how long the window stays open once it opens, e.g.
+    # "4h". Empty lets the KAITO controller apply its 4h default. Ignored
+    # when `schedule` is empty.
+    duration: ""
+
 # gatewayName is the Gateway resource the HTTPRoute attaches to. When
 # empty (the default), the chart derives it as "<namespace>-gw" so the
 # rendered HTTPRoute parents the per-namespace Gateway provisioned by

--- a/hack/e2e/scripts/install-components.sh
+++ b/hack/e2e/scripts/install-components.sh
@@ -161,6 +161,7 @@ install_kaito() {
     --create-namespace \
     --set featureGates.enableInferenceSetController=true \
     --set featureGates.gatewayAPIInferenceExtension=false \
+    --set featureGates.enableBaseImageAutoUpgrade=true \
     --set nodeProvisioner="${NODE_PROVISIONER}" \
     "${KAITO_NODE_CLASS_ARGS[@]+"${KAITO_NODE_CLASS_ARGS[@]}"}" \
     --set image.repository=ghcr.io/kaito-project/kaito/workspace \

--- a/test/e2e/filter_order_test.go
+++ b/test/e2e/filter_order_test.go
@@ -469,14 +469,42 @@ var _ = Describe("Filter execution order",
 				clientset, err := utils.GetK8sClientset()
 				Expect(err).NotTo(HaveOccurred())
 
-				bbrNS := "kaito-system"
-				bbrPod, err := firstRunningPod(ctx, bbrNS,
-					"app.kubernetes.io/name=body-based-routing")
-				Expect(err).NotTo(HaveOccurred())
+				const bbrNS = "kaito-system"
+				const bbrSelector = "app.kubernetes.io/name=body-based-routing"
 
-				before, err := utils.GetPodLogs(clientset, bbrNS, bbrPod, "bbr")
+				// BBR runs as an HA Deployment (>= 2 replicas) and the gateway
+				// load-balances the ext_proc call across every replica, so a
+				// single request may be handled by ANY replica. Snapshotting
+				// one pod's log (firstRunningPod) is therefore racy: the
+				// request can land on a different replica, leaving the observed
+				// pod's log unchanged (the flake this replaces, where
+				// before == after exactly). Aggregate the log length across all
+				// running BBR replicas so we observe growth regardless of which
+				// replica served the request.
+				totalBBRLogLen := func() (int, error) {
+					pods, err := clientset.CoreV1().Pods(bbrNS).List(ctx, metav1.ListOptions{
+						LabelSelector: bbrSelector,
+						FieldSelector: "status.phase=Running",
+					})
+					if err != nil {
+						return 0, err
+					}
+					if len(pods.Items) == 0 {
+						return 0, fmt.Errorf("no Running BBR pods match %q", bbrSelector)
+					}
+					total := 0
+					for i := range pods.Items {
+						logs, err := utils.GetPodLogs(clientset, bbrNS, pods.Items[i].Name, "bbr")
+						if err != nil {
+							return 0, err
+						}
+						total += len(logs)
+					}
+					return total, nil
+				}
+
+				beforeLen, err := totalBBRLogLen()
 				Expect(err).NotTo(HaveOccurred())
-				beforeLen := len(before)
 
 				resp, err := sendAuth("d3-unknown-model", apiKey)
 				Expect(err).NotTo(HaveOccurred())
@@ -484,12 +512,12 @@ var _ = Describe("Filter execution order",
 				Expect(resp.StatusCode).To(Equal(http.StatusNotFound),
 					"unknown model with valid auth should hit catch-all 404")
 
-				time.Sleep(3 * time.Second)
-
-				after, err := utils.GetPodLogs(clientset, bbrNS, bbrPod, "bbr")
-				Expect(err).NotTo(HaveOccurred())
-				Expect(len(after)).To(BeNumerically(">", beforeLen),
-					"BBR log must grow even for catch-all paths (proves BBR runs before router on every request)")
+				// Poll (rather than a fixed sleep) for the aggregated BBR log to
+				// grow, tolerating log-flush latency on whichever replica served
+				// the request.
+				Eventually(totalBBRLogLen, 30*time.Second, 2*time.Second).
+					Should(BeNumerically(">", beforeLen),
+						"BBR log must grow even for catch-all paths (proves BBR runs before router on every request)")
 			})
 
 			// E2 — Non-JSON Content-Type. BBR's body-field-to-header plugin

--- a/test/e2e/modeldeployment_chart_test.go
+++ b/test/e2e/modeldeployment_chart_test.go
@@ -280,7 +280,12 @@ var _ = Describe("ModelDeployment Chart", utils.GinkgoLabelInferenceSet, func() 
 
 			duration, found, _ := unstructured.NestedString(is.Object, "spec", "autoUpgrade", "maintenanceWindow", "duration")
 			Expect(found).To(BeTrue(), "spec.autoUpgrade.maintenanceWindow.duration should be present")
-			Expect(duration).To(Equal("4h"))
+			// The InferenceSet CRD canonicalizes the metav1.Duration, so the
+			// stored value is Go's normalized form ("4h0m0s"), not the literal
+			// "4h" we set. Compare parsed durations to stay normalization-agnostic.
+			parsedDuration, parseErr := time.ParseDuration(duration)
+			Expect(parseErr).NotTo(HaveOccurred(), "spec.autoUpgrade.maintenanceWindow.duration %q should be a valid duration", duration)
+			Expect(parsedDuration).To(Equal(4 * time.Hour))
 		})
 	})
 })

--- a/test/e2e/modeldeployment_chart_test.go
+++ b/test/e2e/modeldeployment_chart_test.go
@@ -222,4 +222,65 @@ var _ = Describe("ModelDeployment Chart", utils.GinkgoLabelInferenceSet, func() 
 			}, 30*time.Second, utils.PollInterval).Should(BeTrue(), "HTTPRoute should be deleted")
 		})
 	})
+
+	Context("modeldeployment chart with autoUpgrade enabled", func() {
+		// Reuse the same base deployment values as the install/uninstall
+		// context, but opt into KAITO automatic base image upgrades with a
+		// maintenance window. Each It installs into a fresh random namespace
+		// (BeforeEach) and recycles it in AfterEach.
+		baseValues := CaseDeployments[CaseModelDeploymentChart][0]
+		deploymentName := baseValues.Name
+
+		var namespace string
+
+		BeforeEach(func() {
+			namespace = generateNamespace("e2e-autoupgrade")
+			createNamespace(ctx, namespace)
+
+			values := baseValues
+			values.Namespace = namespace
+			values.AutoUpgrade = utils.AutoUpgrade{
+				Enabled:                   true,
+				MaintenanceWindowSchedule: "0 2 * * 6",
+				MaintenanceWindowDuration: "4h",
+			}
+			By("Installing modeldeployment chart with autoUpgrade enabled")
+			err := utils.CreateInferenceSetWithRouting(ctx, utils.TestingCluster.KubeClient, values)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			By("Uninstalling modeldeployment chart")
+			if err := utils.CleanupInferenceSetWithRouting(ctx, utils.TestingCluster.KubeClient, deploymentName, namespace); err != nil {
+				GinkgoWriter.Printf("Cleanup warning: %v\n", err)
+			}
+			deleteNamespace(ctx, namespace)
+		})
+
+		It("should render InferenceSet with spec.autoUpgrade and a maintenance window", func() {
+			cl := utils.TestingCluster.KubeClient
+
+			By("Verifying InferenceSet carries spec.autoUpgrade")
+			is := &unstructured.Unstructured{}
+			is.SetGroupVersionKind(schema.GroupVersionKind{
+				Group:   "kaito.sh",
+				Version: "v1alpha1",
+				Kind:    "InferenceSet",
+			})
+			err := cl.Get(ctx, types.NamespacedName{Name: deploymentName, Namespace: namespace}, is)
+			Expect(err).NotTo(HaveOccurred())
+
+			enabled, found, _ := unstructured.NestedBool(is.Object, "spec", "autoUpgrade", "enabled")
+			Expect(found).To(BeTrue(), "spec.autoUpgrade.enabled should be present")
+			Expect(enabled).To(BeTrue())
+
+			schedule, found, _ := unstructured.NestedString(is.Object, "spec", "autoUpgrade", "maintenanceWindow", "schedule")
+			Expect(found).To(BeTrue(), "spec.autoUpgrade.maintenanceWindow.schedule should be present")
+			Expect(schedule).To(Equal("0 2 * * 6"))
+
+			duration, found, _ := unstructured.NestedString(is.Object, "spec", "autoUpgrade", "maintenanceWindow", "duration")
+			Expect(found).To(BeTrue(), "spec.autoUpgrade.maintenanceWindow.duration should be present")
+			Expect(duration).To(Equal("4h"))
+		})
+	})
 })

--- a/test/e2e/utils/helm.go
+++ b/test/e2e/utils/helm.go
@@ -62,6 +62,25 @@ type ModelDeploymentValues struct {
 	// EnsureNamespace; the warmup loop in SetupInferenceSetsWithRouting
 	// reads the resulting Secret and sends Bearer + Host headers.
 	AuthAPIKeyEnabled bool
+	// AutoUpgrade opts the InferenceSet into KAITO automatic base image
+	// upgrades, wired onto the modeldeployment chart's autoUpgrade.* values
+	// (rendered as spec.autoUpgrade). Only rendered when Enabled is true.
+	AutoUpgrade AutoUpgrade
+}
+
+// AutoUpgrade mirrors the modeldeployment chart's autoUpgrade values, wired
+// onto the InferenceSet's spec.autoUpgrade. Consumed only when Enabled is true.
+type AutoUpgrade struct {
+	// Enabled toggles autoUpgrade.enabled (spec.autoUpgrade.enabled).
+	Enabled bool
+	// MaintenanceWindowSchedule is the 5-field cron (UTC) marking when
+	// rollouts may begin (autoUpgrade.maintenanceWindow.schedule). Empty
+	// omits the maintenanceWindow block entirely.
+	MaintenanceWindowSchedule string
+	// MaintenanceWindowDuration is how long the window stays open, e.g. "4h"
+	// (autoUpgrade.maintenanceWindow.duration). Ignored when
+	// MaintenanceWindowSchedule is empty.
+	MaintenanceWindowDuration string
 }
 
 // ScalingMetric describes one composite scaling signal, mirroring a single
@@ -136,6 +155,19 @@ func (v ModelDeploymentValues) helmSetArgs() []string {
 			)
 			if m.Quantile != "" {
 				args = append(args, "--set", prefix+"quantile="+m.Quantile)
+			}
+		}
+	}
+	if v.AutoUpgrade.Enabled {
+		args = append(args, "--set", "autoUpgrade.enabled=true")
+		if v.AutoUpgrade.MaintenanceWindowSchedule != "" {
+			// Use --set-string: the cron schedule contains spaces and
+			// asterisks that must be passed through verbatim.
+			args = append(args, "--set-string",
+				"autoUpgrade.maintenanceWindow.schedule="+v.AutoUpgrade.MaintenanceWindowSchedule)
+			if v.AutoUpgrade.MaintenanceWindowDuration != "" {
+				args = append(args, "--set-string",
+					"autoUpgrade.maintenanceWindow.duration="+v.AutoUpgrade.MaintenanceWindowDuration)
 			}
 		}
 	}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->
This PR enables the `automatic base image upgrades` feature (https://kaito-project.github.io/kaito/docs/inference#automatic-base-image-upgrades) in the ModelDeployment chart.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
