### PR TITLE
modelharness: emit workload namespace via ExtAuthzPerRoute context_ex…

### DIFF
--- a/charts/modelharness/templates/azure/envoyfilter-ext-authz.yaml
+++ b/charts/modelharness/templates/azure/envoyfilter-ext-authz.yaml
@@ -104,6 +104,30 @@ spec:
               timeout: {{ .Values.auth.extAuthzAzure.timeout | quote }}
             metadata_context_namespaces:
               - envoy.filters.http.jwt_authn
+    # Emit the workload namespace to azure-authz via context_extensions so the
+    # authz server does not need to derive it from the client-supplied Host
+    # header. Host is set by the caller and is therefore forgeable by any
+    # client that can reach the Gateway; context_extensions are populated from
+    # the data-plane configuration at proxy-startup time and cannot be
+    # influenced by the request sender. Rendered unconditionally: the namespace
+    # is unambiguous in this per-workload-namespace chart, an opt-in flag would
+    # default to off in most deployments (negating the security benefit), and a
+    # flag reintroduces config divergence between environments. The consuming
+    # server-side change that prefers context_extensions["gateway-namespace"]
+    # over Host (with Host as a backward-compatible fallback) lives in the
+    # llm-gateway-auth repo.
+    - applyTo: VIRTUAL_HOST
+      match:
+        context: GATEWAY
+      patch:
+        operation: MERGE
+        value:
+          typed_per_filter_config:
+            envoy.filters.http.ext_authz:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+              check_settings:
+                context_extensions:
+                  gateway-namespace: {{ include "modelharness.namespace" . | quote }}
     {{- else }}
     {{/* ── hybrid mode ───────────────────────────────────────────────────
          INSERT_FIRST reverses insertion order. Final chain order:
@@ -273,6 +297,28 @@ spec:
                   handle:streamInfo():dynamicMetadata():set(
                     "envoy.filters.http.lua", "auth_mode", mode)
                 end
+    # Emit the workload namespace to both ext_authz backends via
+    # context_extensions (see azure-mode comment above for security rationale).
+    # typed_per_filter_config is keyed by the filter's chain name; an absent key
+    # silently no-ops for that filter branch, so BOTH ext_authz.azure and
+    # ext_authz.apikey must have entries to cover the full hybrid request path.
+    - applyTo: VIRTUAL_HOST
+      match:
+        context: GATEWAY
+      patch:
+        operation: MERGE
+        value:
+          typed_per_filter_config:
+            ext_authz.azure:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+              check_settings:
+                context_extensions:
+                  gateway-namespace: {{ include "modelharness.namespace" . | quote }}
+            ext_authz.apikey:
+              "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+              check_settings:
+                context_extensions:
+                  gateway-namespace: {{ include "modelharness.namespace" . | quote }}
     {{- end }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
…tensions

Add a VIRTUAL_HOST MERGE patch to the azure-variant ext_authz EnvoyFilter so that Envoy injects the workload namespace into every ext_authz CheckRequest as a context_extension field (gateway-namespace: <namespace>).

Security rationale: the authz server previously had to derive the namespace from the inbound Host header, which is set by the caller and is therefore forgeable by any client that can reach the Gateway.  context_extensions are populated from the data-plane configuration at proxy-startup time and cannot be influenced by the request sender, making this a trustworthy control-plane signal.

Implementation notes:
- azure mode: keys the per-route config on "envoy.filters.http.ext_authz", which is the filter's chain name in that mode (INSERT_AFTER jwt_authn).
- hybrid mode: keys on BOTH "ext_authz.azure" and "ext_authz.apikey" because typed_per_filter_config is looked up by filter name and a missing key silently no-ops for that branch.
- Rendered unconditionally (no values flag): the namespace is unambiguous in this per-workload-namespace chart, an opt-in flag defaults to off in most deployments (negating the security benefit), and a flag reintroduces config divergence between environments.
- apikey-only mode is unaffected; the template's outer guard already skips this file for that path.

The consuming server-side change — preferring context_extensions["gateway-namespace"] over Host (with Host retained as a backward-compatible fallback) — lives in the llm-gateway-auth repo.

**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
