### PR TITLE
Run full corpus on perf CI pipeline

### DIFF
--- a/.github/workflows/e2e-perf-weekly.yaml
+++ b/.github/workflows/e2e-perf-weekly.yaml
@@ -120,39 +120,6 @@ jobs:
         with:
           ref: ${{ github.event.inputs.branch || github.ref }}
 
-      - name: Setup Go
-        uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-
-      - name: Generate E2E coverage report
-        run: |
-          REPORT="${{ runner.temp }}/e2e-perf-ginkgo-${{ github.run_id }}-${{ github.run_attempt }}.json"
-          if [[ -f "${REPORT}" ]]; then
-            go run ./hack/e2e/report \
-              --label-filter 'Perf' \
-              --workflow 'E2E tests (weekly, full-corpus perf)' \
-              --results "${REPORT}" \
-              --output-md e2e-coverage-report.md \
-              --output-html e2e-coverage-report.html
-            echo '## Weekly Full-Corpus Perf Coverage' >> "$GITHUB_STEP_SUMMARY"
-            cat e2e-coverage-report.md >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo '## Weekly Full-Corpus Perf Coverage' >> "$GITHUB_STEP_SUMMARY"
-            echo 'No Ginkgo report was produced; inspect the setup and replay logs.' >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Upload E2E coverage report
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: e2e-perf-full-corpus-report
-          path: |
-            e2e-coverage-report.md
-            e2e-coverage-report.html
-            ${{ runner.temp }}/e2e-perf-ginkgo-${{ github.run_id }}-${{ github.run_attempt }}.json
-          if-no-files-found: warn
-
       - name: Azure Login
         if: always()
         run: az login --identity

--- a/.github/workflows/e2e-perf-weekly.yaml
+++ b/.github/workflows/e2e-perf-weekly.yaml
@@ -1,0 +1,181 @@
+name: E2E tests (weekly, full-corpus perf)
+
+# Downloads and replays the complete Hugging Face agentic trace corpus once a
+# week. The corpus is prepared before AKS provisioning so download time does
+# not consume cluster resources.
+on:
+  schedule:
+    # Start after the 14:00 UTC daily nightly workflow to reduce contention on
+    # the singleton self-hosted E2E runner.
+    - cron: '0 18 * * 1'
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch name to run E2E tests against'
+        required: true
+        default: 'main'
+      shard_count:
+        description: 'Number of balanced local shards used for bounded-memory replay'
+        required: false
+        default: '10'
+
+env:
+  RESOURCE_GROUP: "kaito-perf-rg-${{ github.run_id }}-${{ github.run_attempt }}"
+  CLUSTER_NAME: "kaito-perf-aks-${{ github.run_id }}-${{ github.run_attempt }}"
+  ACR_NAME: "kaitoperf${{ github.run_id }}a${{ github.run_attempt }}acr"
+  GPU_MOCKER_IMAGE: "gpu-node-mocker:perf-${{ github.run_id }}-${{ github.run_attempt }}"
+  LOCATION: australiaeast
+  NODE_COUNT: '3'
+  NODE_VM_SIZE: Standard_D8s_v5
+
+permissions:
+  contents: read
+
+concurrency:
+  group: e2e-perf-full-corpus
+  cancel-in-progress: false
+
+jobs:
+  e2e_perf_tests:
+    runs-on: [ "self-hosted", "hostname:kaito-e2e-github-runner" ]
+    environment: e2e-test
+    timeout-minutes: 2160
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Download and shard complete agentic trace corpus
+        id: prepare-corpus
+        background: true
+        env:
+          SHARD_COUNT: ${{ github.event.inputs.shard_count || '10' }}
+          TRACE_SHARD_DIR: ${{ runner.temp }}/agentic-trace-shards
+          HF_HOME: ${{ runner.temp }}/huggingface
+        run: |
+          if ! [[ "${SHARD_COUNT}" =~ ^[1-9][0-9]*$ ]]; then
+            echo "shard_count must be a positive integer, got '${SHARD_COUNT}'" >&2
+            exit 2
+          fi
+          rm -rf "${TRACE_SHARD_DIR}" "${HF_HOME}"
+          python -m pip install --disable-pip-version-check datasets
+          python hack/e2e/scripts/extract_agentic_traces.py \
+            --shards "${SHARD_COUNT}" \
+            --shard-dir "${TRACE_SHARD_DIR}" \
+            --max-sessions 0 \
+            --sources
+          du -sh "${TRACE_SHARD_DIR}"
+          find "${TRACE_SHARD_DIR}" -name 'shard-*.jsonl' -type f -print -exec wc -l {} \;
+
+      - name: E2E base setup
+        uses: ./.github/actions/e2e-base-setup
+        with:
+          resource-group: ${{ env.RESOURCE_GROUP }}
+          cluster-name: ${{ env.CLUSTER_NAME }}
+          acr-name: ${{ env.ACR_NAME }}
+          gpu-mocker-image: ${{ env.GPU_MOCKER_IMAGE }}
+          location: ${{ env.LOCATION }}
+          node-count: ${{ env.NODE_COUNT }}
+          node-vm-size: ${{ env.NODE_VM_SIZE }}
+
+      - name: Wait for agentic trace corpus
+        wait: prepare-corpus
+
+      - name: Run full-corpus prefix-cache perf tests
+        run: make test-e2e-perf
+        env:
+          E2E_TRACE_FIXTURE: ${{ runner.temp }}/agentic-trace-shards
+          E2E_PERF_TIMEOUT: 18h
+
+      - name: Preserve Ginkgo report for the cleanup job
+        if: always()
+        run: |
+          if [[ -f ginkgo-report.json ]]; then
+            cp ginkgo-report.json "${{ runner.temp }}/e2e-perf-ginkgo-${{ github.run_id }}-${{ github.run_attempt }}.json"
+          else
+            echo "No Ginkgo report was produced"
+          fi
+
+  report_and_cleanup:
+    needs: e2e_perf_tests
+    if: always()
+    runs-on: [ "self-hosted", "hostname:kaito-e2e-github-runner" ]
+    environment: e2e-test
+    timeout-minutes: 120
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.branch || github.ref }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+
+      - name: Generate E2E coverage report
+        run: |
+          REPORT="${{ runner.temp }}/e2e-perf-ginkgo-${{ github.run_id }}-${{ github.run_attempt }}.json"
+          if [[ -f "${REPORT}" ]]; then
+            go run ./hack/e2e/report \
+              --label-filter 'Perf' \
+              --workflow 'E2E tests (weekly, full-corpus perf)' \
+              --results "${REPORT}" \
+              --output-md e2e-coverage-report.md \
+              --output-html e2e-coverage-report.html
+            echo '## Weekly Full-Corpus Perf Coverage' >> "$GITHUB_STEP_SUMMARY"
+            cat e2e-coverage-report.md >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo '## Weekly Full-Corpus Perf Coverage' >> "$GITHUB_STEP_SUMMARY"
+            echo 'No Ginkgo report was produced; inspect the setup and replay logs.' >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload E2E coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-perf-full-corpus-report
+          path: |
+            e2e-coverage-report.md
+            e2e-coverage-report.html
+            ${{ runner.temp }}/e2e-perf-ginkgo-${{ github.run_id }}-${{ github.run_attempt }}.json
+          if-no-files-found: warn
+
+      - name: Azure Login
+        if: always()
+        run: az login --identity
+
+      - name: Connect to cluster for diagnostics
+        if: ${{ always() && needs.e2e_perf_tests.result == 'failure' }}
+        run: |
+          if az aks show --resource-group "${RESOURCE_GROUP}" --name "${CLUSTER_NAME}" >/dev/null 2>&1; then
+            az aks get-credentials --resource-group "${RESOURCE_GROUP}" --name "${CLUSTER_NAME}" --overwrite-existing
+          fi
+
+      - name: Dump cluster state
+        if: ${{ always() && needs.e2e_perf_tests.result == 'failure' }}
+        run: make e2e-dump
+
+      - name: Teardown cluster
+        if: always()
+        run: make e2e-teardown
+        env:
+          RESOURCE_GROUP: ${{ env.RESOURCE_GROUP }}
+
+      - name: Remove temporary trace data
+        if: always()
+        run: |
+          rm -rf "${{ runner.temp }}/agentic-trace-shards" "${{ runner.temp }}/huggingface"
+          rm -f "${{ runner.temp }}/e2e-perf-ginkgo-${{ github.run_id }}-${{ github.run_attempt }}.json"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -84,8 +84,7 @@ jobs:
           node-class: ${{ github.event.inputs.node_class }}
 
       - name: Run E2E tests
-        # Skip Nightly and Perf specs. Nightly runs in e2e-nightly.yaml;
-        # prefix-cache load tests run via the dedicated test-e2e-perf target.
+        # Slow Nightly and Perf specs run in their dedicated workflows.
         run: make test-e2e
         env:
           E2E_LABEL: "!Nightly && !Perf"

--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ azure-karpenter-helm: ## Install Azure Karpenter Helm chart (run karpenter-azure
 .PHONY: e2e-up-karpenter
 e2e-up-karpenter: ## One command to set up full local E2E env using real Karpenter (AKS NAP, no gpu-node-mocker).
 	@set -e; \
-	export CLUSTER_NAME=$(E2E_CLUSTER_NAME) RESOURCE_GROUP=$(E2E_RESOURCE_GROUP) LOCATION=swedencentral KAITO_NODE_PROVISIONER=karpenter KAITO_NODE_CLASS=azure ENABLE_NODE_MOCKER=false; \
+	export CLUSTER_NAME=$(E2E_CLUSTER_NAME) RESOURCE_GROUP=$(E2E_RESOURCE_GROUP) LOCATION=eastus KAITO_NODE_PROVISIONER=karpenter KAITO_NODE_CLASS=azure ENABLE_NODE_MOCKER=false; \
 	hack/e2e/scripts/prepare-image.sh; \
 	hack/e2e/scripts/run-e2e-local.sh setup; \
 	$(MAKE) karpenter-azure-identity AZURE_CLUSTER_NAME=$(E2E_CLUSTER_NAME) AZURE_RESOURCE_GROUP=$(E2E_RESOURCE_GROUP); \

--- a/Makefile
+++ b/Makefile
@@ -273,7 +273,7 @@ azure-karpenter-helm: ## Install Azure Karpenter Helm chart (run karpenter-azure
 .PHONY: e2e-up-karpenter
 e2e-up-karpenter: ## One command to set up full local E2E env using real Karpenter (AKS NAP, no gpu-node-mocker).
 	@set -e; \
-	export CLUSTER_NAME=$(E2E_CLUSTER_NAME) RESOURCE_GROUP=$(E2E_RESOURCE_GROUP) LOCATION=eastus KAITO_NODE_PROVISIONER=karpenter KAITO_NODE_CLASS=azure ENABLE_NODE_MOCKER=false; \
+	export CLUSTER_NAME=$(E2E_CLUSTER_NAME) RESOURCE_GROUP=$(E2E_RESOURCE_GROUP) LOCATION=swedencentral KAITO_NODE_PROVISIONER=karpenter KAITO_NODE_CLASS=azure ENABLE_NODE_MOCKER=false; \
 	hack/e2e/scripts/prepare-image.sh; \
 	hack/e2e/scripts/run-e2e-local.sh setup; \
 	$(MAKE) karpenter-azure-identity AZURE_CLUSTER_NAME=$(E2E_CLUSTER_NAME) AZURE_RESOURCE_GROUP=$(E2E_RESOURCE_GROUP); \

--- a/Makefile
+++ b/Makefile
@@ -119,6 +119,7 @@ docker-buildx: ## Multi-arch build (and optionally push) the gpu-node-mocker ima
 E2E_LABEL ?=
 E2E_PARALLEL ?= 2
 E2E_TIMEOUT  ?= 60m
+E2E_PERF_TIMEOUT ?= 24h
 E2E_JSON_REPORT ?= ginkgo-report.json
 
 .PHONY: test-e2e
@@ -139,8 +140,8 @@ test-e2e-karpenter: ## Run the Karpenter nightly scale-from-zero scenarios with 
 	$(MAKE) test-e2e E2E_LABEL='Karpenter' E2E_PARALLEL=1 E2E_TIMEOUT=180m
 
 .PHONY: test-e2e-perf
-test-e2e-perf: ## Run the prefix-cache perf/load replay spec (serial). Override the trace fixture with E2E_TRACE_FIXTURE=/path (a .jsonl file or shard directory).
-	$(MAKE) test-e2e E2E_LABEL='Perf' E2E_PARALLEL=1 E2E_TIMEOUT=90m
+test-e2e-perf: ## Run prefix-cache perf specs serially. Override E2E_TRACE_FIXTURE and E2E_PERF_TIMEOUT as needed.
+	$(MAKE) test-e2e E2E_LABEL='Perf' E2E_PARALLEL=1 E2E_TIMEOUT=$(E2E_PERF_TIMEOUT)
 ## --------------------------------------
 ## E2E Targets
 ##

--- a/hack/e2e/scripts/extract_agentic_traces.py
+++ b/hack/e2e/scripts/extract_agentic_traces.py
@@ -15,10 +15,11 @@
 """Extract a small, committable trace fixture from the HuggingFace dataset
 sammshen/lmcache-agentic-traces for the prefix-cache perf e2e spec.
 
-This is the ONE-TIME, OFFLINE step of "Option A": the full dataset is ~2.37 GB
-and must never be fetched at test time. Run this locally to (re)generate the
-committed fixture at test/e2e/testdata/agentic-traces.jsonl, then commit the
-result.
+For normal E2E runs this is an offline preparation step: run it locally to
+(re)generate the small committed fixture at
+test/e2e/testdata/agentic-traces.jsonl, then commit the result. The dedicated
+weekly perf workflow also uses partition mode to fetch and shard the complete
+~2.37 GB corpus before provisioning its test cluster.
 
 The output schema matches what test/e2e/utils/traces.go (LoadTraceSessions)
 reads: one JSON object per line, one object per LLM iteration, grouped by

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -83,15 +83,17 @@ Step-by-step targets exist as well: `e2e-setup`, `docker-build`, `e2e-push-image
 
 [`prefix_cache_perf_test.go`](prefix_cache_perf_test.go) (labels `Perf` + `PrefixCache`, case `CasePrefixCachePerf`) drives **sustained concurrent load** through the gateway → EPP → backend chain and asserts on the EPP prefix-cache-scorer signals (hit ratio ≥ 80%, zero 5xx, bounded 429/503, KV-cache / queue metrics exported). It runs on the **gpu-node-mocker** path (`llm-d-inference-sim` shadow pods, no real GPU), and the simulator is configured with `enable-kvcache` + `block-size 16` using the sim's built-in (dummy) tokenizer, which still yields deterministic per-block hashes so `vllm:prefix_cache_hits/_queries` and sticky routing are genuine — only throughput/latency are synthetic.
 
-The spec has three `It`s:
+The spec has two `It`s:
 
-1. **Load + cache effectiveness** — replays the fixture under concurrency and asserts hit ratio ≥ 80%, zero 5xx / transport errors, ≤ 10% 429/503, and that `vllm:kv_cache_usage_perc` / `vllm:num_requests_waiting` are exported and in-bounds.
-2. **A/B benefit** — shared-prefix load must yield a higher cache-hit ratio than genuinely unique-prefix load (per-request nonce at block 0).
-3. **Sticky routing concentration** — selects one exact, loader-approved turn per session, primes those prefixes concurrently, then repeats each identical turn in isolation and asserts one pod serves ≥ 70% of its requests (`perfStickyConcentrationTarget`). The threshold is below 100% because the queue / kv-cache scorers can legitimately spill some requests under load.
+1. **Load + cache effectiveness + A/B benefit** — replays the fixture under concurrency and asserts hit ratio ≥ 80%, zero 5xx / transport errors, ≤ 10% 429/503, and that `vllm:kv_cache_usage_perc` / `vllm:num_requests_waiting` are exported and in-bounds. The same measured shared-prefix ratio is then compared with a genuinely unique-prefix control (one request per session with a nonce at block 0), avoiding a second six-round shared replay.
+2. **Sticky routing concentration** — selects one loader-approved turn per session, prepends a fresh stable nonce so earlier specs cannot have cached it on both pods, primes those prefixes concurrently, then repeats each identical turn in isolation and asserts one pod serves ≥ 70% of its requests (`perfStickyConcentrationTarget`). The threshold is below 100% because the queue / kv-cache scorers can legitimately spill some requests under load.
 
 ```bash
-# Convenience target (serial, 90m timeout):
+# Convenience target (serial, 24h timeout for corpus-scale runs):
 make test-e2e-perf
+
+# Use a shorter timeout for the committed fixture or a single shard:
+E2E_PERF_TIMEOUT=30m make test-e2e-perf
 
 # Equivalent explicit invocation:
 E2E_LABEL='Perf' E2E_PARALLEL=1 make test-e2e
@@ -104,7 +106,7 @@ Load is a **replay of real multi-turn agentic sessions**, not a synthetic prompt
 1. **Fixture → sessions.** `LoadTraceSessions` reads a JSONL fixture (one row per LLM iteration) and groups rows by `session_id` into ordered `ReplaySession`s. Each turn's `input` is the full cumulative OpenAI messages array, so turn *N* is a prefix-superset of turn *N-1* — exactly the shared-prefix pattern the prefix-cache-scorer exploits. Turns are dropped at load time if they fall below one 16-token block (`BlockSizeTokens` floor — no prefix hashes) or exceed the model context window (`MaxModelLenTokens` = 32768 ceiling — unservable, the backend would 400). Because turns grow monotonically, the ceiling truncates a session at its first over-length turn, preserving the shared-prefix chain of what remains.
 2. **Concurrent replay.** `ReplaySessionsConcurrent` distributes sessions across a worker pool (`perfConcurrency`, default 8). Turns **within** a session are sent sequentially by one worker (so the shared prefix accumulates in the KV cache); **sessions** run in parallel (to saturate serving and fill the queue). All requests target the deployment name (`X-Gateway-Model-Name`), overriding the model recorded in the trace.
 3. **Measurement.** The fixture is replayed `perfMeasuredRounds` times while prefix-cache / success / error counters are snapshotted before and after. There is **no separate warm-up pass** — each shard's first replay round absorbs its first-touch cold misses and the remaining rounds run hot, so `perfMeasuredRounds` is set high enough to keep the aggregate ratio above target. `repeatSessions` concatenates the fixture N times so a small fixture still generates sustained load.
-4. **A/B check.** Shared-prefix load (repeated sessions) is compared against genuinely unique-prefix load (a per-request nonce prepended at block 0, single-turn) to prove cache-hit growth is real.
+4. **A/B check.** The shared-prefix ratio already measured by the load run is compared against genuinely unique-prefix load (a per-request nonce prepended at block 0, single-turn) to prove cache-hit growth is real without repeating the expensive shared workload.
 
 Total requests ≈ `sessions × turns × perfMeasuredRounds`, spread across `perfConcurrency` workers. The load constants are in [`prefix_cache_perf_test.go`](prefix_cache_perf_test.go): `perfConcurrency`, `perfMeasuredRounds`, and the `prefixCacheHitRatioTarget` threshold.
 
@@ -132,7 +134,7 @@ The replay also buckets **HTTP response codes** (outcome tallies, not Prometheus
 
 ### The trace fixture (and pulling down more)
 
-The committed fixture [`testdata/agentic-traces.jsonl`](testdata/agentic-traces.jsonl) is only a **small trimmed slice** of the HuggingFace dataset [`sammshen/lmcache-agentic-traces`](https://huggingface.co/datasets/sammshen/lmcache-agentic-traces) (~2.36 GB). The full dataset is **never fetched at test time** — the test reads a local file only, keeping CI hermetic and network-independent.
+The committed fixture [`testdata/agentic-traces.jsonl`](testdata/agentic-traces.jsonl) is only a **small trimmed slice** of the HuggingFace dataset [`sammshen/lmcache-agentic-traces`](https://huggingface.co/datasets/sammshen/lmcache-agentic-traces) (~2.36 GB). Normal E2E runs read this local fixture and remain hermetic. The dedicated weekly workflow [`.github/workflows/e2e-perf-weekly.yaml`](../../.github/workflows/e2e-perf-weekly.yaml) downloads and shards the complete corpus before provisioning AKS, then runs only the `Perf` specs.
 
 To pull down more, regenerate the fixture **offline** with [`hack/e2e/scripts/extract_agentic_traces.py`](../../hack/e2e/scripts/extract_agentic_traces.py). It uses `datasets` streaming, so it downloads only what it needs and stops early:
 
@@ -163,9 +165,11 @@ A bigger fixture raises the load automatically (more distinct sessions and deepe
 
 > **Goal: run against the full ~2.36 GB corpus.** The two-stage design (offline extract → local replay) is intended to scale up to the entire dataset. Because real sessions have a median ~21K input tokens, committing a full-size fixture would bloat the repo, so the path to "all traces" is: generate a large (or complete) fixture to a scratch path, then drive the perf spec at it via `E2E_TRACE_FIXTURE` (e.g. in a dedicated nightly/manual job) rather than checking the corpus into git. Raise `--num-sessions` / `--max-turns` toward the dataset's full session/turn counts, and scale `perfConcurrency` to keep the backend saturated.
 
+The weekly workflow regenerates the shards on every run. At ~2.36 GB, the download is small relative to the many-hour replay and guarantees that the run covers the current upstream corpus. Persisting the shards in Azure Blob Storage is unnecessary initially; add a versioned blob snapshot only if Hugging Face availability or download time becomes a recurring source of failed runs. GitHub artifacts are intended for run outputs, not as a durable corpus store.
+
 ### Running the perf test against real dataset shards
 
-The three specs above stream a fixture selected by `E2E_TRACE_FIXTURE` (default: the committed trimmed fixture) — either a single JSONL file or a directory of shards. Each shard is warmed and measured **on its own** and the results are aggregated (Σhits/Σqueries), so the spec can replay the **whole corpus** while only ever holding **one shard in memory at a time** (peak RAM ≈ the largest shard, not the sum of all shards). To exercise the perf spec against **real** agentic data at scale, partition the HuggingFace corpus into shard files and point the spec at the directory (whole corpus) or one file (single-shard dev run).
+The two specs above stream a fixture selected by `E2E_TRACE_FIXTURE` (default: the committed trimmed fixture) — either a single JSONL file or a directory of shards. Each shard is warmed and measured **on its own** and the results are aggregated (Σhits/Σqueries), so the spec can replay the **whole corpus** while only ever holding **one shard in memory at a time** (peak RAM ≈ the largest shard, not the sum of all shards). To exercise the perf spec against **real** agentic data at scale, partition the HuggingFace corpus into shard files and point the spec at the directory (whole corpus) or one file (single-shard dev run).
 
 **1. Partition the corpus into shards (offline, streaming):**
 
@@ -191,6 +195,9 @@ This streams the whole dataset (never holding it in memory) and assigns each **w
 ```bash
 # a whole directory: takes ALL *.jsonl files in it (streamed one at a time = whole corpus)
 E2E_TRACE_FIXTURE=/tmp/pc-shards make test-e2e-perf
+
+# Override the 24h default when the corpus needs a different budget
+E2E_TRACE_FIXTURE=/tmp/pc-shards E2E_PERF_TIMEOUT=36h make test-e2e-perf
 
 # one shard for a quick dev run (only if it has >=2 sessions, else the spec skips)
 E2E_TRACE_FIXTURE=/tmp/pc-shards/shard-0.jsonl make test-e2e-perf

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -87,7 +87,7 @@ The spec has three `It`s:
 
 1. **Load + cache effectiveness** — replays the fixture under concurrency and asserts hit ratio ≥ 80%, zero 5xx / transport errors, ≤ 10% 429/503, and that `vllm:kv_cache_usage_perc` / `vllm:num_requests_waiting` are exported and in-bounds.
 2. **A/B benefit** — shared-prefix load must yield a higher cache-hit ratio than genuinely unique-prefix load (per-request nonce at block 0).
-3. **Sticky routing concentration** — replays each prefix in isolation (after a concurrent priming pass) and asserts one pod serves ≥ 70% of that prefix's requests (`perfStickyConcentrationTarget`). The threshold is below 100% because the queue / kv-cache scorers can legitimately spill some requests under load.
+3. **Sticky routing concentration** — selects one exact, loader-approved turn per session, primes those prefixes concurrently, then repeats each identical turn in isolation and asserts one pod serves ≥ 70% of its requests (`perfStickyConcentrationTarget`). The threshold is below 100% because the queue / kv-cache scorers can legitimately spill some requests under load.
 
 ```bash
 # Convenience target (serial, 90m timeout):
@@ -126,7 +126,7 @@ The spec scrapes Prometheus metrics from every shadow pod (backend) and from the
 
 | Metric | Used for | Assertion |
 | --- | --- | --- |
-| `inference_extension_prefix_indexer_hit_ratio` | independent cross-check of the prefix indexer's hit ratio (from EPP's longest-prefix-match decisions, not the vLLM counters) | max across shards `> 0` |
+| `inference_extension_prefix_indexer_hit_ratio` | independent cross-check of the prefix indexer's hit ratio (from EPP's longest-prefix-match decisions, not the vLLM counters) | when exported by the EPP build, max across shards `> 0`; otherwise the cross-check is skipped and logged |
 
 The replay also buckets **HTTP response codes** (outcome tallies, not Prometheus metrics): 2xx are successes, aggregate **5xx must be 0**, and **429/503** load-shed responses must stay `≤ 10%` of total requests. 400s (e.g. context overflow) are content errors excluded from the load-shed budget — over-length turns are already dropped at load time.
 

--- a/test/e2e/prefix_cache_perf_test.go
+++ b/test/e2e/prefix_cache_perf_test.go
@@ -70,7 +70,6 @@ const (
 	// shard's fixed first-touch cold misses; perfMeasuredRounds is set high
 	// enough that those are diluted below this target.
 	prefixCacheHitRatioTarget = 0.80
-
 	// perfMeasuredRounds replays each shard's sessions repeatedly under load and
 	// measures the hit ratio and error counters across ALL rounds. The first
 	// round absorbs that shard's one-off first-touch cold misses; the remaining

--- a/test/e2e/prefix_cache_perf_test.go
+++ b/test/e2e/prefix_cache_perf_test.go
@@ -160,7 +160,7 @@ func noncePrefixedTurn(base []utils.ChatMessage) ([]utils.ChatMessage, bool) {
 	turn := make([]utils.ChatMessage, 0, len(base)+1)
 	turn = append(turn, utils.ChatMessage{Role: "system", Content: uniqueNonce()})
 	turn = append(turn, base...)
-	return turn, utils.FitsModelContext(turn)
+	return turn, utils.FitsModelContextWithCompletion(turn, 1)
 }
 
 // uniquePrefixSessions rewrites sessions into genuinely unique-prefix load: each
@@ -213,6 +213,8 @@ var _ = Describe("Prefix Cache Routing Perf",
 					return nil
 				}
 				By(fmt.Sprintf("shard %s: %d sessions", shardName, len(sh.Sessions)))
+				Expect(utils.RefreshPortForward(gatewayURL)).To(Succeed(),
+					"refreshing gateway port-forward before shard %s", shardName)
 				fn(shardName, sh.Sessions)
 				return nil
 			})

--- a/test/e2e/prefix_cache_perf_test.go
+++ b/test/e2e/prefix_cache_perf_test.go
@@ -53,7 +53,8 @@ import (
 //   - Prefix-cache effectiveness: aggregate hit ratio (Δvllm:prefix_cache_hits /
 //     Δvllm:prefix_cache_queries) >= 0.80 once shared prefixes are warm,
 //     cross-checked against EPP's own inference_extension_prefix_indexer_hit_ratio
-//     (an independent, router-side view of the same property).
+//     when the EPP build exports it (an independent, router-side view of the
+//     same property).
 //   - KV-cache / queue signal: vllm:kv_cache_usage_perc and
 //     vllm:num_requests_waiting are asserted to be exported (so the
 //     kv-cache-utilization-scorer and queue-scorer have signal) and within
@@ -80,6 +81,11 @@ const (
 	perfMeasuredRounds = 6
 	// perfConcurrency is the number of sessions replayed in parallel.
 	perfConcurrency = 8
+
+	// perfStickyMeasuredRequests is the number of identical requests used to
+	// measure one prefix. Ten samples let the 70% target map exactly to 7/10;
+	// reusing perfMeasuredRounds=6 would accidentally require 5/6 (83.3%).
+	perfStickyMeasuredRequests = 10
 
 	// perfStickyConcentrationTarget is the minimum share of a single prefix's
 	// requests that must land on one backend pod. It is deliberately below
@@ -268,6 +274,7 @@ var _ = Describe("Prefix Cache Routing Perf",
 				hitsDeltaSum       float64
 				queriesDeltaSum    float64
 				maxIndexerHitRatio float64
+				indexerMetricPods  int
 			)
 
 			forEachUsableShard(func(sessions []utils.ReplaySession) {
@@ -294,9 +301,10 @@ var _ = Describe("Prefix Cache Routing Perf",
 				// the two confirms EPP believed it routed to a warm pod AND the
 				// backend confirms the block was resident. Keep the best value
 				// observed across shards (measured over each shard's warm rounds).
-				indexerRatio, err := utils.ScrapeEPPMetric(ctx, clientset, model, caseNamespace,
+				indexerRatio, present, err := utils.ScrapeEPPMetricWithPresence(ctx, clientset, model, caseNamespace,
 					"inference_extension_prefix_indexer_hit_ratio", nil)
 				Expect(err).NotTo(HaveOccurred())
+				indexerMetricPods += present
 				if indexerRatio > maxIndexerHitRatio {
 					maxIndexerHitRatio = indexerRatio
 				}
@@ -333,11 +341,14 @@ var _ = Describe("Prefix Cache Routing Perf",
 				ratio, prefixCacheHitRatioTarget, hitsDeltaSum, queriesDeltaSum)
 
 			By("cross-checking EPP's own prefix-indexer hit ratio (independent of the vllm counters)")
-			GinkgoWriter.Printf("[perf] inference_extension_prefix_indexer_hit_ratio (max across shards) = %.4f\n", maxIndexerHitRatio)
-			Expect(maxIndexerHitRatio).To(BeNumerically(">", 0),
-				"EPP's inference_extension_prefix_indexer_hit_ratio stayed 0 under shared-prefix load — the prefix-cache-scorer's "+
-					"indexer registered no prefix matches (or the metric is not exported by this EPP build); the vllm-side ratio was %.3f",
-				ratio)
+			if indexerMetricPods == 0 {
+				GinkgoWriter.Printf("[perf] EPP does not export inference_extension_prefix_indexer_hit_ratio; skipping router-side cross-check\n")
+			} else {
+				GinkgoWriter.Printf("[perf] inference_extension_prefix_indexer_hit_ratio (max across shards) = %.4f\n", maxIndexerHitRatio)
+				Expect(maxIndexerHitRatio).To(BeNumerically(">", 0),
+					"EPP's inference_extension_prefix_indexer_hit_ratio stayed 0 under shared-prefix load — the prefix-cache-scorer's "+
+						"indexer registered no prefix matches; the vllm-side ratio was %.3f", ratio)
+			}
 
 			By("asserting KV-cache utilization is exported and a valid ratio")
 			kvUsage, kvPresent, err := utils.ScrapeModelMetricWithPresence(ctx, clientset, caseNamespace, model, "vllm:kv_cache_usage_perc")
@@ -423,14 +434,29 @@ var _ = Describe("Prefix Cache Routing Perf",
 			Expect(err).NotTo(HaveOccurred())
 
 			forEachUsableShard(func(sessions []utils.ReplaySession) {
-				// Prime every prefix in this shard once under concurrent load so
-				// the sticky pod for each is established (and first-touch cold
-				// misses don't count against the concentration measurement
-				// below).
-				warm := utils.ReplaySessionsConcurrent(ctx, gatewayURL, model, sessions, perfConcurrency, false)
+				// Measure one exact prompt per session. Replaying a whole multi-turn
+				// session would aggregate several distinct cumulative prompts and
+				// could look evenly distributed even when each prompt is sticky.
+				// Use the first loader-approved turn because it is above the cache
+				// block floor and avoids later turns near the context limit.
+				prefixes := make([]utils.ReplaySession, 0, len(sessions))
+				for _, session := range sessions {
+					if len(session.Turns) == 0 {
+						continue
+					}
+					prefixes = append(prefixes, utils.ReplaySession{
+						SessionID: session.SessionID,
+						Turns:     [][]utils.ChatMessage{session.Turns[0]},
+						PreGaps:   []float64{0},
+					})
+				}
+
+				// Prime every selected prefix once under concurrent load so the
+				// sticky pod for each is established.
+				warm := utils.ReplaySessionsConcurrent(ctx, gatewayURL, model, prefixes, perfConcurrency, false)
 				Expect(warm.Errors5xx).To(BeNumerically("==", 0), "priming produced 5xx: %+v", warm)
 
-				for _, s := range sessions {
+				for _, s := range prefixes {
 					By(fmt.Sprintf("measuring routing concentration for session %s", s.SessionID))
 
 					before, err := utils.ScrapeRequestSuccessTotal(ctx, clientset, caseNamespace, model)
@@ -440,7 +466,7 @@ var _ = Describe("Prefix Cache Routing Perf",
 					// the per-pod request delta reflects the routing *decision*
 					// for a single warm prefix rather than worker interleaving.
 					single := []utils.ReplaySession{s}
-					stats := utils.ReplaySessionsConcurrent(ctx, gatewayURL, model, repeatSessions(single, perfMeasuredRounds), 1, false)
+					stats := utils.ReplaySessionsConcurrent(ctx, gatewayURL, model, repeatSessions(single, perfStickyMeasuredRequests), 1, false)
 					Expect(stats.Errors5xx).To(BeNumerically("==", 0), "sticky run produced 5xx: %+v", stats)
 
 					after, err := utils.ScrapeRequestSuccessTotal(ctx, clientset, caseNamespace, model)

--- a/test/e2e/prefix_cache_perf_test.go
+++ b/test/e2e/prefix_cache_perf_test.go
@@ -70,6 +70,7 @@ const (
 	// shard's fixed first-touch cold misses; perfMeasuredRounds is set high
 	// enough that those are diluted below this target.
 	prefixCacheHitRatioTarget = 0.80
+
 	// perfMeasuredRounds replays each shard's sessions repeatedly under load and
 	// measures the hit ratio and error counters across ALL rounds. The first
 	// round absorbs that shard's one-off first-touch cold misses; the remaining

--- a/test/e2e/prefix_cache_perf_test.go
+++ b/test/e2e/prefix_cache_perf_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package e2e
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -130,6 +129,14 @@ func repeatSessions(sessions []utils.ReplaySession, rounds int) []utils.ReplaySe
 	return out
 }
 
+func replayRequestCount(sessions []utils.ReplaySession) int64 {
+	var total int64
+	for _, session := range sessions {
+		total += int64(len(session.Turns))
+	}
+	return total
+}
+
 // perfNonceSeed makes uniquePrefixSessions' nonces distinct across processes so
 // a re-run against a still-warm backend can't accidentally reuse cached blocks.
 var perfNonceSeed = time.Now().UnixNano()
@@ -149,6 +156,13 @@ func uniqueNonce() string {
 	return b.String()
 }
 
+func noncePrefixedTurn(base []utils.ChatMessage) ([]utils.ChatMessage, bool) {
+	turn := make([]utils.ChatMessage, 0, len(base)+1)
+	turn = append(turn, utils.ChatMessage{Role: "system", Content: uniqueNonce()})
+	turn = append(turn, base...)
+	return turn, utils.FitsModelContext(turn)
+}
+
 // uniquePrefixSessions rewrites sessions into genuinely unique-prefix load: each
 // session becomes a single-turn request carrying its full cumulative context
 // (the last, largest turn) with a unique nonce prepended. This removes both
@@ -157,18 +171,18 @@ func uniqueNonce() string {
 func uniquePrefixSessions(sessions []utils.ReplaySession) []utils.ReplaySession {
 	out := make([]utils.ReplaySession, 0, len(sessions))
 	for i, s := range sessions {
-		if len(s.Turns) == 0 {
-			continue
+		for turnIdx := len(s.Turns) - 1; turnIdx >= 0; turnIdx-- {
+			turn, fits := noncePrefixedTurn(s.Turns[turnIdx])
+			if !fits {
+				continue
+			}
+			out = append(out, utils.ReplaySession{
+				SessionID: fmt.Sprintf("%s-unique-%d", s.SessionID, i),
+				Turns:     [][]utils.ChatMessage{turn},
+				PreGaps:   []float64{0},
+			})
+			break
 		}
-		base := s.Turns[len(s.Turns)-1]
-		turn := make([]utils.ChatMessage, 0, len(base)+1)
-		turn = append(turn, utils.ChatMessage{Role: "system", Content: uniqueNonce()})
-		turn = append(turn, base...)
-		out = append(out, utils.ReplaySession{
-			SessionID: fmt.Sprintf("%s-unique-%d", s.SessionID, i),
-			Turns:     [][]utils.ChatMessage{turn},
-			PreGaps:   []float64{0},
-		})
 	}
 	return out
 }
@@ -180,7 +194,6 @@ var _ = Describe("Prefix Cache Routing Perf",
 		caseNamespace := CaseNamespace(CasePrefixCachePerf)
 
 		var (
-			ctx        context.Context
 			gatewayURL string
 			fixture    string
 		)
@@ -191,23 +204,22 @@ var _ = Describe("Prefix Cache Routing Perf",
 		// cross-pod prefix routing. Shards with fewer are logged and skipped. A
 		// hard load error fails the spec. BeforeAll has already guaranteed at
 		// least one usable shard exists, so fn runs at least once.
-		forEachUsableShard := func(fn func(sessions []utils.ReplaySession)) {
+		forEachUsableShard := func(fn func(shardName string, sessions []utils.ReplaySession)) {
 			err := utils.StreamTraceShards(fixture, func(sh utils.TraceShard) error {
+				shardName := filepath.Base(sh.Path)
 				if len(sh.Sessions) < 2 {
 					GinkgoWriter.Printf("[perf] skipping shard %s: %d session(s) < 2, cannot exercise cross-pod routing\n",
-						filepath.Base(sh.Path), len(sh.Sessions))
+						shardName, len(sh.Sessions))
 					return nil
 				}
-				By(fmt.Sprintf("shard %s: %d sessions", filepath.Base(sh.Path), len(sh.Sessions)))
-				fn(sh.Sessions)
+				By(fmt.Sprintf("shard %s: %d sessions", shardName, len(sh.Sessions)))
+				fn(shardName, sh.Sessions)
 				return nil
 			})
 			Expect(err).NotTo(HaveOccurred(), "streaming trace shards from %s", fixture)
 		}
 
 		BeforeAll(func() {
-			ctx = context.Background()
-
 			fixture = resolveTraceFixture()
 
 			// Validate by streaming the shards once (one resident at a time, so
@@ -249,7 +261,7 @@ var _ = Describe("Prefix Cache Routing Perf",
 			UninstallCase(CasePrefixCachePerf)
 		})
 
-		It("replays agentic traces under concurrent load with zero 5xx and >=80% prefix-cache hit ratio", func() {
+		It("replays agentic traces under load with stable errors, effective caching, and an A/B benefit", func(ctx SpecContext) {
 			clientset, err := utils.GetK8sClientset()
 			Expect(err).NotTo(HaveOccurred())
 
@@ -269,6 +281,7 @@ var _ = Describe("Prefix Cache Routing Perf",
 			var (
 				totalReqs          int64
 				total5xx           int64
+				total503           int64
 				totalTransport     int64
 				totalLoadShed      int64
 				hitsDeltaSum       float64
@@ -277,23 +290,42 @@ var _ = Describe("Prefix Cache Routing Perf",
 				indexerMetricPods  int
 			)
 
-			forEachUsableShard(func(sessions []utils.ReplaySession) {
+			forEachUsableShard(func(shardName string, sessions []utils.ReplaySession) {
 				hitsBefore, err := utils.ScrapeModelMetric(ctx, clientset, caseNamespace, model, "vllm:prefix_cache_hits")
 				Expect(err).NotTo(HaveOccurred())
 				queriesBefore, err := utils.ScrapeModelMetric(ctx, clientset, caseNamespace, model, "vllm:prefix_cache_queries")
 				Expect(err).NotTo(HaveOccurred())
 
 				By(fmt.Sprintf("replaying %d sessions x %d rounds at concurrency %d", len(sessions), perfMeasuredRounds, perfConcurrency))
-				stats := utils.ReplaySessionsConcurrent(ctx, gatewayURL, model, repeatSessions(sessions, perfMeasuredRounds), perfConcurrency, false)
+				runSessions := repeatSessions(sessions, perfMeasuredRounds)
+				stats := utils.ReplaySessionsConcurrent(ctx, gatewayURL, model, runSessions, perfConcurrency, false)
 				GinkgoWriter.Printf("[perf] shard replay stats: %+v\n", stats)
+				Expect(stats.Total).To(Equal(replayRequestCount(runSessions)),
+					"shared-prefix replay did not attempt every selected turn: %+v", stats)
+				Expect(stats.OtherNon2xx-stats.StatusCounts[429]).To(BeNumerically("==", 0),
+					"shared-prefix replay for shard %s produced unexpected 4xx responses: %+v", shardName, stats)
+				Expect(stats.Errors5xx-stats.StatusCounts[503]).To(BeNumerically("==", 0),
+					"shared-prefix replay for shard %s produced unexpected 5xx responses: %+v", shardName, stats)
 
 				hitsAfter, err := utils.ScrapeModelMetric(ctx, clientset, caseNamespace, model, "vllm:prefix_cache_hits")
 				Expect(err).NotTo(HaveOccurred())
 				queriesAfter, err := utils.ScrapeModelMetric(ctx, clientset, caseNamespace, model, "vllm:prefix_cache_queries")
 				Expect(err).NotTo(HaveOccurred())
 
-				hitsDeltaSum += utils.SumSnapshot(utils.DiffSnapshots(hitsBefore, hitsAfter))
-				queriesDeltaSum += utils.SumSnapshot(utils.DiffSnapshots(queriesBefore, queriesAfter))
+				Expect(utils.ValidateCounterSnapshots(hitsBefore, hitsAfter)).To(Succeed(),
+					"prefix-cache hit counters changed identity or reset during shard replay")
+				Expect(utils.ValidateCounterSnapshots(queriesBefore, queriesAfter)).To(Succeed(),
+					"prefix-cache query counters changed identity or reset during shard replay")
+				shardHits := utils.SumSnapshot(utils.DiffSnapshots(hitsBefore, hitsAfter))
+				shardQueries := utils.SumSnapshot(utils.DiffSnapshots(queriesBefore, queriesAfter))
+				Expect(shardQueries).To(BeNumerically(">", 0),
+					"shard %s replay did not advance vllm:prefix_cache_queries", shardName)
+				shardRatio := shardHits / shardQueries
+				Expect(shardRatio).To(BeNumerically(">=", prefixCacheHitRatioTarget),
+					"shard %s prefix-cache hit ratio %.3f below target %.2f (hitsΔ=%.0f queriesΔ=%.0f)",
+					shardName, shardRatio, prefixCacheHitRatioTarget, shardHits, shardQueries)
+				hitsDeltaSum += shardHits
+				queriesDeltaSum += shardQueries
 
 				// EPP-side cross-check: the prefix indexer's own hit ratio. It is
 				// computed independently of the sim's vllm counters — from the
@@ -311,6 +343,7 @@ var _ = Describe("Prefix Cache Routing Perf",
 
 				totalReqs += stats.Total
 				total5xx += stats.Errors5xx
+				total503 += stats.StatusCounts[503]
 				totalTransport += stats.TransportErr
 				// Bounded backpressure: at most 10% of requests may be load-shed
 				// (429 Too Many Requests / 503 Service Unavailable). 400s (e.g.
@@ -322,8 +355,8 @@ var _ = Describe("Prefix Cache Routing Perf",
 
 			By("asserting aggregate error-rate stability under saturation")
 			Expect(totalReqs).To(BeNumerically(">", 0))
-			Expect(total5xx).To(BeNumerically("==", 0),
-				"gateway->EPP->backend chain must stay 5xx-free under load (aggregate 5xx=%d)", total5xx)
+			Expect(total5xx).To(Equal(total503),
+				"only 503 load-shed responses are allowed under load (aggregate 5xx=%d, 503=%d)", total5xx, total503)
 			Expect(totalTransport).To(BeNumerically("==", 0),
 				"replay hit transport errors (aggregate=%d)", totalTransport)
 			Expect(float64(totalLoadShed)).To(BeNumerically("<=", 0.10*float64(totalReqs)),
@@ -374,87 +407,83 @@ var _ = Describe("Prefix Cache Routing Perf",
 			Expect(utils.MinSnapshot(waiting)).To(BeNumerically(">=", 0),
 				"num_requests_waiting is a non-negative gauge: %+v", waiting)
 			GinkgoWriter.Printf("[perf] vllm:num_requests_waiting max across pods = %.0f\n", utils.MaxSnapshot(waiting))
-		})
 
-		It("shows shared-prefix load yields a higher cache-hit ratio than unique-prefix load", utils.GinkgoLabelPerf, func() {
-			clientset, err := utils.GetK8sClientset()
-			Expect(err).NotTo(HaveOccurred())
-
-			// measure runs one load and returns the (hits, queries) deltas it
-			// produced, so callers can accumulate across shards before taking a
-			// ratio (Σhits/Σqueries) — the same shard-by-shard aggregation the
-			// main spec uses, keeping peak memory at one shard.
-			measure := func(runSessions []utils.ReplaySession) (hits, queries float64) {
-				hb, err := utils.ScrapeModelMetric(ctx, clientset, caseNamespace, model, "vllm:prefix_cache_hits")
+			// Reuse the six-round load above as the shared side of the A/B
+			// comparison. Only run the inexpensive one-request-per-session unique
+			// control here; replaying the shared workload again would duplicate the
+			// dominant cost without adding another measurement.
+			var uniqueHits, uniqueQueries float64
+			forEachUsableShard(func(_ string, sessions []utils.ReplaySession) {
+				hitsBefore, err := utils.ScrapeModelMetric(ctx, clientset, caseNamespace, model, "vllm:prefix_cache_hits")
 				Expect(err).NotTo(HaveOccurred())
-				qb, err := utils.ScrapeModelMetric(ctx, clientset, caseNamespace, model, "vllm:prefix_cache_queries")
+				queriesBefore, err := utils.ScrapeModelMetric(ctx, clientset, caseNamespace, model, "vllm:prefix_cache_queries")
 				Expect(err).NotTo(HaveOccurred())
-
-				stats := utils.ReplaySessionsConcurrent(ctx, gatewayURL, model, runSessions, perfConcurrency, false)
-				Expect(stats.Errors5xx).To(BeNumerically("==", 0), "A/B run produced 5xx: %+v", stats)
-
-				ha, err := utils.ScrapeModelMetric(ctx, clientset, caseNamespace, model, "vllm:prefix_cache_hits")
-				Expect(err).NotTo(HaveOccurred())
-				qa, err := utils.ScrapeModelMetric(ctx, clientset, caseNamespace, model, "vllm:prefix_cache_queries")
-				Expect(err).NotTo(HaveOccurred())
-
-				return utils.SumSnapshot(utils.DiffSnapshots(hb, ha)), utils.SumSnapshot(utils.DiffSnapshots(qb, qa))
-			}
-
-			var sharedHits, sharedQueries, uniqueHits, uniqueQueries float64
-			forEachUsableShard(func(sessions []utils.ReplaySession) {
-				By("running shared-prefix load (repeated identical sessions)")
-				h, q := measure(repeatSessions(sessions, perfMeasuredRounds))
-				sharedHits += h
-				sharedQueries += q
 
 				By("running unique-prefix load (per-request unique nonce, no shared prefix)")
-				h, q = measure(uniquePrefixSessions(sessions))
-				uniqueHits += h
-				uniqueQueries += q
+				uniqueSessions := uniquePrefixSessions(sessions)
+				Expect(uniqueSessions).NotTo(BeEmpty(), "no session in shard has room for the unique-prefix nonce")
+				stats := utils.ReplaySessionsConcurrent(ctx, gatewayURL, model, uniqueSessions, perfConcurrency, false)
+				Expect(stats.Total).To(Equal(replayRequestCount(uniqueSessions)),
+					"A/B unique run did not attempt every selected request: %+v", stats)
+				Expect(stats.Success).To(Equal(stats.Total), "A/B unique run must succeed completely: %+v", stats)
+
+				hitsAfter, err := utils.ScrapeModelMetric(ctx, clientset, caseNamespace, model, "vllm:prefix_cache_hits")
+				Expect(err).NotTo(HaveOccurred())
+				queriesAfter, err := utils.ScrapeModelMetric(ctx, clientset, caseNamespace, model, "vllm:prefix_cache_queries")
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(utils.ValidateCounterSnapshots(hitsBefore, hitsAfter)).To(Succeed(),
+					"prefix-cache hit counters changed identity or reset during unique control")
+				Expect(utils.ValidateCounterSnapshots(queriesBefore, queriesAfter)).To(Succeed(),
+					"prefix-cache query counters changed identity or reset during unique control")
+				uniqueHits += utils.SumSnapshot(utils.DiffSnapshots(hitsBefore, hitsAfter))
+				uniqueQueries += utils.SumSnapshot(utils.DiffSnapshots(queriesBefore, queriesAfter))
 			})
 
-			ratio := func(hits, queries float64) float64 {
-				if queries <= 0 {
-					return 0
-				}
-				return hits / queries
-			}
-			sharedRatio := ratio(sharedHits, sharedQueries)
-			uniqueRatio := ratio(uniqueHits, uniqueQueries)
+			Expect(uniqueQueries).To(BeNumerically(">", 0),
+				"unique-prefix control did not advance vllm:prefix_cache_queries")
+			uniqueRatio := uniqueHits / uniqueQueries
 
-			GinkgoWriter.Printf("[perf] aggregate shared-prefix hit ratio=%.3f unique-prefix hit ratio=%.3f\n", sharedRatio, uniqueRatio)
-			Expect(sharedRatio).To(BeNumerically(">", uniqueRatio),
+			GinkgoWriter.Printf("[perf] aggregate shared-prefix hit ratio=%.3f unique-prefix hit ratio=%.3f\n", ratio, uniqueRatio)
+			Expect(ratio).To(BeNumerically(">", uniqueRatio),
 				"shared-prefix load should yield a higher cache-hit ratio than unique-prefix load (shared=%.3f unique=%.3f)",
-				sharedRatio, uniqueRatio)
+				ratio, uniqueRatio)
 		})
 
-		It("concentrates each prefix's requests on a single pod (sticky routing under load)", utils.GinkgoLabelPerf, func() {
+		It("concentrates each prefix's requests on a single pod (sticky routing under load)", utils.GinkgoLabelPerf, func(ctx SpecContext) {
 			clientset, err := utils.GetK8sClientset()
 			Expect(err).NotTo(HaveOccurred())
 
-			forEachUsableShard(func(sessions []utils.ReplaySession) {
-				// Measure one exact prompt per session. Replaying a whole multi-turn
-				// session would aggregate several distinct cumulative prompts and
-				// could look evenly distributed even when each prompt is sticky.
-				// Use the first loader-approved turn because it is above the cache
-				// block floor and avoids later turns near the context limit.
+			forEachUsableShard(func(_ string, sessions []utils.ReplaySession) {
+				// Measure one exact prompt per session. Give it a fresh block-0 nonce
+				// so earlier perf specs cannot have warmed the same prefix on both
+				// pods. Replaying a whole multi-turn session would aggregate several
+				// distinct cumulative prompts and could look evenly distributed even
+				// when each prompt is sticky. Use the first loader-approved turn to
+				// avoid later turns near the context limit.
 				prefixes := make([]utils.ReplaySession, 0, len(sessions))
 				for _, session := range sessions {
-					if len(session.Turns) == 0 {
-						continue
+					for _, base := range session.Turns {
+						turn, fits := noncePrefixedTurn(base)
+						if !fits {
+							continue
+						}
+						prefixes = append(prefixes, utils.ReplaySession{
+							SessionID: session.SessionID,
+							Turns:     [][]utils.ChatMessage{turn},
+							PreGaps:   []float64{0},
+						})
+						break
 					}
-					prefixes = append(prefixes, utils.ReplaySession{
-						SessionID: session.SessionID,
-						Turns:     [][]utils.ChatMessage{session.Turns[0]},
-						PreGaps:   []float64{0},
-					})
 				}
+				Expect(prefixes).NotTo(BeEmpty(), "no session in shard has room for the sticky-routing nonce")
 
 				// Prime every selected prefix once under concurrent load so the
 				// sticky pod for each is established.
 				warm := utils.ReplaySessionsConcurrent(ctx, gatewayURL, model, prefixes, perfConcurrency, false)
-				Expect(warm.Errors5xx).To(BeNumerically("==", 0), "priming produced 5xx: %+v", warm)
+				Expect(warm.Total).To(Equal(replayRequestCount(prefixes)),
+					"sticky priming did not attempt every selected request: %+v", warm)
+				Expect(warm.Success).To(Equal(warm.Total), "sticky priming must succeed completely: %+v", warm)
 
 				for _, s := range prefixes {
 					By(fmt.Sprintf("measuring routing concentration for session %s", s.SessionID))
@@ -467,10 +496,14 @@ var _ = Describe("Prefix Cache Routing Perf",
 					// for a single warm prefix rather than worker interleaving.
 					single := []utils.ReplaySession{s}
 					stats := utils.ReplaySessionsConcurrent(ctx, gatewayURL, model, repeatSessions(single, perfStickyMeasuredRequests), 1, false)
-					Expect(stats.Errors5xx).To(BeNumerically("==", 0), "sticky run produced 5xx: %+v", stats)
+					Expect(stats.Total).To(Equal(int64(perfStickyMeasuredRequests)),
+						"sticky run did not attempt every request: %+v", stats)
+					Expect(stats.Success).To(Equal(stats.Total), "sticky run must succeed completely: %+v", stats)
 
 					after, err := utils.ScrapeRequestSuccessTotal(ctx, clientset, caseNamespace, model)
 					Expect(err).NotTo(HaveOccurred())
+					Expect(utils.ValidateCounterSnapshots(before, after)).To(Succeed(),
+						"request-success counters changed identity or reset during sticky measurement")
 
 					delta := utils.DiffSnapshots(before, after)
 					served := utils.SumSnapshot(delta)

--- a/test/e2e/utils/http.go
+++ b/test/e2e/utils/http.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -27,6 +28,7 @@ import (
 	"os/exec"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -43,9 +45,10 @@ const (
 
 // ChatCompletionRequest represents an OpenAI-compatible chat completion request body.
 type ChatCompletionRequest struct {
-	Model    string        `json:"model"`
-	Messages []ChatMessage `json:"messages"`
-	Tools    []Tool        `json:"tools,omitempty"`
+	Model     string        `json:"model"`
+	Messages  []ChatMessage `json:"messages"`
+	Tools     []Tool        `json:"tools,omitempty"`
+	MaxTokens int           `json:"max_tokens,omitempty"`
 }
 
 // ChatMessage represents a single message in a chat completion request.
@@ -146,6 +149,7 @@ type portForward struct {
 	err       error
 	localPort int
 	url       string
+	restartMu sync.Mutex
 }
 
 // portForwardKey identifies a (namespace, serviceName) pair so the same
@@ -334,9 +338,22 @@ func startPortForward(pf *portForward, namespace, serviceName string) error {
 // Send* helpers fresh each iteration. portForwardMu must NOT be held.
 func restartPortForward(key portForwardKey) error {
 	portForwardMu.Lock()
-	defer portForwardMu.Unlock()
 	pf, ok := portForwards[key]
+	portForwardMu.Unlock()
 	if !ok {
+		return fmt.Errorf("no port-forward registered for %s/%s", key.namespace, key.service)
+	}
+	pf.restartMu.Lock()
+	defer pf.restartMu.Unlock()
+	return restartPortForwardLocked(key, pf)
+}
+
+// restartPortForwardLocked performs a restart while pf.restartMu is held.
+func restartPortForwardLocked(key portForwardKey, pf *portForward) error {
+	portForwardMu.Lock()
+	defer portForwardMu.Unlock()
+	current, ok := portForwards[key]
+	if !ok || current != pf {
 		return fmt.Errorf("no port-forward registered for %s/%s", key.namespace, key.service)
 	}
 	// Another goroutine may have already restarted it.
@@ -363,6 +380,62 @@ func restartPortForward(key portForwardKey) error {
 	portForwardByURL[newURL] = key
 	pf.url = newURL
 	return nil
+}
+
+// recoverPortForward restarts the registered tunnel used by failedURL even if
+// kubectl is still running. A port-forward process can remain alive after its
+// SPDY stream wedges, so process-exit checks alone cannot detect every broken
+// tunnel. Concurrent failures are coalesced: after the first restart changes
+// pf.url, later callers see that their failed URL is stale and return.
+func recoverPortForward(failedURL string) error {
+	portForwardMu.Lock()
+	key, ok := portForwardByURL[failedURL]
+	if !ok {
+		portForwardMu.Unlock()
+		return fmt.Errorf("no port-forward registered for %s", failedURL)
+	}
+	pf, ok := portForwards[key]
+	portForwardMu.Unlock()
+	if !ok {
+		return fmt.Errorf("no port-forward registered for %s/%s", key.namespace, key.service)
+	}
+
+	pf.restartMu.Lock()
+	defer pf.restartMu.Unlock()
+
+	portForwardMu.Lock()
+	if current, exists := portForwards[key]; !exists || current != pf {
+		portForwardMu.Unlock()
+		return fmt.Errorf("port-forward registration changed for %s/%s", key.namespace, key.service)
+	}
+	if pf.url != failedURL {
+		portForwardMu.Unlock()
+		return nil
+	}
+	cmd, done := pf.cmd, pf.done
+	portForwardMu.Unlock()
+
+	if cmd != nil && cmd.Process != nil {
+		_ = cmd.Process.Kill()
+		if done != nil {
+			<-done
+		}
+	}
+	return restartPortForwardLocked(key, pf)
+}
+
+// RefreshPortForward replaces the tunnel behind gatewayURL. Long full-corpus
+// runs rotate between shards while no requests are in flight, avoiding stale
+// SPDY streams without masking request failures inside a measured shard.
+func RefreshPortForward(gatewayURL string) error {
+	return recoverPortForward(resolveGatewayURL(gatewayURL))
+}
+
+func isRecoverablePortForwardError(err error) bool {
+	return errors.Is(err, io.EOF) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNREFUSED)
 }
 
 // GetGatewayURLFor returns a base URL that proxies HTTP traffic to the
@@ -522,25 +595,50 @@ func SendChatCompletionWithPrompt(gatewayURL, model, prompt string) (*http.Respo
 
 // SendChatCompletionRaw sends an arbitrary ChatCompletionRequest to the gateway.
 func SendChatCompletionRaw(gatewayURL string, reqBody ChatCompletionRequest) (*http.Response, error) {
+	return sendChatCompletionRaw(context.Background(), gatewayURL, reqBody, HTTPTimeout)
+}
+
+func sendChatCompletionRaw(ctx context.Context, gatewayURL string, reqBody ChatCompletionRequest, timeout time.Duration) (*http.Response, error) {
+	return sendChatCompletionRawAttempt(ctx, gatewayURL, reqBody, timeout, false)
+}
+
+func sendChatCompletionRawWithRecovery(ctx context.Context, gatewayURL string, reqBody ChatCompletionRequest, timeout time.Duration) (*http.Response, error) {
+	return sendChatCompletionRawAttempt(ctx, gatewayURL, reqBody, timeout, true)
+}
+
+func sendChatCompletionRawAttempt(ctx context.Context, gatewayURL string, reqBody ChatCompletionRequest, timeout time.Duration, recoverTransport bool) (*http.Response, error) {
 	if err := checkAllPortForwards(); err != nil {
 		return nil, err
 	}
-	gatewayURL = resolveGatewayURL(gatewayURL)
 	bodyBytes, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	client := &http.Client{Timeout: HTTPTimeout}
-	url := gatewayURL + "/v1/chat/completions"
-
-	req, err := http.NewRequest(http.MethodPost, url, bytes.NewReader(bodyBytes))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+	maxAttempts := 1
+	if recoverTransport {
+		maxAttempts = 2
 	}
-	req.Header.Set("Content-Type", "application/json")
+	var lastErr error
+	for attempt := 0; attempt < maxAttempts; attempt++ {
+		attemptURL := resolveGatewayURL(gatewayURL)
+		client := &http.Client{Timeout: timeout}
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, attemptURL+"/v1/chat/completions", bytes.NewReader(bodyBytes))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create HTTP request: %w", err)
+		}
+		req.Header.Set("Content-Type", "application/json")
 
-	return client.Do(req)
+		resp, err := client.Do(req)
+		if err == nil || !recoverTransport || ctx.Err() != nil || !isRecoverablePortForwardError(err) {
+			return resp, err
+		}
+		lastErr = err
+		if err := recoverPortForward(attemptURL); err != nil {
+			return nil, fmt.Errorf("request failed (%v) and port-forward recovery failed: %w", lastErr, err)
+		}
+	}
+	return nil, fmt.Errorf("request still failed after port-forward recovery: %w", lastErr)
 }
 
 // SendChatCompletionWithAuth sends an OpenAI-compatible chat completion request

--- a/test/e2e/utils/http_test.go
+++ b/test/e2e/utils/http_test.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The KAITO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"syscall"
+	"testing"
+)
+
+func TestChatCompletionRequestSerializesMaxTokens(t *testing.T) {
+	data, err := json.Marshal(ChatCompletionRequest{Model: "model", MaxTokens: 1})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := string(data), `{"model":"model","messages":null,"max_tokens":1}`; got != want {
+		t.Fatalf("json.Marshal() = %s, want %s", got, want)
+	}
+}
+
+func TestIsRecoverablePortForwardError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "wrapped EOF", err: fmt.Errorf("post request: %w", io.EOF), want: true},
+		{name: "connection reset", err: syscall.ECONNRESET, want: true},
+		{name: "request deadline", err: context.DeadlineExceeded, want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := isRecoverablePortForwardError(test.err); got != test.want {
+				t.Fatalf("isRecoverablePortForwardError() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/test/e2e/utils/metrics.go
+++ b/test/e2e/utils/metrics.go
@@ -262,6 +262,25 @@ func DiffSnapshots(before, after PodMetricSnapshot) PodMetricSnapshot {
 	return diff
 }
 
+// ValidateCounterSnapshots verifies that a counter delta is meaningful. Pod
+// replacement changes the snapshot key set, while a lower value indicates a
+// counter reset; either condition invalidates a before/after measurement.
+func ValidateCounterSnapshots(before, after PodMetricSnapshot) error {
+	if len(before) != len(after) {
+		return fmt.Errorf("metric pod set changed: before=%v after=%v", before, after)
+	}
+	for pod, beforeVal := range before {
+		afterVal, ok := after[pod]
+		if !ok {
+			return fmt.Errorf("metric pod set changed: pod %q missing after measurement", pod)
+		}
+		if afterVal < beforeVal {
+			return fmt.Errorf("metric counter reset on pod %q: before=%v after=%v", pod, beforeVal, afterVal)
+		}
+	}
+	return nil
+}
+
 // TotalDelta returns the sum of all deltas in a diff snapshot.
 func TotalDelta(diff PodMetricSnapshot) float64 {
 	var total float64

--- a/test/e2e/utils/metrics.go
+++ b/test/e2e/utils/metrics.go
@@ -331,23 +331,30 @@ func GetEPPPods(ctx context.Context, clientset *kubernetes.Clientset, deployment
 // ScrapeEPPMetric scrapes a single metric from the EPP pod(s) for a deployment
 // and returns the value. If multiple EPP pods exist, sums across them.
 func ScrapeEPPMetric(ctx context.Context, clientset *kubernetes.Clientset, deploymentName, namespace, metricName string, labels map[string]string) (float64, error) {
+	total, _, err := ScrapeEPPMetricWithPresence(ctx, clientset, deploymentName, namespace, metricName, labels)
+	return total, err
+}
+
+// ScrapeEPPMetricWithPresence scrapes a single metric from the EPP pod(s),
+// returning both its summed value and the number of pods that exported it.
+func ScrapeEPPMetricWithPresence(ctx context.Context, clientset *kubernetes.Clientset, deploymentName, namespace, metricName string, labels map[string]string) (total float64, present int, err error) {
 	pods, err := GetEPPPods(ctx, clientset, deploymentName, namespace)
 	if err != nil {
-		return 0, err
+		return 0, 0, err
 	}
 
-	var total float64
 	for _, pod := range pods {
 		raw, err := ScrapePodMetrics(ctx, clientset, namespace, pod.Name, EPPMetricsPort)
 		if err != nil {
-			return 0, fmt.Errorf("scraping EPP pod %s: %w", pod.Name, err)
+			return 0, 0, fmt.Errorf("scraping EPP pod %s: %w", pod.Name, err)
 		}
 		val, found := ParseMetricValue(raw, metricName, labels)
 		if found {
 			total += val
+			present++
 		}
 	}
-	return total, nil
+	return total, present, nil
 }
 
 // SumSnapshot returns the sum of all values in a snapshot.

--- a/test/e2e/utils/metrics_test.go
+++ b/test/e2e/utils/metrics_test.go
@@ -1,0 +1,61 @@
+/*
+Copyright 2026 The KAITO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import "testing"
+
+func TestValidateCounterSnapshots(t *testing.T) {
+	tests := []struct {
+		name    string
+		before  PodMetricSnapshot
+		after   PodMetricSnapshot
+		wantErr bool
+	}{
+		{
+			name:   "stable pod set and increasing counters",
+			before: PodMetricSnapshot{"pod-a": 10, "pod-b": 20},
+			after:  PodMetricSnapshot{"pod-a": 12, "pod-b": 20},
+		},
+		{
+			name:    "pod added",
+			before:  PodMetricSnapshot{"pod-a": 10},
+			after:   PodMetricSnapshot{"pod-a": 12, "pod-b": 1},
+			wantErr: true,
+		},
+		{
+			name:    "pod replaced",
+			before:  PodMetricSnapshot{"pod-a": 10},
+			after:   PodMetricSnapshot{"pod-b": 12},
+			wantErr: true,
+		},
+		{
+			name:    "counter reset",
+			before:  PodMetricSnapshot{"pod-a": 10},
+			after:   PodMetricSnapshot{"pod-a": 2},
+			wantErr: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateCounterSnapshots(test.before, test.after)
+			if (err != nil) != test.wantErr {
+				t.Fatalf("ValidateCounterSnapshots() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}

--- a/test/e2e/utils/traces.go
+++ b/test/e2e/utils/traces.go
@@ -135,6 +135,13 @@ func estimateTokens(msgs []ChatMessage) int {
 	return words
 }
 
+// FitsModelContext reports whether messages fit within the simulator's
+// configured context window according to the same conservative estimator used
+// when loading trace turns.
+func FitsModelContext(msgs []ChatMessage) bool {
+	return estimateTokens(msgs) <= MaxModelLenTokens
+}
+
 // decodeTraceLine parses one JSONL line into a trace row. ok is false when the
 // line is blank, missing required fields, or filtered by the block-size floor
 // or context ceiling; err is non-nil only for a hard JSON parse failure. It is

--- a/test/e2e/utils/traces.go
+++ b/test/e2e/utils/traces.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"sync"
@@ -106,6 +107,12 @@ type ReplaySample struct {
 // — such turns are dropped at load time (block-size floor).
 const BlockSizeTokens = 16
 
+// traceRequestTimeout allows large prompts queued under perf concurrency to
+// outlive the general-purpose 60-second E2E request timeout without letting a
+// wedged tunnel stall each worker for several minutes. Transport failures get
+// one retry through a freshly established port-forward.
+const traceRequestTimeout = 2 * time.Minute
+
 // MaxModelLenTokens mirrors the simulator's max-model-len (the shadow pod
 // config sets max-model-len: 32768). A turn whose prompt exceeds the model's
 // context window is unservable — the backend rejects it with HTTP 400
@@ -113,33 +120,56 @@ const BlockSizeTokens = 16
 // rather than send it. Such turns are dropped at load time (context ceiling),
 // symmetric to the block-size floor. Because turns grow monotonically within a
 // session, dropping an over-length turn truncates the session at that point and
-// preserves the shared-prefix chain of what remains. The estimator below is
-// >= the sim's (roughly word-based) dummy tokenizer count, so the ceiling
-// conservatively catches every turn the sim would reject.
+// preserves the shared-prefix chain of what remains. The estimator below
+// mirrors the simulator's dummy tokenizer and chat-message rendering.
 const MaxModelLenTokens = 32768
 
-// estimateTokens approximates the token count of a messages array closely
-// enough to enforce the one-block floor. It takes the larger of the
-// whitespace-word count and chars/4 (a common rough bytes-per-token ratio):
-// it matches neither tokenizer exactly but is comfortably conservative for a
-// 16-token floor, so it never drops a turn that would actually span a block.
+// dummyTokenizerRegex mirrors llm-d-inference-sim's SimpleTokenizer. In
+// particular, punctuation and identifiers are separate tokens, which matters
+// for code-heavy agent traces where chars/4 substantially undercounts.
+var dummyTokenizerRegex = regexp.MustCompile(`(\{|\}|:|,|-|\.|\?|\!|;|@|#|\$|%|\^|&|\*|\(|\)|\+|\-|_|~|/|\\|>|<|\[|\]|=|"|'|\w+)(\s*)`)
+
+// estimateTokens reproduces the simulator's SimpleTokenizer.RenderMessages
+// path: each message is wrapped in its chat separators, rendered with role and
+// tool-call metadata, then split with the dummy tokenizer regex.
 func estimateTokens(msgs []ChatMessage) int {
-	words, chars := 0, 0
+	var rendered strings.Builder
 	for _, m := range msgs {
-		chars += len(m.Content)
-		words += len(strings.Fields(m.Content))
+		rendered.WriteString("### ")
+		rendered.WriteString(m.Role)
+		if m.ToolCallID != "" {
+			rendered.WriteString("(")
+			rendered.WriteString(m.ToolCallID)
+			rendered.WriteString(")")
+		}
+		rendered.WriteString(": ")
+		rendered.WriteString(m.Content)
+		for _, toolCall := range m.ToolCalls {
+			if toolCall.Function.Name == "" {
+				continue
+			}
+			rendered.WriteString("[")
+			rendered.WriteString(toolCall.Function.Name)
+			rendered.WriteString("(")
+			rendered.WriteString(toolCall.Function.Arguments)
+			rendered.WriteString(")]")
+		}
+		rendered.WriteString("\n")
 	}
-	if approx := chars / 4; approx > words {
-		return approx
-	}
-	return words
+	return len(dummyTokenizerRegex.FindAllStringIndex(rendered.String(), -1))
 }
 
 // FitsModelContext reports whether messages fit within the simulator's
 // configured context window according to the same conservative estimator used
 // when loading trace turns.
 func FitsModelContext(msgs []ChatMessage) bool {
-	return estimateTokens(msgs) <= MaxModelLenTokens
+	return FitsModelContextWithCompletion(msgs, 0)
+}
+
+// FitsModelContextWithCompletion reports whether the prompt and requested
+// completion fit together within the simulator's context window.
+func FitsModelContextWithCompletion(msgs []ChatMessage, completionTokens int) bool {
+	return estimateTokens(msgs)+completionTokens <= MaxModelLenTokens
 }
 
 // decodeTraceLine parses one JSONL line into a trace row. ok is false when the
@@ -170,7 +200,7 @@ func decodeTraceLine(text string) (row traceRow, ok bool, err error) {
 	// a real client could serve. Dropping an over-length (necessarily trailing)
 	// turn truncates the session there and preserves the prefix chain of the
 	// earlier turns.
-	if estimateTokens(row.Input) > MaxModelLenTokens {
+	if !FitsModelContextWithCompletion(row.Input, 1) {
 		return traceRow{}, false, nil
 	}
 	return row, true, nil
@@ -384,13 +414,15 @@ func replayFromChannel(ctx context.Context, gatewayURL, model string, in <-chan 
 						time.Sleep(time.Duration(s.PreGaps[turnIdx] * float64(time.Second)))
 					}
 					total.Add(1)
-					resp, err := SendChatCompletionRaw(gatewayURL, ChatCompletionRequest{
-						Model:    model,
-						Messages: turn,
-					})
+					resp, err := sendChatCompletionRawWithRecovery(ctx, gatewayURL, ChatCompletionRequest{
+						Model:     model,
+						Messages:  turn,
+						MaxTokens: 1,
+					}, traceRequestTimeout)
 					if err != nil {
 						transportErr.Add(1)
 						recordStatus(0)
+						captureSample(0, []byte(err.Error()))
 						continue
 					}
 					body, _ := ReadResponseBody(resp)

--- a/test/e2e/utils/traces_test.go
+++ b/test/e2e/utils/traces_test.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The KAITO Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestEstimateTokensMirrorsDummyTokenizer(t *testing.T) {
+	messages := []ChatMessage{{Role: "user", Content: "hello, world!"}}
+	if got, want := estimateTokens(messages), 9; got != want {
+		t.Fatalf("estimateTokens() = %d, want %d", got, want)
+	}
+
+	messages = []ChatMessage{{
+		Role: "assistant",
+		ToolCalls: []ToolCall{{
+			Function: ToolCallFunction{Name: "lookup", Arguments: `{"x":1}`},
+		}},
+	}}
+	if got, want := estimateTokens(messages), 17; got != want {
+		t.Fatalf("estimateTokens() with tool call = %d, want %d", got, want)
+	}
+}
+
+func TestFitsModelContextAtDummyTokenizerBoundary(t *testing.T) {
+	overheadTokens := 5 // "###", role, and colon.
+	if !FitsModelContext([]ChatMessage{{
+		Role:    "user",
+		Content: strings.Repeat("word ", MaxModelLenTokens-overheadTokens),
+	}}) {
+		t.Fatal("prompt at max-model-len should fit")
+	}
+	if FitsModelContext([]ChatMessage{{
+		Role:    "user",
+		Content: strings.Repeat("word ", MaxModelLenTokens-overheadTokens+1),
+	}}) {
+		t.Fatal("prompt above max-model-len should not fit")
+	}
+}
+
+func TestDecodeTraceLineRejectsPunctuationHeavyOverflow(t *testing.T) {
+	row := traceRow{
+		SessionID: "code-heavy",
+		Input: []ChatMessage{{
+			Role:    "user",
+			Content: strings.Repeat("x,", (MaxModelLenTokens/2)+1),
+		}},
+	}
+	data, err := json.Marshal(row)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok, err := decodeTraceLine(string(data)); err != nil || ok {
+		t.Fatalf("decodeTraceLine() = ok %v, err %v; want filtered without error", ok, err)
+	}
+}


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->
perf(e2e): run full trace corpus in weekly CI

* Add a dedicated weekly performance workflow that downloads and shards the
complete agentic trace corpus - successful run: https://github.com/kaito-project/production-stack/actions/runs/31254447076/job/93095640764
* Keep full-corpus replay memory bounded by processing one shard at a time.
* Strengthen cache effectiveness, load shedding, sticky routing, and metric counter assertions.
* Avoid duplicate shared-prefix replay by reusing its measured cache-hit ratio for the unique-prefix comparison.
* Match trace token counting to the simulator tokenizer and account for completion tokens when enforcing context limits.
* Cap completions at one token to keep the prompt-cache workload focused and bounded.
* Improve long-running test reliability by rotating port-forwards between shards and recovering once from EOF, reset, broken-pipe, or refused-connection failures.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
