### PR TITLE
Added storage class template under productionstack chart

### DIFF
--- a/charts/productionstack/templates/azure/modelmirror-storageclass.yaml
+++ b/charts/productionstack/templates/azure/modelmirror-storageclass.yaml
@@ -1,0 +1,53 @@
+{{- if and (eq .Values.cloudprovider "azure") .Values.modelMirror.storageAccount }}
+{{/*
+Model-mirror StorageClass for KAITO's model-mirror download Job.
+
+KAITO's model-mirror download Job writes model weights into an Azure blob
+container and inference pods read them back. KAITO creates a PVC referencing
+this StorageClass; the Blob CSI driver (`blob.csi.azure.com`) dynamically
+creates a container and mounts it. The mount uses Azure Workload Identity.
+
+KAITO's workspace controller validates two fields at reconcile time and
+rejects the workspace otherwise, so both are FIXED constants:
+  - metadata.name MUST equal the controller's
+    --default-model-mirror-storage-class (the fixed `kaito-model-mirror`).
+  - provisioner MUST be `blob.csi.azure.com`.
+
+Rendered ONLY when `modelMirror.storageAccount` is non-empty.
+The mounting workload runs under the streaming ServiceAccount
+(`kaito-model-streamer`, rendered by charts/modelharness), federated to the
+same identity as `clientID`.
+*/}}
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: kaito-model-mirror
+  labels:
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    kaito.sh/owned-by: productionstack
+provisioner: blob.csi.azure.com
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+parameters:
+  storageAccount: {{ .Values.modelMirror.storageAccount | quote }}
+  resourceGroup: {{ .Values.modelMirror.resourceGroup | quote }}
+  protocol: fuse2
+  skuName: Premium_LRS
+  # Keyless mount auth — shared-key access is disabled on the account.
+  clientID: {{ .Values.modelMirror.clientID | quote }}
+  mountWithWorkloadIdentityToken: "true"
+mountOptions:
+  - -o allow_other
+  - -o attr_timeout=120
+  - -o entry_timeout=120
+  - -o negative_timeout=120
+  - --cancel-list-on-mount-seconds=10
+  - --use-attr-cache=true
+  - --block-cache
+  - --block-cache-block-size=16
+  - --block-cache-pool-size=8192
+  - --block-cache-prefetch=11
+{{- else if .Values.modelMirror.storageAccount }}
+{{- fail "modelMirror.storageAccount is set but requires cloudprovider=\"azure\"" }}
+{{- end }}

--- a/charts/productionstack/values.yaml
+++ b/charts/productionstack/values.yaml
@@ -190,10 +190,6 @@ modelMirror:
   # dynamically-created container.
   storageAccount: ""
   # resourceGroup is the resource group holding the storage account.
-  # REQUIRED — the account lives in RP's managed resource group, which is
-  # NOT the cluster's resource group, so the Blob CSI driver cannot derive
-  # it from cluster context; an empty value makes the mount look in the
-  # wrong RG and fail.
   resourceGroup: ""
   # clientID is the user-assigned managed identity (UAMI) client-id GUID used
   # for the keyless Workload-Identity mount. Same GUID as the streaming

--- a/charts/productionstack/values.yaml
+++ b/charts/productionstack/values.yaml
@@ -174,6 +174,32 @@ llm-gateway-apikey:
     extAuthzInsert:
       operation: INSERT_FIRST
 
+# modelMirror configures the cluster-wide model-mirror StorageClass
+# (`kaito-model-mirror`) that KAITO's model-mirror download Job uses for its
+# mirror PVCs. The StorageClass is rendered by
+# templates/modelmirror-storageclass.yaml ONLY when `storageAccount` is
+# non-empty. All values arrive as strings via the AKS-extension ConfigurationSettings.
+#
+# The StorageClass name (`kaito-model-mirror`) and provisioner
+# (`blob.csi.azure.com`) are FIXED constants validated by KAITO's workspace
+# controller, so they are not exposed as values.
+modelMirror:
+  # storageAccount is the pre-existing per-AIManager model-mirror storage
+  # account name. Non-empty renders the StorageClass; empty (the default)
+  # renders nothing. Pins the account the Blob CSI driver reuses for the
+  # dynamically-created container.
+  storageAccount: ""
+  # resourceGroup is the resource group holding the storage account.
+  # REQUIRED — the account lives in RP's managed resource group, which is
+  # NOT the cluster's resource group, so the Blob CSI driver cannot derive
+  # it from cluster context; an empty value makes the mount look in the
+  # wrong RG and fail.
+  resourceGroup: ""
+  # clientID is the user-assigned managed identity (UAMI) client-id GUID used
+  # for the keyless Workload-Identity mount. Same GUID as the streaming
+  # ServiceAccount's azure.workload.identity/client-id (charts/modelharness).
+  clientID: ""
+
 # cloudprovider selects which cloud provider's integrations render.
 # Cloud-specific templates (those living under templates/<provider>/)
 # are gated on this matching their subfolder AND the per-feature


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->
It creates a fuse2 workload-identity-authed storage class per productionstack chart. This creates the cluster-scoped storage class needed by kaito's model mirror.
**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->
Closes #161
**Notes for Reviewers**:

Prerequisite roles: because this StorageClass uses dynamic provisioning with a token-only Workload-Identity mount on a shared-key-disabled account, two role assignments on the storage account are required — Storage Account Contributor on the Blob CSI driver's control-plane identity (to create the container, management plane), and Storage Blob Data Contributor on the user-assigned managed identity referenced by clientID (to read/write blob data during the mount, data plane; Storage Blob Data Reader is insufficient because the model-mirror download writes).

Because this StorageClass lives under templates/azure/, it only renders when the chart-wide cloudprovider selector is set to azure. This is a requirement for caller.

Manually tested and proven e2e from chart creation to inference ready.