### PR TITLE
ci: publish productionstack-status-reporter image to GHCR

### DIFF
--- a/.github/workflows/publish-helm-chart.yaml
+++ b/.github/workflows/publish-helm-chart.yaml
@@ -53,6 +53,17 @@ jobs:
           yq -i ".image.repository = \"ghcr.io/kaito-project/gpu-node-mocker\" | .image.tag = \"${IMG_TAG}\"" \
             charts/gpu-node-mocker/values.yaml
 
+      - name: Pin productionstack-status-reporter subchart to release image
+        # The umbrella chart bundles the productionstack-status-reporter
+        # subchart; publish-image.yaml has pushed
+        # ghcr.io/kaito-project/productionstack-status-reporter:${IMG_TAG}.
+        # Bake the tag in so a default install does not pull :latest (which
+        # is never published and 403s).
+        run: |
+          IMG_TAG="$(sed -e 's/^v//g' <<< '${{ inputs.release_version }}')"
+          yq -i ".image.repository = \"ghcr.io/kaito-project/productionstack-status-reporter\" | .image.tag = \"${IMG_TAG}\"" \
+            charts/productionstack/charts/productionstack-status-reporter/values.yaml
+
       - name: Update productionstack chart dependencies
         # productionstack is an umbrella chart with an OCI subchart
         # (llm-gateway-apikey) pulled from a public registry at
@@ -122,6 +133,14 @@ jobs:
           yq -i ".image.repository = \"ghcr.io/kaito-project/gpu-node-mocker\" | .image.tag = \"${IMG_TAG}\"" \
             charts/gpu-node-mocker/values.yaml
 
+      - name: Pin productionstack-status-reporter subchart to release image
+        # See push-charts-to-ghp for rationale: bake the released image
+        # repository and tag into the subchart values before packaging.
+        run: |
+          IMG_TAG="$(sed -e 's/^v//g' <<< '${{ inputs.release_version }}')"
+          yq -i ".image.repository = \"ghcr.io/kaito-project/productionstack-status-reporter\" | .image.tag = \"${IMG_TAG}\"" \
+            charts/productionstack/charts/productionstack-status-reporter/values.yaml
+
       - name: Push charts to GHCR
         run: |
           export CHART_REGISTRY='ghcr.io/kaito-project/helm'
@@ -160,6 +179,13 @@ jobs:
           IMG_TAG="$(sed -e 's/^v//g' <<< '${{ inputs.release_version }}')"
           yq -i ".image.repository = \"ghcr.io/kaito-project/gpu-node-mocker\" | .image.tag = \"${IMG_TAG}\"" \
             charts/gpu-node-mocker/values.yaml
+      - name: Pin productionstack-status-reporter subchart to release image
+        # See push-charts-to-ghp for rationale: bake the released image
+        # repository and tag into the subchart values before packaging.
+        run: |
+          IMG_TAG="$(sed -e 's/^v//g' <<< '${{ inputs.release_version }}')"
+          yq -i ".image.repository = \"ghcr.io/kaito-project/productionstack-status-reporter\" | .image.tag = \"${IMG_TAG}\"" \
+            charts/productionstack/charts/productionstack-status-reporter/values.yaml
       - name: ACR Login
         run: |
           az login --identity

--- a/.github/workflows/publish-image.yaml
+++ b/.github/workflows/publish-image.yaml
@@ -19,6 +19,7 @@ permissions:
 env:
   GO_VERSION: '1.26'
   IMAGE_NAME: 'gpu-node-mocker'
+  STATUS_REPORTER_IMAGE_NAME: 'productionstack-status-reporter'
   REGISTRY: ghcr.io
 
 jobs:
@@ -120,6 +121,32 @@ jobs:
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ steps.get-registry.outputs.registry_repository }}/${{ env.IMAGE_NAME }}:${{ env.IMG_TAG }}
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+          timeout: '5m0s'
+        env:
+          TRIVY_USERNAME: ${{ github.actor }}
+          TRIVY_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push productionstack-status-reporter image
+        # The umbrella chart's productionstack-status-reporter subchart pulls
+        # ghcr.io/kaito-project/productionstack-status-reporter. Publish it here
+        # too, otherwise a default `helm install productionstack` fails with a
+        # 403 Forbidden (GHCR returns 403 for a package that was never pushed).
+        run: |
+          OUTPUT_TYPE=type=registry make docker-buildx-status-reporter
+        env:
+          REGISTRY: ${{ steps.get-registry.outputs.registry_repository }}
+          STATUS_REPORTER_IMG_NAME: ${{ env.STATUS_REPORTER_IMAGE_NAME }}
+          IMG_TAG: ${{ env.IMG_TAG }}
+
+      - name: Scan ${{ steps.get-registry.outputs.registry_repository }}/${{ env.STATUS_REPORTER_IMAGE_NAME }}:${{ env.IMG_TAG }}
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ steps.get-registry.outputs.registry_repository }}/${{ env.STATUS_REPORTER_IMAGE_NAME }}:${{ env.IMG_TAG }}
           format: 'table'
           exit-code: '1'
           ignore-unfixed: true


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

The release workflow only built and pushed gpu-node-mocker, so ghcr.io/kaito-project/productionstack-status-reporter was never published. A default helm install therefore hit ImagePullBackOff with 403 Forbidden (GHCR returns 403 for a package that was never pushed).

- publish-image.yaml: build/push and Trivy-scan the status-reporter image alongside gpu-node-mocker.
- publish-helm-chart.yaml: pin the status-reporter subchart image repository/tag before packaging in all three publish jobs.

**Requirements**

- [x] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
