### PR TITLE
ci: publish productionstack-status-reporter in nightly workflows

### DIFF
--- a/.github/workflows/publish-nightly-acr.yaml
+++ b/.github/workflows/publish-nightly-acr.yaml
@@ -70,6 +70,16 @@ jobs:
           IMG_NAME: ${{ matrix.image_name }}
           IMG_TAG: ${{ steps.get-image-tag.outputs.img_tag }}
 
+      - name: Build and push productionstack-status-reporter:${{ steps.get-image-tag.outputs.img_tag }}
+        # The umbrella chart's status-reporter subchart pulls this image;
+        # build it under the same nightly tag so publish-charts-acr can pin it.
+        run: |
+          OUTPUT_TYPE=type=registry make docker-buildx-status-reporter
+        env:
+          REGISTRY: ${{ secrets.KAITO_ACR_REGISTRY }}
+          STATUS_REPORTER_IMG_NAME: productionstack-status-reporter
+          IMG_TAG: ${{ steps.get-image-tag.outputs.img_tag }}
+
   publish-charts-acr:
     needs: [build-publish-image-acr]
     runs-on: [ "self-hosted", "hostname:kaito-e2e-github-runner" ]
@@ -108,6 +118,15 @@ jobs:
         run: |
           yq -i ".image.repository = \"${REGISTRY}/gpu-node-mocker\" | .image.tag = \"${IMG_TAG}\"" \
             charts/gpu-node-mocker/values.yaml
+        env:
+          REGISTRY: ${{ secrets.KAITO_ACR_REGISTRY }}
+
+      - name: Pin productionstack-status-reporter subchart to nightly ACR image
+        # The umbrella chart bundles the status-reporter subchart; pin it to
+        # the nightly ACR image so a nightly install does not pull :latest.
+        run: |
+          yq -i ".image.repository = \"${REGISTRY}/productionstack-status-reporter\" | .image.tag = \"${IMG_TAG}\"" \
+            charts/productionstack/charts/productionstack-status-reporter/values.yaml
         env:
           REGISTRY: ${{ secrets.KAITO_ACR_REGISTRY }}
 

--- a/.github/workflows/publish-nightly-image-gh.yaml
+++ b/.github/workflows/publish-nightly-image-gh.yaml
@@ -34,6 +34,10 @@ jobs:
         include:
           - image_name: gpu-node-mocker
             chart_path: charts/gpu-node-mocker
+            make_target: docker-buildx
+          - image_name: productionstack-status-reporter
+            chart_path: charts/productionstack/charts/productionstack-status-reporter
+            make_target: docker-buildx-status-reporter
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -67,10 +71,11 @@ jobs:
 
       - name: Build and push ${{ matrix.image_name }}:${{ env.IMG_TAG }}
         run: |
-          OUTPUT_TYPE=type=registry make docker-buildx
+          OUTPUT_TYPE=type=registry make ${{ matrix.make_target }}
         env:
           REGISTRY: ${{ steps.get-registry.outputs.registry_repository }}
           IMG_NAME: ${{ matrix.image_name }}
+          STATUS_REPORTER_IMG_NAME: ${{ matrix.image_name }}
 
       - name: Scan ${{ steps.get-registry.outputs.registry_repository }}/${{ matrix.image_name }}:${{ env.IMG_TAG }}
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

The nightly GHCR and ACR pipelines only built gpu-node-mocker, so a nightly productionstack chart install still pulled a nonexistent status-reporter image (403 / :latest).

- publish-nightly-image-gh.yaml: add a matrix entry (with make_target) to build/scan/promote the status-reporter image alongside gpu-node-mocker.
- publish-nightly-acr.yaml: build/push the status-reporter image under the same nightly tag and pin the subchart image before packaging the productionstack chart.

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
