### PR TITLE
feat: support service account creation per modelharness and streaming annotations

### DIFF
--- a/charts/modeldeployment/templates/inferenceset.yaml
+++ b/charts/modeldeployment/templates/inferenceset.yaml
@@ -72,13 +72,30 @@ spec:
         cross-namespace ingress to them would silently succeed.
         */}}
         {{- include "modeldeployment.ownerLabel" . | nindent 8 }}
-      {{- if or (not .Values.enableBenchmark) .Values.performanceMode }}
+      {{/*
+      Streaming annotations are stamped here on spec.template.metadata.annotations
+      */}}
+      {{- $disabled := eq (.Values.streaming.disabled | toString) "true" }}
+      {{- $sas := eq (.Values.streaming.staticModelMirror | toString) "true" }}
+      {{- if and $disabled $sas }}
+      {{- fail "modeldeployment: streaming.disabled and streaming.staticModelMirror are mutually exclusive" }}
+      {{- end }}
+      {{- if or (not .Values.enableBenchmark) .Values.performanceMode $disabled $sas }}
       annotations:
         {{- if not .Values.enableBenchmark }}
         kaito.sh/disable-benchmark: "true"
         {{- end }}
         {{- with .Values.performanceMode }}
         kaito.sh/performance-mode: {{ . | quote }}
+        {{- end }}
+        {{- if $disabled }}
+        kaito.sh/model-streaming: "disabled"
+        {{- end }}
+        {{- if $sas }}
+        inference.kaito.sh/static-model-mirror: "true"
+        inference.kaito.sh/stream-datarefs-url: {{ .Values.streaming.datarefsUrl | quote }}
+        inference.kaito.sh/stream-identity-client-id: {{ .Values.streaming.identityClientId | quote }}
+        inference.kaito.sh/stream-source-type: {{ .Values.streaming.sourceType | quote }}
         {{- end }}
       {{- end }}
     resource:

--- a/charts/modeldeployment/values.schema.json
+++ b/charts/modeldeployment/values.schema.json
@@ -107,6 +107,33 @@
       "enum": ["", "balanced", "interactivity", "throughput"],
       "description": "When non-empty, stamps kaito.sh/performance-mode: <value> on the InferenceSet template so the KAITO controller applies the corresponding vLLM profile. Empty (default) omits the annotation and the controller falls back to its own default (balanced). Allowed values: interactivity (low per-request latency), balanced (trade-off), throughput (maximize aggregate tokens/sec)."
     },
+    "streaming": {
+      "type": "object",
+      "additionalProperties": true,
+      "description": "KAITO model-streaming annotations stamped onto spec.template.metadata.annotations of the InferenceSet (propagated to child Workspaces). Every value is delivered as a STRING; gate keys are typed 'string' (not boolean).",
+      "properties": {
+        "disabled": {
+          "type": "string",
+          "description": "When 'true', stamps kaito.sh/model-streaming: 'disabled' to force KAITO's download-at-runtime path. Any other value keeps streaming enabled. Mutually exclusive with staticModelMirror."
+        },
+        "staticModelMirror": {
+          "type": "string",
+          "description": "When 'true', the gate that activates the SAS direct-stream path; stamps inference.kaito.sh/static-model-mirror and requires datarefsUrl, identityClientId, and sourceType."
+        },
+        "datarefsUrl": {
+          "type": "string",
+          "description": "SAS-mint endpoint URL, stamped verbatim as inference.kaito.sh/stream-datarefs-url. Consumed only when staticModelMirror is 'true'."
+        },
+        "identityClientId": {
+          "type": "string",
+          "description": "UAMI client-id GUID, stamped as inference.kaito.sh/stream-identity-client-id. Must match modelharness serviceAccount.workloadIdentityClientId. Consumed only when staticModelMirror is 'true'."
+        },
+        "sourceType": {
+          "type": "string",
+          "description": "Selects KAITO's URL-derivation rule / token audience, stamped as inference.kaito.sh/stream-source-type. The value can only be 'public' or 'byo'. Consumed only when staticModelMirror is 'true'."
+        }
+      }
+    },
     "gatewayName": {
       "type": "string",
       "description": "Gateway the HTTPRoute attaches to. Empty derives '<namespace>-gw'."

--- a/charts/modeldeployment/values.yaml
+++ b/charts/modeldeployment/values.yaml
@@ -122,6 +122,33 @@ enableBenchmark: true
 #     aggressive batching, throughput-oriented kernels).
 performanceMode: ""
 
+# streaming groups the KAITO model-streaming annotations stamped onto
+# spec.template.metadata.annotations of the InferenceSet (which the KAITO
+# InferenceSet controller clones onto every child Workspace, where the
+# streaming logic reads them).
+streaming:
+  # disabled, when "true", stamps `kaito.sh/model-streaming: "disabled"` to
+  # force KAITO's normal download-at-runtime path (no SAS, no az://). Any
+  # other value (or empty) leaves streaming enabled. Mutually exclusive with
+  # staticModelMirror.
+  disabled: ""
+  # staticModelMirror, when "true", is the gate that activates the SAS
+  # direct-stream path; it stamps `inference.kaito.sh/static-model-mirror:
+  # "true"` and requires datarefsUrl, identityClientId, and sourceType below.
+  staticModelMirror: ""
+  # datarefsUrl is the SAS-mint endpoint URL. Consumed only when
+  # staticModelMirror is "true".
+  datarefsUrl: ""
+  # identityClientId is the UAMI client-id GUID, stamped as
+  # `inference.kaito.sh/stream-identity-client-id`. Must match the value sent
+  # to modelharness's serviceAccount.workloadIdentityClientId. Consumed only
+  # when staticModelMirror is "true".
+  identityClientId: ""
+  # sourceType selects the KAITO URL-derivation rule / token audience,
+  # stamped as `inference.kaito.sh/stream-source-type`. The value can only be
+  # "public" or "byo". Consumed only when staticModelMirror is "true".
+  sourceType: ""
+
 # autoUpgrade configures KAITO's automatic base image upgrades for this
 # InferenceSet, rendered as spec.autoUpgrade. KAITO ships the vLLM base
 # image embedded in the controller; when the controller is upgraded to a

--- a/charts/modelharness/templates/_helpers.tpl
+++ b/charts/modelharness/templates/_helpers.tpl
@@ -17,6 +17,14 @@ Gateway name distinct from the namespace name.
 {{- end }}
 
 {{/*
+Streaming ServiceAccount name. PINNED to the constant "kaito-model-streamer"
+and intentionally NOT exposed as a tunable value.
+*/}}
+{{- define "modelharness.streamingServiceAccountName" -}}
+kaito-model-streamer
+{{- end }}
+
+{{/*
 Common labels applied to every harness-owned resource.
 
 `kaito.sh/owned-by: modelharness` is the stable ownership label the

--- a/charts/modelharness/templates/serviceaccount.yaml
+++ b/charts/modelharness/templates/serviceaccount.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.serviceAccount.workloadIdentityClientId }}
+{{/*
+Streaming ServiceAccount for Azure Workload Identity.
+
+The SAS / Workload-Identity model-streaming pods run as this dedicated
+ServiceAccount. The `azure.workload.identity/client-id` annotation carries the
+user-assigned managed identity (UAMI) client-id and delivers via `serviceAccount.workloadIdentityClientId`; 
+the pod's projected SA token is exchanged (via the per-namespace Federated Identity Credential) for
+that identity's AAD token to mint the SAS / read the blob.
+
+The SA name is pinned to `kaito-model-streamer`. KAITO adds the 
+`azure.workload.identity/use: "true"` pod label.
+*/}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "modelharness.streamingServiceAccountName" . }}
+  namespace: {{ include "modelharness.namespace" . }}
+  labels:
+    {{- include "modelharness.labels" . | nindent 4 }}
+  annotations:
+    azure.workload.identity/client-id: {{ .Values.serviceAccount.workloadIdentityClientId | quote }}
+{{- end }}

--- a/charts/modelharness/values.schema.json
+++ b/charts/modelharness/values.schema.json
@@ -22,6 +22,17 @@
       "minLength": 1,
       "description": "GatewayClass the per-namespace Gateway binds to. MUST be non-empty."
     },
+    "serviceAccount": {
+      "type": "object",
+      "additionalProperties": false,
+      "description": "Streaming ServiceAccount configuration for KAITO model-streaming pods. Rendered only when workloadIdentityClientId is non-empty.",
+      "properties": {
+        "workloadIdentityClientId": {
+          "type": "string",
+          "description": "User-assigned managed identity (UAMI) client-id GUID. Non-empty renders the streaming ServiceAccount annotated with azure.workload.identity/client-id. Empty (default) renders no ServiceAccount."
+        }
+      }
+    },
     "gatewayPort": {
       "type": "integer",
       "minimum": 1,

--- a/charts/modelharness/values.yaml
+++ b/charts/modelharness/values.yaml
@@ -18,6 +18,17 @@ manageNamespace: true
 # Istio's "istio" GatewayClass.
 gatewayClassName: istio
 
+# serviceAccount configures the streaming ServiceAccount used by KAITO's
+# model-streaming pods (both the default Workload-Identity mirror+stream
+# path and the SAS direct-stream path).
+serviceAccount:
+  # workloadIdentityClientId is the user-assigned managed identity (UAMI)
+  # client-id GUID. When non-empty, the chart
+  # renders the streaming ServiceAccount annotated with
+  # `azure.workload.identity/client-id: <value>`. Empty (the default) renders
+  # no ServiceAccount.
+  workloadIdentityClientId: ""
+
 # gatewayName is the per-namespace Istio Gateway resource name. When
 # empty (the default), the chart derives "<namespace>-gw" so the Gateway
 # name self-identifies the workload namespace it serves while staying


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

- Added support to create a fixed-name ServiceAccount per modelharness chart to support model streaming. Stamps the azure.workload.identity/client-id annotation on the SA.
- Added five streaming annotations to the modeldeployment InferenceSet template (kaito.sh/model-streaming, inference.kaito.sh/static-model-mirror, inference.kaito.sh/stream-datarefs-url, inference.kaito.sh/stream-identity-client-id, inference.kaito.sh/stream-source-type).
**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Closes #157 
**Notes for Reviewers**:
