### PR TITLE
feat(gpu-mocker): derive fake node nvidia.com/gpu from cloud SKU

### DIFF
--- a/.github/typos.toml
+++ b/.github/typos.toml
@@ -3,6 +3,9 @@ Ded = "Ded"
 rsource = "rsource"
 AKS = "AKS"
 stopp = "stopp"
+# "ND" is the Azure GPU VM family prefix (ND96isr, ND96asr, ND96amsr, …)
+# and is otherwise corrected to "AND" by the default typos dictionary.
+ND = "ND"
 
 [default.extend-identifiers]
 ObjectCreater = "ObjectCreater"

--- a/charts/gpu-node-mocker/templates/deployment.yaml
+++ b/charts/gpu-node-mocker/templates/deployment.yaml
@@ -76,6 +76,7 @@ spec:
             - --node-class-version={{ .Values.nodeClass.version }}
             - --node-class-kind={{ .Values.nodeClass.kind }}
             - --node-class-resource={{ .Values.nodeClass.resource }}
+            - --cloud-provider={{ .Values.cloudProvider }}
           ports:
             - name: metrics
               containerPort: 8080

--- a/charts/gpu-node-mocker/values.yaml
+++ b/charts/gpu-node-mocker/values.yaml
@@ -47,6 +47,12 @@ shadowPod:
 # Must match KAITO's --node-provisioner value: azure-gpu-provisioner or karpenter.
 nodeProvisioner: karpenter
 
+# cloudProvider selects the KAITO SKU catalog used to size each fake node's
+# nvidia.com/gpu capacity. Valid values: "azure", "aws", "arc". Set to "" to
+# disable the lookup and advertise 1 GPU on every fake node regardless of the
+# NodeClaim's node.kubernetes.io/instance-type requirement.
+cloudProvider: azure
+
 # nodeClass selects the karpenter NodeClass kind the mocker reconciles (and
 # discovery-checks at startup) in karpenter mode. The default mock node class
 # lives in the karpenter.kaito.sh group, which a real Karpenter provider does

--- a/cmd/gpu-node-mocker/main.go
+++ b/cmd/gpu-node-mocker/main.go
@@ -84,6 +84,7 @@ func main() {
 		nodeClassVersion       string
 		nodeClassKind          string
 		nodeClassResource      string
+		cloudProvider          string
 	)
 
 	defaultNodeClass := controllers.DefaultNodeClassRef()
@@ -135,6 +136,9 @@ func main() {
 		"Kind of the karpenter NodeClass to reconcile in karpenter mode.")
 	flag.StringVar(&nodeClassResource, "node-class-resource", defaultNodeClass.Resource,
 		"Plural resource name of the karpenter NodeClass (used for the startup CRD discovery check).")
+	flag.StringVar(&cloudProvider, "cloud-provider", controllers.DefaultCloudProvider,
+		fmt.Sprintf("Cloud SKU catalog used to size the fake node's nvidia.com/gpu (%q, %q, %q). Empty disables the lookup and every fake node advertises 1 GPU.",
+			controllers.CloudProviderAzure, controllers.CloudProviderAWS, controllers.CloudProviderArc))
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
 	flag.Parse()
@@ -158,6 +162,13 @@ func main() {
 	}
 	if latencyCalculator == "" {
 		latencyCalculator = controllers.DefaultLatencyCalculator
+	}
+	switch cloudProvider {
+	case "", controllers.CloudProviderAzure, controllers.CloudProviderAWS, controllers.CloudProviderArc:
+	default:
+		setupLog.Error(nil, "--cloud-provider must be \"azure\", \"aws\", \"arc\", or empty",
+			"value", cloudProvider)
+		os.Exit(1)
 	}
 
 	cfg := controllers.Config{
@@ -183,6 +194,7 @@ func main() {
 			Kind:     nodeClassKind,
 			Resource: nodeClassResource,
 		},
+		CloudProvider: cloudProvider,
 	}
 
 	restCfg := ctrl.GetConfigOrDie()

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,11 @@ go 1.26.4
 require (
 	github.com/awslabs/operatorpkg v0.0.0-20260217224511-7a138650b2d1
 	github.com/go-logr/logr v1.4.3
+	github.com/kaito-project/kaito v0.11.0
 	github.com/onsi/ginkgo/v2 v2.28.1
 	github.com/onsi/gomega v1.39.1
 	github.com/prometheus/client_model v0.6.2
-	github.com/prometheus/common v0.67.4
+	github.com/prometheus/common v0.67.5
 	k8s.io/api v0.35.3
 	k8s.io/apimachinery v0.35.3
 	k8s.io/client-go v0.35.3
@@ -56,7 +57,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f // indirect
-	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -97,6 +97,8 @@ github.com/joshdk/go-junit v1.0.0 h1:S86cUKIdwBHWwA6xCmFlf3RTLfVXYQfvanM5Uh+K6GE
 github.com/joshdk/go-junit v1.0.0/go.mod h1:TiiV0PqkaNfFXjEiyjWM3XXrhVyCa1K4Zfga6W52ung=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/kaito-project/kaito v0.11.0 h1:Y8wS9ng4HXr6V1+Wj/dFBEAsLoaiP8mgAedcyUoLZu0=
+github.com/kaito-project/kaito v0.11.0/go.mod h1:WM/XCHYy2z+cKZ5XVq+AAjUIIIlFds4e3Z/CU8N23As=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -131,14 +133,15 @@ github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaR
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
+github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/prometheus/client_golang v1.23.2 h1:Je96obch5RDVy3FDMndoUsjAhG5Edi49h0RJWRi/o0o=
 github.com/prometheus/client_golang v1.23.2/go.mod h1:Tb1a6LWHB3/SPIzCoaDXI4I8UHKeFTEQ1YCr+0Gyqmg=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
-github.com/prometheus/common v0.67.4 h1:yR3NqWO1/UyO1w2PhUvXlGQs/PtFmoveVO0KZ4+Lvsc=
-github.com/prometheus/common v0.67.4/go.mod h1:gP0fq6YjjNCLssJCQp0yk4M8W6ikLURwkdd/YKtTbyI=
+github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTUGI4=
+github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=

--- a/pkg/gpu-node-mocker/controllers/config.go
+++ b/pkg/gpu-node-mocker/controllers/config.go
@@ -147,6 +147,13 @@ const (
 	MockNodeClassVersion  = "v1alpha1"
 	MockNodeClassKind     = "MockNodeClass"
 	MockNodeClassResource = "mocknodeclasses"
+
+	// Cloud provider identifiers accepted by --cloud-provider. They match the
+	// KAITO pkg/sku catalog keys (github.com/kaito-project/kaito/pkg/utils/consts).
+	CloudProviderAzure = "azure"
+	CloudProviderAWS   = "aws"
+	CloudProviderArc   = "arc"
+	DefaultCloudProvider = CloudProviderAzure
 )
 
 // NodeClassRef identifies the cluster-scoped karpenter NodeClass resource that
@@ -227,4 +234,9 @@ type Config struct {
 	// NodeClass is the karpenter NodeClass GVK the mocker reconciles (and
 	// discovery-checks) in karpenter mode. Defaults to the mock node class.
 	NodeClass NodeClassRef
+
+	// CloudProvider selects the KAITO SKU catalog used to size the fake node's
+	// nvidia.com/gpu capacity. Valid values: "azure", "aws", "arc". Empty
+	// disables the lookup and every fake node advertises 1 GPU.
+	CloudProvider string
 }

--- a/pkg/gpu-node-mocker/controllers/config.go
+++ b/pkg/gpu-node-mocker/controllers/config.go
@@ -150,9 +150,9 @@ const (
 
 	// Cloud provider identifiers accepted by --cloud-provider. They match the
 	// KAITO pkg/sku catalog keys (github.com/kaito-project/kaito/pkg/utils/consts).
-	CloudProviderAzure = "azure"
-	CloudProviderAWS   = "aws"
-	CloudProviderArc   = "arc"
+	CloudProviderAzure   = "azure"
+	CloudProviderAWS     = "aws"
+	CloudProviderArc     = "arc"
 	DefaultCloudProvider = CloudProviderAzure
 )
 

--- a/pkg/gpu-node-mocker/controllers/node_claim_controller.go
+++ b/pkg/gpu-node-mocker/controllers/node_claim_controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	"github.com/awslabs/operatorpkg/status"
+	"github.com/kaito-project/kaito/pkg/sku"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -69,6 +70,11 @@ type NodeClaimReconciler struct {
 	// (used by the azure-gpu-provisioner mode where no other provisioner runs).
 	NodeClassFilter *NodeClassRef
 
+	// SKUHandler is the KAITO cloud SKU catalog used by nodeCapacity to size
+	// the fake node's nvidia.com/gpu. Resolved from Config.CloudProvider in
+	// SetupWithManager; nil means "no lookup, every fake node gets 1 GPU".
+	SKUHandler sku.CloudSKUHandler
+
 	// mu protects cancelFuncs.
 	mu          sync.Mutex
 	cancelFuncs map[string]context.CancelFunc // key = node name
@@ -77,6 +83,14 @@ type NodeClaimReconciler struct {
 // SetupWithManager registers the controller and initialises internal state.
 func (r *NodeClaimReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	r.cancelFuncs = make(map[string]context.CancelFunc)
+	if r.SKUHandler == nil && r.Config.CloudProvider != "" {
+		h := sku.GetCloudSKUHandler(r.Config.CloudProvider)
+		if h == nil {
+			return fmt.Errorf("unsupported cloud provider %q; valid values: %q, %q, %q",
+				r.Config.CloudProvider, CloudProviderAzure, CloudProviderAWS, CloudProviderArc)
+		}
+		r.SKUHandler = h
+	}
 	b := ctrl.NewControllerManagedBy(mgr)
 	if r.NodeClassFilter != nil {
 		nodeClassPred := predicate.NewPredicateFuncs(func(obj client.Object) bool {
@@ -246,12 +260,10 @@ func (r *NodeClaimReconciler) ensureFakeNode(ctx context.Context, nc *karpenterv
 	}
 	// Get instance type from NodeClaim requirements so KAITO's
 	// node readiness check can match the workspace instanceType.
-	for _, req := range nc.Spec.Requirements {
-		if req.Key == "node.kubernetes.io/instance-type" && len(req.Values) > 0 {
-			labels["node.kubernetes.io/instance-type"] = req.Values[0]
-			labels["beta.kubernetes.io/instance-type"] = req.Values[0]
-			break
-		}
+	instanceType := instanceTypeFromNodeClaim(nc)
+	if instanceType != "" {
+		labels["node.kubernetes.io/instance-type"] = instanceType
+		labels["beta.kubernetes.io/instance-type"] = instanceType
 	}
 	for k, v := range nc.Labels {
 		labels[k] = v
@@ -302,7 +314,7 @@ func (r *NodeClaimReconciler) ensureNodeReady(ctx context.Context, node *corev1.
 	}
 
 	now := metav1.Now()
-	capacity := nodeCapacity()
+	capacity := nodeCapacity(r.SKUHandler, instanceTypeFromNodeClaim(nc))
 
 	patch := client.MergeFrom(node.DeepCopy())
 	node.Status = corev1.NodeStatus{
@@ -351,7 +363,7 @@ func (r *NodeClaimReconciler) ensureNodeClaimReady(ctx context.Context, nc *karp
 	}
 
 	now := metav1.Now()
-	capacity := nodeCapacity()
+	capacity := nodeCapacity(r.SKUHandler, instanceTypeFromNodeClaim(nc))
 
 	patch := client.MergeFrom(nc.DeepCopy())
 	nc.Status.NodeName = nodeName
@@ -545,18 +557,36 @@ func controllerName(nodeName string) string {
 	return ControllerName + "/" + nodeName
 }
 
-// nodeCapacity returns a fixed ResourceList with enough capacity for the
-// scheduler to place KAITO inference pods on the fake node.
-// The exact values don't matter — no real workload runs here
-// Phase 2 redirects pods to shadow pods on real nodes.
-// KAITO only populates spec.resources.requests with storage so CPU/memory/GPU are hardcoded.
-func nodeCapacity() corev1.ResourceList {
+// nodeCapacity returns a ResourceList sized to place KAITO inference pods on
+// the fake node. CPU/memory/pods are fixed (KAITO only populates
+// spec.resources.requests with storage), while nvidia.com/gpu is derived from
+// the instance-type SKU via the supplied KAITO catalog so a 2- or 8-GPU SKU
+// advertises its real GPU count. A nil handler or unknown SKU falls back to
+// 1 GPU.
+func nodeCapacity(skuHandler sku.CloudSKUHandler, instanceType string) corev1.ResourceList {
+	gpuCount := int64(1)
+	if skuHandler != nil && instanceType != "" {
+		if cfg := skuHandler.GetGPUConfigBySKU(instanceType); cfg != nil && cfg.GPUCount > 0 {
+			gpuCount = int64(cfg.GPUCount)
+		}
+	}
 	return corev1.ResourceList{
 		corev1.ResourceCPU:                    resource.MustParse("4"),
 		corev1.ResourceMemory:                 resource.MustParse("16Gi"),
 		corev1.ResourcePods:                   resource.MustParse("110"),
-		corev1.ResourceName("nvidia.com/gpu"): resource.MustParse("1"),
+		corev1.ResourceName("nvidia.com/gpu"): *resource.NewQuantity(gpuCount, resource.DecimalSI),
 	}
+}
+
+// instanceTypeFromNodeClaim returns the SKU string from the NodeClaim's
+// node.kubernetes.io/instance-type requirement, or "" if not set.
+func instanceTypeFromNodeClaim(nc *karpenterv1.NodeClaim) string {
+	for _, req := range nc.Spec.Requirements {
+		if req.Key == "node.kubernetes.io/instance-type" && len(req.Values) > 0 {
+			return req.Values[0]
+		}
+	}
+	return ""
 }
 
 // makeCondition constructs a NodeCondition with the given parameters.

--- a/pkg/gpu-node-mocker/controllers/node_claim_controller_test.go
+++ b/pkg/gpu-node-mocker/controllers/node_claim_controller_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kaito-project/kaito/pkg/sku"
 	coordinationv1 "k8s.io/api/coordination/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -98,19 +99,54 @@ func TestControllerName(t *testing.T) {
 }
 
 func TestNodeCapacity(t *testing.T) {
-	cap := nodeCapacity()
-	if cap.Cpu().Cmp(resource.MustParse("4")) != 0 {
-		t.Errorf("CPU = %s, want 4", cap.Cpu().String())
+	azure := sku.NewAzureSKUHandler()
+	aws := sku.NewAwsSKUHandler()
+	tests := []struct {
+		name         string
+		handler      sku.CloudSKUHandler
+		instanceType string
+		wantGPU      string
+	}{
+		{name: "nil handler falls back to 1 GPU", handler: nil, instanceType: "Standard_NC48ads_A100_v4", wantGPU: "1"},
+		{name: "azure: empty SKU falls back to 1 GPU", handler: azure, instanceType: "", wantGPU: "1"},
+		{name: "azure: unknown SKU falls back to 1 GPU", handler: azure, instanceType: "p4d.24xlarge", wantGPU: "1"},
+		{name: "azure: single-GPU A100 SKU", handler: azure, instanceType: "Standard_NC24ads_A100_v4", wantGPU: "1"},
+		{name: "azure: 2-GPU A100 SKU", handler: azure, instanceType: "Standard_NC48ads_A100_v4", wantGPU: "2"},
+		{name: "azure: 4-GPU A100 SKU", handler: azure, instanceType: "Standard_NC96ads_A100_v4", wantGPU: "4"},
+		{name: "azure: 8-GPU H100 SKU", handler: azure, instanceType: "Standard_ND96isr_H100_v5", wantGPU: "8"},
+		{name: "aws: 8-GPU A100 SKU", handler: aws, instanceType: "p4d.24xlarge", wantGPU: "8"},
+		{name: "aws: rejects Azure SKU", handler: aws, instanceType: "Standard_NC48ads_A100_v4", wantGPU: "1"},
 	}
-	if cap.Memory().Cmp(resource.MustParse("16Gi")) != 0 {
-		t.Errorf("Mem = %s, want 16Gi", cap.Memory().String())
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cap := nodeCapacity(tt.handler, tt.instanceType)
+			if cap.Cpu().Cmp(resource.MustParse("4")) != 0 {
+				t.Errorf("CPU = %s, want 4", cap.Cpu().String())
+			}
+			if cap.Memory().Cmp(resource.MustParse("16Gi")) != 0 {
+				t.Errorf("Mem = %s, want 16Gi", cap.Memory().String())
+			}
+			if cap.Pods().Cmp(resource.MustParse("110")) != 0 {
+				t.Errorf("Pods = %s, want 110", cap.Pods().String())
+			}
+			gpuVal := cap[corev1.ResourceName("nvidia.com/gpu")]
+			if gpuVal.Cmp(resource.MustParse(tt.wantGPU)) != 0 {
+				t.Errorf("GPU = %s, want %s", gpuVal.String(), tt.wantGPU)
+			}
+		})
 	}
-	gpuVal := cap[corev1.ResourceName("nvidia.com/gpu")]
-	if gpuVal.Cmp(resource.MustParse("1")) != 0 {
-		t.Errorf("GPU = %s, want 1", gpuVal.String())
+}
+
+func TestInstanceTypeFromNodeClaim(t *testing.T) {
+	nc := &karpenterv1.NodeClaim{}
+	if got := instanceTypeFromNodeClaim(nc); got != "" {
+		t.Errorf("empty requirements: got %q, want \"\"", got)
 	}
-	if cap.Pods().Cmp(resource.MustParse("110")) != 0 {
-		t.Errorf("Pods = %s, want 110", cap.Pods().String())
+	nc.Spec.Requirements = []karpenterv1.NodeSelectorRequirementWithMinValues{
+		{Key: "node.kubernetes.io/instance-type", Operator: "In", Values: []string{"Standard_NC48ads_A100_v4"}},
+	}
+	if got := instanceTypeFromNodeClaim(nc); got != "Standard_NC48ads_A100_v4" {
+		t.Errorf("got %q", got)
 	}
 }
 


### PR DESCRIPTION

**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

Wire kaito-project/kaito@v0.11.0's pkg/sku catalog into the NodeClaim reconciler so nodeCapacity() looks up the SKU (from the NodeClaim's node.kubernetes.io/instance-type requirement) and advertises the real GPUCount instead of a hardcoded 1. Which catalog is used is configurable via --cloud-provider ("azure", "aws", or "arc"); an empty value or an unknown SKU falls back to 1 GPU. CPU/memory/pods stay fixed (KAITO only populates NodeClaim.Spec.Resources.Requests with storage).

- Add CloudProvider field to Config plus CloudProviderAzure/AWS/Arc and DefaultCloudProvider constants (default "azure", backward compatible).
- Add SKUHandler field to NodeClaimReconciler; resolve it in SetupWithManager via sku.GetCloudSKUHandler and error out on an unrecognised non-empty provider.
- nodeCapacity(skuHandler, instanceType) — handler is passed in explicitly; no more package-level sync.Once/global.
- Extract instanceTypeFromNodeClaim() and reuse it in ensureFakeNode (labels) and ensureNodeReady / ensureNodeClaimReady (capacity).
- Expose --cloud-provider on the binary and .Values.cloudProvider in the gpu-node-mocker Helm chart (deployment template + values.yaml).
- Table-drive TestNodeCapacity across nil handler, empty/unknown SKU, and Azure A100/H100 (1/2/4/8 GPUs) plus AWS p4d.24xlarge (8 GPUs) and a cross-cloud SKU rejection; add TestInstanceTypeFromNodeClaim.

Effect: the e2e assertion in test/e2e/karpenter_test.go that a fake node carries nvidia.com/gpu >= minGPUsPerNode now reflects the requested SKU, so the 2-GPU Standard_NC48ads_A100_v4 case sees nvidia.com/gpu=2.


**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
