### PR TITLE
ci(e2e): scope PR triggers and move weekly perf to Saturday

### DIFF
--- a/.github/workflows/e2e-perf-weekly.yaml
+++ b/.github/workflows/e2e-perf-weekly.yaml
@@ -5,9 +5,9 @@ name: E2E tests (weekly, perf)
 # not consume cluster resources.
 on:
   schedule:
-    # Start after the 14:00 UTC daily nightly workflow to reduce contention on
-    # the singleton self-hosted E2E runner.
-    - cron: '0 18 * * 1'
+    # Saturday 18:00 UTC. Runs after that day's 14:00 UTC nightly workflow to
+    # reduce contention on the singleton self-hosted E2E runner.
+    - cron: '0 18 * * 6'
   workflow_dispatch:
     inputs:
       branch:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,10 +1,26 @@
-name: E2E tests (push / PR)
+name: E2E tests (PR)
 
 on:
-  push:
-    branches:
-      - main
-  pull_request: {}
+  # Only run E2E when a change can actually affect cluster behaviour
+  # (controllers, charts, images, the e2e suite or its setup / build inputs).
+  # Docs-only or otherwise unrelated changes are skipped so the singleton
+  # self-hosted E2E runner isn't spent on PRs that can't change the outcome.
+  # No push-to-main trigger: PRs already gate the merge and e2e-nightly.yaml
+  # runs the full suite on main daily, so post-merge breakage is caught there.
+  pull_request:
+    paths:
+      - 'cmd/**'
+      - 'pkg/**'
+      - 'charts/**'
+      - 'docker/**'
+      - 'test/**'
+      - 'hack/e2e/**'
+      - 'go.mod'
+      - 'go.sum'
+      - 'Makefile'
+      - 'versions.env'
+      - '.github/actions/e2e-base-setup/**'
+      - '.github/workflows/e2e.yaml'
   workflow_dispatch:
     inputs:
       branch:


### PR DESCRIPTION
**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

- e2e: run only on relevant PR paths, drop push-to-main
- e2e-perf: schedule weekly run on Saturday

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
