### PR TITLE
chore: bump llm-gateway-apikey and llm-gateway-azureauth to 0.1.0

### DIFF
--- a/charts/productionstack/Chart.lock
+++ b/charts/productionstack/Chart.lock
@@ -1,18 +1,21 @@
 dependencies:
 - name: body-based-routing
   repository: ""
-  version: 0.1.0
+  version: 0.1.1
 - name: keda-kaito-scaler
   repository: ""
   version: 0.6.2
 - name: gpu-node-mocker
   repository: file://../gpu-node-mocker
-  version: 0.3.1
+  version: 0.4.0
 - name: llm-gateway-apikey
   repository: oci://mcr.microsoft.com/aks/kaito/helm
-  version: 0.0.14-alpha
+  version: 0.1.0
 - name: llm-gateway-azureauth
   repository: oci://mcr.microsoft.com/aks/kaito/helm
-  version: 0.0.14-alpha
-digest: sha256:9660cc186a97fec0a2ab26d2d0650ce67b625e9efeb9c469e4652340c2a8513f
-generated: "2026-07-24T10:04:59.639851+10:00"
+  version: 0.1.0
+- name: productionstack-status-reporter
+  repository: ""
+  version: 0.4.0
+digest: sha256:0696ac2c3d12b27befff51bb79224796601cbee3cdb87f7f73ff09708401f7db
+generated: "2026-08-12T15:01:05.834782+10:00"

--- a/charts/productionstack/Chart.yaml
+++ b/charts/productionstack/Chart.yaml
@@ -74,7 +74,7 @@ dependencies:
   # is part of the umbrella `productionstack` release manifest, so
   # `helm uninstall productionstack` cleans it up automatically.
   - name: llm-gateway-apikey
-    version: 0.0.14-alpha
+    version: 0.1.0
     repository: oci://mcr.microsoft.com/aks/kaito/helm
     condition: llm-gateway-apikey.enabled
     tags:
@@ -91,7 +91,7 @@ dependencies:
   # tenant-specific configuration (`azure.tenantId`, `azure.jwt.audiences`)
   # and has no sensible default.
   - name: llm-gateway-azureauth
-    version: 0.0.14-alpha
+    version: 0.1.0
     repository: oci://mcr.microsoft.com/aks/kaito/helm
     condition: llm-gateway-azureauth.enabled
     tags:


### PR DESCRIPTION
Both auth subcharts move from 0.0.14-alpha to 0.1.0. Templates and values.yaml are byte-identical across the two versions, so no values migration is required. The only change is CRD packaging:

  * llm-gateway-apikey — the APIKey CRD moves from crds/ into templates/kaito.sh_apikeys.yaml (annotated helm.sh/resource-policy: keep), so it is now part of the release manifest. The Istio CRD stubs (envoyfilter, peerauthentication) are dropped.
  * llm-gateway-azureauth — the crds/ directory (Istio stubs only) and the crds.install value are removed. The umbrella never set crds.install, so this is a no-op here.

Because apikeys.kaito.sh is now Helm-managed, an in-place upgrade on a cluster that already carries the 0.0.14-alpha CRD needs it adopted first:

  kubectl annotate crd apikeys.kaito.sh \
    meta.helm.sh/release-name=productionstack \
    meta.helm.sh/release-namespace=<ns> --overwrite
  kubectl label crd apikeys.kaito.sh \
    app.kubernetes.io/managed-by=Helm --overwrite

Chart.lock is regenerated by `helm dependency update`, which also picks up two pre-existing drifts against Chart.yaml: body-based-routing 0.1.0 -> 0.1.1 and gpu-node-mocker 0.3.1 -> 0.4.0. The lock cannot be refreshed partially.

**Reason for Change**:
<!-- What does this PR improve or fix in production-stack? Why is it needed? -->

**Requirements**

- [ ] added unit tests and e2e tests (if applicable).

**Issue Fixed**:
<!-- If this PR fixes GitHub issue 4321, add "Fixes #4321" to the next line. -->

**Notes for Reviewers**:
